### PR TITLE
Missing mac_vendors in /etc/objects/

### DIFF
--- a/packaging/rpm/redborder-common.spec
+++ b/packaging/rpm/redborder-common.spec
@@ -26,7 +26,7 @@ mkdir -p %{buildroot}/usr/lib/redborder/bin
 mkdir -p %{buildroot}/usr/lib/redborder/scripts
 install -D -m 0644 resources/redborder-common.sh %{buildroot}/etc/profile.d
 cp resources/bin/* %{buildroot}/usr/lib/redborder/bin
-cp resources/etc/* %{buildroot}/etc
+cp -r resources/etc/* %{buildroot}/etc
 cp resources/scripts/* %{buildroot}/usr/lib/redborder/scripts
 chmod 0755 %{buildroot}/usr/lib/redborder/bin/*
 chmod 0755 %{buildroot}/usr/lib/redborder/scripts/*

--- a/packaging/rpm/redborder-common.spec
+++ b/packaging/rpm/redborder-common.spec
@@ -26,6 +26,7 @@ mkdir -p %{buildroot}/usr/lib/redborder/bin
 mkdir -p %{buildroot}/usr/lib/redborder/scripts
 install -D -m 0644 resources/redborder-common.sh %{buildroot}/etc/profile.d
 cp resources/bin/* %{buildroot}/usr/lib/redborder/bin
+cp resources/etc/* %{buildroot}/etc
 cp resources/scripts/* %{buildroot}/usr/lib/redborder/scripts
 chmod 0755 %{buildroot}/usr/lib/redborder/bin/*
 chmod 0755 %{buildroot}/usr/lib/redborder/scripts/*
@@ -43,6 +44,7 @@ exit 0
 /usr/lib/redborder/scripts
 %defattr(0644,root,root)
 /etc/profile.d/redborder-common.sh
+/etc/objects/mac_vendors
 
 %doc
 

--- a/resources/etc/objects/mac_vendors
+++ b/resources/etc/objects/mac_vendors
@@ -1,0 +1,20485 @@
+000000|XEROX CORPORATION
+000001|XEROX CORPORATION
+000002|XEROX CORPORATION
+000003|XEROX CORPORATION
+000004|XEROX CORPORATION
+000005|XEROX CORPORATION
+000006|XEROX CORPORATION
+000007|XEROX CORPORATION
+000008|XEROX CORPORATION
+000009|XEROX CORPORATION
+00000A|OMRON TATEISI ELECTRONICS CO.
+00000B|MATRIX CORPORATION
+00000C|Cisco
+00000D|FIBRONICS LTD.
+00000E|FUJITSU LIMITED
+00000F|NEXT, INC.
+000010|SYTEK INC.
+000011|NORMEREL SYSTEMES
+000012|INFORMATION TECHNOLOGY LIMITED
+000013|CAMEX
+000014|NETRONIX
+000015|DATAPOINT CORPORATION
+000016|DU PONT PIXEL SYSTEMS     .
+000017|Oracle
+000018|WEBSTER COMPUTER CORPORATION
+000019|APPLIED DYNAMICS INTERNATIONAL
+00001A|ADVANCED MICRO DEVICES
+00001B|NOVELL INC.
+00001C|BELL TECHNOLOGIES
+00001D|CABLETRON SYSTEMS, INC.
+00001E|TELSIST INDUSTRIA ELECTRONICA
+00001F|Telco Systems, Inc.
+000020|DATAINDUSTRIER DIAB AB
+000021|SUREMAN COMP. & COMMUN. CORP.
+000022|VISUAL TECHNOLOGY INC.
+000023|ABB INDUSTRIAL SYSTEMS AB
+000024|CONNECT AS
+000025|RAMTEK CORP.
+000026|SHA-KEN CO., LTD.
+000027|JAPAN RADIO COMPANY
+000028|PRODIGY SYSTEMS CORPORATION
+000029|IMC NETWORKS CORP.
+00002A|TRW - SEDD/INP
+00002B|CRISP AUTOMATION, INC
+00002C|AUTOTOTE LIMITED
+00002D|CHROMATICS INC
+00002E|SOCIETE EVIRA
+00002F|TIMEPLEX INC.
+000030|VG LABORATORY SYSTEMS LTD
+000031|QPSX COMMUNICATIONS PTY LTD
+000032|Marconi plc
+000033|EGAN MACHINERY COMPANY
+000034|NETWORK RESOURCES CORPORATION
+000035|SPECTRAGRAPHICS CORPORATION
+000036|ATARI CORPORATION
+000037|OXFORD METRICS LIMITED
+000038|CSS LABS
+000039|TOSHIBA CORPORATION
+00003A|CHYRON CORPORATION
+00003B|i Controls, Inc.
+00003C|AUSPEX SYSTEMS INC.
+00003D|UNISYS
+00003E|SIMPACT
+00003F|SYNTREX, INC.
+000040|APPLICON, INC.
+000041|ICE CORPORATION
+000042|METIER MANAGEMENT SYSTEMS LTD.
+000043|MICRO TECHNOLOGY
+000044|CASTELLE CORPORATION
+000045|FORD AEROSPACE & COMM. CORP.
+000046|OLIVETTI NORTH AMERICA
+000047|NICOLET INSTRUMENTS CORP.
+000048|SEIKO EPSON CORPORATION
+000049|APRICOT COMPUTERS, LTD
+00004A|ADC CODENOLL TECHNOLOGY CORP.
+00004B|ICL DATA OY
+00004C|NEC CORPORATION
+00004D|DCI CORPORATION
+00004E|AMPEX CORPORATION
+00004F|LOGICRAFT, INC.
+000050|RADISYS CORPORATION
+000051|HOB ELECTRONIC GMBH & CO. KG
+000052|Intrusion.com, Inc.
+000053|COMPUCORP
+000054|Schnieder Electric
+000055|COMMISSARIAT A L`ENERGIE ATOM.
+000056|DR. B. STRUCK
+000057|SCITEX CORPORATION LTD.
+000058|RACORE COMPUTER PRODUCTS INC.
+000059|HELLIGE GMBH
+00005A|SysKonnect GmbH
+00005B|ELTEC ELEKTRONIK AG
+00005C|TELEMATICS INTERNATIONAL INC.
+00005D|CS TELECOM
+00005E|ICANN, IANA Department
+00005F|SUMITOMO ELECTRIC IND., LTD.
+000060|KONTRON ELEKTRONIK GMBH
+000061|GATEWAY COMMUNICATIONS
+000062|BULL HN INFORMATION SYSTEMS
+000063|BARCO CONTROL ROOMS GMBH
+000064|Yokogawa Electric Corporation
+000065|Network General Corporation
+000066|TALARIS SYSTEMS, INC.
+000067|SOFT * RITE, INC.
+000068|ROSEMOUNT CONTROLS
+000069|CONCORD COMMUNICATIONS INC
+00006A|COMPUTER CONSOLES INC.
+00006B|SILICON GRAPHICS INC./MIPS
+00006C|THE FOXBORO COMPANY 
+00006D|CRAY COMMUNICATIONS, LTD.
+00006E|ARTISOFT, INC.
+00006F|Madge Ltd.
+000070|HCL LIMITED
+000071|ADRA SYSTEMS INC.
+000072|MINIWARE TECHNOLOGY
+000073|SIECOR CORPORATION
+000074|RICOH COMPANY LTD.
+000075|Nortel Networks
+000076|ABEKAS VIDEO SYSTEM
+000077|INTERPHASE CORPORATION
+000078|LABTAM LIMITED
+000079|NETWORTH INCORPORATED
+00007A|DANA COMPUTER INC.
+00007B|RESEARCH MACHINES
+00007C|AMPERE INCORPORATED
+00007D|Oracle Corporation
+00007E|CLUSTRIX CORPORATION
+00007F|LINOTYPE-HELL AG
+000080|CRAY COMMUNICATIONS A/S
+000081|BAY NETWORKS
+000082|LECTRA SYSTEMES SA
+000083|TADPOLE TECHNOLOGY PLC
+000084|SUPERNET
+000085|CANON INC.
+000086|MEGAHERTZ CORPORATION
+000087|HITACHI, LTD.
+000088|Brocade Communications Systems, Inc.
+000089|CAYMAN SYSTEMS INC.
+00008A|DATAHOUSE INFORMATION SYSTEMS
+00008B|INFOTRON
+00008C|Alloy Computer Products (Australia) Pty Ltd
+00008D|Cryptek Inc.
+00008E|SOLBOURNE COMPUTER, INC.
+00008F|Raytheon
+000090|MICROCOM
+000091|ANRITSU CORPORATION
+000092|COGENT DATA TECHNOLOGIES
+000093|PROTEON INC.
+000094|ASANTE TECHNOLOGIES
+000095|SONY TEKTRONIX CORP.
+000096|MARCONI ELECTRONICS LTD.
+000097|EMC Corporation
+000098|CROSSCOMM CORPORATION
+000099|MTX, INC.
+00009A|RC COMPUTER A/S
+00009B|INFORMATION INTERNATIONAL, INC
+00009C|ROLM MIL-SPEC COMPUTERS
+00009D|LOCUS COMPUTING CORPORATION
+00009E|MARLI S.A.
+00009F|AMERISTAR TECHNOLOGIES INC.
+0000A0|SANYO Electric Co., Ltd.
+0000A1|MARQUETTE ELECTRIC CO.
+0000A2|BAY NETWORKS
+0000A3|NETWORK APPLICATION TECHNOLOGY
+0000A4|ACORN COMPUTERS LIMITED
+0000A5|Tattile SRL
+0000A6|NETWORK GENERAL CORPORATION
+0000A7|NETWORK COMPUTING DEVICES INC.
+0000A8|STRATUS COMPUTER INC.
+0000A9|NETWORK SYSTEMS CORP.
+0000AA|XEROX CORPORATION
+0000AB|LOGIC MODELING CORPORATION
+0000AC|CONWARE COMPUTER CONSULTING
+0000AD|BRUKER INSTRUMENTS INC.
+0000AE|DASSAULT ELECTRONIQUE
+0000AF|Canberra Industries, Inc.
+0000B0|RND-RAD NETWORK DEVICES
+0000B1|ALPHA MICROSYSTEMS INC.
+0000B2|TELEVIDEO SYSTEMS, INC.
+0000B3|CIMLINC INCORPORATED
+0000B4|EDIMAX COMPUTER COMPANY
+0000B5|DATABILITY SOFTWARE SYS. INC.
+0000B6|MICRO-MATIC RESEARCH
+0000B7|DOVE COMPUTER CORPORATION
+0000B8|SEIKOSHA CO., LTD.
+0000B9|MCDONNELL DOUGLAS COMPUTER SYS
+0000BA|SIIG, INC.
+0000BB|TRI-DATA
+0000BC|Rockwell Automation
+0000BD|MITSUBISHI CABLE COMPANY
+0000BE|THE NTI GROUP
+0000BF|SYMMETRIC COMPUTER SYSTEMS
+0000C0|WESTERN DIGITAL CORPORATION
+0000C1|Madge Ltd.
+0000C2|INFORMATION PRESENTATION TECH.
+0000C3|HARRIS CORP COMPUTER SYS DIV
+0000C4|WATERS DIV. OF MILLIPORE
+0000C5|ARRIS Group, Inc.
+0000C6|EON SYSTEMS
+0000C7|ARIX CORPORATION
+0000C8|ALTOS COMPUTER SYSTEMS
+0000C9|Emulex Corporation
+0000CA|ARRIS International
+0000CB|COMPU-SHACK ELECTRONIC GMBH
+0000CC|DENSAN CO., LTD.
+0000CD|Allied Telesis Labs Ltd
+0000CE|MEGADATA CORP.
+0000CF|HAYES MICROCOMPUTER PRODUCTS
+0000D0|DEVELCON ELECTRONICS LTD.
+0000D1|ADAPTEC INCORPORATED
+0000D2|SBE, INC.
+0000D3|WANG LABORATORIES INC.
+0000D4|PURE DATA LTD.
+0000D5|MICROGNOSIS INTERNATIONAL
+0000D6|PUNCH LINE HOLDING
+0000D7|DARTMOUTH COLLEGE
+0000D8|NOVELL, INC.
+0000D9|NIPPON TELEGRAPH & TELEPHONE
+0000DA|ATEX
+0000DB|British Telecommunications plc
+0000DC|HAYES MICROCOMPUTER PRODUCTS
+0000DD|TCL INCORPORATED
+0000DE|CETIA
+0000DF|BELL & HOWELL PUB SYS DIV
+0000E0|QUADRAM CORP.
+0000E1|GRID SYSTEMS
+0000E2|ACER TECHNOLOGIES CORP.
+0000E3|INTEGRATED MICRO PRODUCTS LTD
+0000E4|IN2 GROUPE INTERTECHNIQUE
+0000E5|SIGMEX LTD.
+0000E6|APTOR PRODUITS DE COMM INDUST
+0000E7|STAR GATE TECHNOLOGIES
+0000E8|ACCTON TECHNOLOGY CORP.
+0000E9|ISICAD, INC.
+0000EA|UPNOD AB
+0000EB|MATSUSHITA COMM. IND. CO. LTD.
+0000EC|MICROPROCESS
+0000ED|APRIL
+0000EE|NETWORK DESIGNERS, LTD.
+0000EF|KTI
+0000F0|Samsung
+0000F1|MAGNA COMPUTER CORPORATION
+0000F2|SPIDER COMMUNICATIONS
+0000F3|GANDALF DATA LIMITED
+0000F4|Allied Telesis
+0000F5|DIAMOND SALES LIMITED
+0000F6|APPLIED MICROSYSTEMS CORP.
+0000F7|YOUTH KEEP ENTERPRISE CO LTD
+0000F8|DIGITAL EQUIPMENT CORPORATION
+0000F9|QUOTRON SYSTEMS INC.
+0000FA|MICROSAGE COMPUTER SYSTEMS INC
+0000FB|RECHNER ZUR KOMMUNIKATION
+0000FC|MEIKO
+0000FD|HIGH LEVEL HARDWARE
+0000FE|ANNAPOLIS MICRO SYSTEMS
+0000FF|CAMTEC ELECTRONICS LTD.
+000100|EQUIP'TRANS
+000102|3COM CORPORATION
+000103|3COM CORPORATION
+000104|DVICO Co., Ltd.
+000105|Beckhoff Automation GmbH
+000106|Tews Datentechnik GmbH
+000107|Leiser GmbH
+000108|AVLAB Technology, Inc.
+000109|Nagano Japan Radio Co., Ltd.
+00010A|CIS TECHNOLOGY INC.
+00010B|Space CyberLink, Inc.
+00010C|System Talks Inc.
+00010D|CORECO, INC.
+00010E|Bri-Link Technologies Co., Ltd
+00010F|Brocade Communications Systems, Inc.
+000110|Gotham Networks
+000111|iDigm Inc.
+000112|Shark Multimedia Inc.
+000113|OLYMPUS CORPORATION
+000114|KANDA TSUSHIN KOGYO CO., LTD.
+000115|EXTRATECH CORPORATION
+000116|Netspect Technologies, Inc.
+000117|CANAL +
+000118|EZ Digital Co., Ltd.
+000119|RTUnet (Australia)
+00011A|Hoffmann und Burmeister GbR
+00011B|Unizone Technologies, Inc.
+00011C|Universal Talkware Corporation
+00011D|Centillium Communications
+00011E|Precidia Technologies, Inc.
+00011F|RC Networks, Inc.
+000120|OSCILLOQUARTZ S.A.
+000121|Watchguard Technologies, Inc.
+000122|Trend Communications, Ltd.
+000123|DIGITAL ELECTRONICS CORP.
+000124|Acer Incorporated
+000125|YAESU MUSEN CO., LTD.
+000126|PAC Labs
+000127|OPEN Networks Pty Ltd
+000128|EnjoyWeb, Inc.
+000129|DFI Inc.
+00012A|Telematica Sistems Inteligente
+00012B|TELENET Co., Ltd.
+00012C|Aravox Technologies, Inc.
+00012D|Komodo Technology
+00012E|PC Partner Ltd.
+00012F|Twinhead International Corp
+000130|Extreme Networks
+000131|Bosch Security Systems, Inc.
+000132|Dranetz - BMI
+000133|KYOWA Electronic Instruments C
+000134|Selectron Systems AG
+000135|KDC Corp.
+000136|CyberTAN Technology, Inc.
+000137|IT Farm Corporation
+000138|XAVi Technologies Corp.
+000139|Point Multimedia Systems
+00013A|SHELCAD COMMUNICATIONS, LTD.
+00013B|BNA SYSTEMS
+00013C|TIW SYSTEMS
+00013D|RiscStation Ltd.
+00013E|Ascom Tateco AB
+00013F|Neighbor World Co., Ltd.
+000140|Sendtek Corporation
+000141|CABLE PRINT
+000142|Cisco
+000143|Cisco
+000144|EMC Corporation
+000145|WINSYSTEMS, INC.
+000146|Tesco Controls, Inc.
+000147|Zhone Technologies
+000148|X-traWeb Inc.
+000149|T.D.T. Transfer Data Test GmbH
+00014A|Sony Corporation
+00014B|Ennovate Networks, Inc.
+00014C|Berkeley Process Control
+00014D|Shin Kin Enterprises Co., Ltd
+00014E|WIN Enterprises, Inc.
+00014F|ADTRAN INC
+000150|GILAT COMMUNICATIONS, LTD.
+000151|Ensemble Communications
+000152|CHROMATEK INC.
+000153|ARCHTEK TELECOM CORPORATION
+000154|G3M Corporation
+000155|Promise Technology, Inc.
+000156|FIREWIREDIRECT.COM, INC.
+000157|SYSWAVE CO., LTD
+000158|Electro Industries/Gauge Tech
+000159|S1 Corporation
+00015A|Digital Video Broadcasting
+00015B|ITALTEL S.p.A/RF-UP-I
+00015C|CADANT INC.
+00015D|Oracle Corporation
+00015E|BEST TECHNOLOGY CO., LTD.
+00015F|DIGITAL DESIGN GmbH
+000160|ELMEX Co., LTD.
+000161|Meta Machine Technology
+000162|Cygnet Technologies, Inc.
+000163|Cisco
+000164|Cisco
+000165|AirSwitch Corporation
+000166|TC GROUP A/S
+000167|HIOKI E.E. CORPORATION
+000168|VITANA CORPORATION
+000169|Celestix Networks Pte Ltd.
+00016A|ALITEC
+00016B|LightChip, Inc.
+00016C|FOXCONN
+00016D|CarrierComm Inc.
+00016E|Conklin Corporation
+00016F|Inkel Corp.
+000170|ESE Embedded System Engineer'g
+000171|Allied Data Technologies
+000172|TechnoLand Co., LTD.
+000173|AMCC
+000174|CyberOptics Corporation
+000175|Radiant Communications Corp.
+000176|Orient Silver Enterprises
+000177|EDSL
+000178|MARGI Systems, Inc.
+000179|WIRELESS TECHNOLOGY, INC.
+00017A|Chengdu Maipu Electric Industrial Co., Ltd.
+00017B|Heidelberger Druckmaschinen AG
+00017C|AG-E GmbH
+00017D|ThermoQuest
+00017E|ADTEK System Science Co., Ltd.
+00017F|Experience Music Project
+000180|AOpen, Inc.
+000181|Nortel Networks
+000182|DICA TECHNOLOGIES AG
+000183|ANITE TELECOMS
+000184|SIEB & MEYER AG
+000185|Hitachi Aloka Medical, Ltd.
+000186|Uwe Disch
+000187|I2SE GmbH
+000188|LXCO Technologies ag
+000189|Refraction Technology, Inc.
+00018A|ROI COMPUTER AG
+00018B|NetLinks Co., Ltd.
+00018C|Mega Vision
+00018D|AudeSi Technologies
+00018E|Logitec Corporation
+00018F|Kenetec, Inc.
+000190|SMK-M
+000191|SYRED Data Systems
+000192|Texas Digital Systems
+000193|Hanbyul Telecom Co., Ltd.
+000194|Capital Equipment Corporation
+000195|Sena Technologies, Inc.
+000196|Cisco
+000197|Cisco
+000198|Darim Vision
+000199|HeiSei Electronics
+00019A|LEUNIG GmbH
+00019B|Kyoto Microcomputer Co., Ltd.
+00019C|JDS Uniphase Inc.
+00019D|E-Control Systems, Inc.
+00019E|ESS Technology, Inc.
+00019F|ReadyNet
+0001A0|Infinilink Corporation
+0001A1|Mag-Tek, Inc.
+0001A2|Logical Co., Ltd.
+0001A3|GENESYS LOGIC, INC.
+0001A4|Microlink Corporation
+0001A5|Nextcomm, Inc.
+0001A6|Scientific-Atlanta Arcodan A/S
+0001A7|UNEX TECHNOLOGY CORPORATION
+0001A8|Welltech Computer Co., Ltd.
+0001A9|BMW AG
+0001AA|Airspan Communications, Ltd.
+0001AB|Main Street Networks
+0001AC|Sitara Networks, Inc.
+0001AD|Coach Master International  d.b.a. CMI Worldwide, Inc.
+0001AE|Trex Enterprises
+0001AF|Artesyn Embedded Technologies
+0001B0|Fulltek Technology Co., Ltd.
+0001B1|General Bandwidth
+0001B2|Digital Processing Systems, Inc.
+0001B3|Precision Electronic Manufacturing
+0001B4|Wayport, Inc.
+0001B5|Turin Networks, Inc.
+0001B6|SAEJIN T&M Co., Ltd.
+0001B7|Centos, Inc.
+0001B8|Netsensity, Inc.
+0001B9|SKF Condition Monitoring
+0001BA|IC-Net, Inc.
+0001BB|Frequentis
+0001BC|Brains Corporation
+0001BD|Peterson Electro-Musical Products, Inc.
+0001BE|Gigalink Co., Ltd.
+0001BF|Teleforce Co., Ltd.
+0001C0|CompuLab, Ltd.
+0001C1|Vitesse Semiconductor Corporation
+0001C2|ARK Research Corp.
+0001C3|Acromag, Inc.
+0001C4|NeoWave, Inc.
+0001C5|Simpler Networks
+0001C6|Quarry Technologies
+0001C7|Cisco
+0001C8|THOMAS CONRAD CORP.
+0001C8|CONRAD CORP.
+0001C9|Cisco
+0001CA|Geocast Network Systems, Inc.
+0001CB|EVR
+0001CC|Japan Total Design Communication Co., Ltd.
+0001CD|ARtem
+0001CE|Custom Micro Products, Ltd.
+0001CF|Alpha Data Parallel Systems, Ltd.
+0001D0|VitalPoint, Inc.
+0001D1|CoNet Communications, Inc.
+0001D2|inXtron, Inc.
+0001D3|PAXCOMM, Inc.
+0001D4|Leisure Time, Inc.
+0001D5|HAEDONG INFO & COMM CO., LTD
+0001D6|manroland AG
+0001D7|F5 Networks, Inc.
+0001D8|Teltronics, Inc.
+0001D9|Sigma, Inc.
+0001DA|WINCOMM Corporation
+0001DB|Freecom Technologies GmbH
+0001DC|Activetelco
+0001DD|Avail Networks
+0001DE|Trango Systems, Inc.
+0001DF|ISDN Communications, Ltd.
+0001E0|Fast Systems, Inc.
+0001E1|Kinpo Electronics, Inc.
+0001E2|Ando Electric Corporation
+0001E3|Siemens AG
+0001E4|Sitera, Inc.
+0001E5|Supernet, Inc.
+0001E6|Hewlett-Packard Company
+0001E7|Hewlett-Packard Company
+0001E8|Force10 Networks, Inc.
+0001E9|Litton Marine Systems B.V.
+0001EA|Cirilium Corp.
+0001EB|C-COM Corporation
+0001EC|Ericsson Group
+0001ED|SETA Corp.
+0001EE|Comtrol Europe, Ltd.
+0001EF|Camtel Technology Corp.
+0001F0|Tridium, Inc.
+0001F1|Innovative Concepts, Inc.
+0001F2|Mark of the Unicorn, Inc.
+0001F3|QPS, Inc.
+0001F4|Enterasys Networks
+0001F5|ERIM S.A.
+0001F6|Association of Musical Electronics Industry
+0001F7|Image Display Systems, Inc.
+0001F8|Texio Technology Corporation
+0001F9|TeraGlobal Communications Corp.
+0001FA|HOROSCAS
+0001FB|DoTop Technology, Inc.
+0001FC|Keyence Corporation
+0001FD|Digital Voice Systems, Inc.
+0001FE|DIGITAL EQUIPMENT CORPORATION
+0001FF|Data Direct Networks, Inc.
+000200|Net & Sys Co., Ltd.
+000201|IFM Electronic gmbh
+000202|Amino Communications, Ltd.
+000203|Woonsang Telecom, Inc.
+000204|Bodmann Industries Elektronik GmbH
+000205|Hitachi Denshi, Ltd.
+000206|Telital R&D Denmark A/S
+000207|VisionGlobal Network Corp.
+000208|Unify Networks, Inc.
+000209|Shenzhen SED Information Technology Co., Ltd.
+00020A|Gefran Spa
+00020B|Native Networks, Inc.
+00020C|Metro-Optix
+00020D|Micronpc.com
+00020E|ECI Telecom, Ltd
+00020F|AATR
+000210|Fenecom
+000211|Nature Worldwide Technology Corp.
+000212|SierraCom
+000213|S.D.E.L.
+000214|DTVRO
+000215|Cotas Computer Technology A/B
+000216|Cisco
+000217|Cisco
+000218|Advanced Scientific Corp
+000219|Paralon Technologies
+00021A|Zuma Networks
+00021B|Kollmorgen-Servotronix
+00021C|Network Elements, Inc.
+00021D|Data General Communication Ltd.
+00021E|SIMTEL S.R.L.
+00021F|Aculab PLC
+000220|CANON FINETECH INC.
+000221|DSP Application, Ltd.
+000222|Chromisys, Inc.
+000223|ClickTV
+000224|C-COR
+000225|One Stop Systems
+000226|XESystems, Inc.
+000227|ESD Electronic System Design GmbH
+000228|Necsom, Ltd.
+000229|Adtec Corporation
+00022A|Asound Electronic
+00022B|SAXA, Inc.
+00022C|ABB Bomem, Inc.
+00022D|Agere Systems
+00022E|TEAC Corp. R& D
+00022F|P-Cube, Ltd.
+000230|Intersoft Electronics
+000231|Ingersoll-Rand
+000232|Avision, Inc.
+000233|Mantra Communications, Inc.
+000234|Imperial Technology, Inc.
+000235|Paragon Networks International
+000236|INIT GmbH
+000237|Cosmo Research Corp.
+000238|Serome Technology, Inc.
+000239|Visicom
+00023A|ZSK Stickmaschinen GmbH
+00023B|Ericsson
+00023C|Creative Technology, Ltd.
+00023D|Cisco
+00023E|Selta Telematica S.p.a
+00023F|Compal Electronics, Inc.
+000240|Seedek Co., Ltd.
+000241|Amer.com
+000242|Videoframe Systems
+000243|Raysis Co., Ltd.
+000244|SURECOM Technology Co.
+000245|Lampus Co, Ltd.
+000246|All-Win Tech Co., Ltd.
+000247|Great Dragon Information Technology (Group) Co., Ltd.
+000248|Pilz GmbH & Co.
+000249|Aviv Infocom Co, Ltd.
+00024A|Cisco
+00024B|Cisco
+00024C|SiByte, Inc.
+00024D|Mannesman Dematic Colby Pty. Ltd.
+00024E|Datacard Group
+00024F|IPM Datacom S.R.L.
+000250|Geyser Networks, Inc.
+000251|Soma Networks, Inc.
+000252|Carrier Corporation
+000253|Televideo, Inc.
+000254|WorldGate
+000255|IBM Corp
+000256|Alpha Processor, Inc.
+000257|Microcom Corp.
+000258|Flying Packets Communications
+000259|Tsann Kuen China (Shanghai)Enterprise Co., Ltd. IT Group
+00025A|Catena Networks
+00025B|Cambridge Silicon Radio
+00025C|SCI Systems (Kunshan) Co., Ltd.
+00025D|Calix Networks
+00025E|High Technology Ltd
+00025F|Nortel Networks
+000260|Accordion Networks, Inc.
+000261|Tilgin AB
+000262|Soyo Group Soyo Com Tech Co., Ltd
+000263|UPS Manufacturing SRL
+000264|AudioRamp.com
+000265|Virditech Co. Ltd.
+000266|Thermalogic Corporation
+000267|NODE RUNNER, INC.
+000268|Harris Government Communications
+000269|Nadatel Co., Ltd
+00026A|Cocess Telecom Co., Ltd.
+00026B|BCM Computers Co., Ltd.
+00026C|Philips CFT
+00026D|Adept Telecom
+00026E|NeGeN Access, Inc.
+00026F|Senao International Co., Ltd.
+000270|Crewave Co., Ltd.
+000271|Zhone Technologies
+000272|CC&C Technologies, Inc.
+000273|Coriolis Networks
+000274|Tommy Technologies Corp.
+000275|SMART Technologies, Inc.
+000276|Primax Electronics Ltd.
+000277|Cash Systemes Industrie
+000278|Samsung
+000279|Control Applications, Ltd.
+00027A|IOI Technology Corporation
+00027B|Amplify Net, Inc.
+00027C|Trilithic, Inc.
+00027D|Cisco
+00027E|Cisco
+00027F|ask-technologies.com
+000280|Mu Net, Inc.
+000281|Madge Ltd.
+000282|ViaClix, Inc.
+000283|Spectrum Controls, Inc.
+000284|AREVA T&D
+000285|Riverstone Networks
+000286|Occam Networks
+000287|Adapcom
+000288|GLOBAL VILLAGE COMMUNICATION
+000289|DNE Technologies
+00028A|Ambit Microsystems Corporation
+00028B|VDSL Systems OY
+00028C|Micrel-Synergy Semiconductor
+00028D|Movita Technologies, Inc.
+00028E|Rapid 5 Networks, Inc.
+00028F|Globetek, Inc.
+000290|Woorigisool, Inc.
+000291|Open Network Co., Ltd.
+000292|Logic Innovations, Inc.
+000293|Solid Data Systems
+000294|Tokyo Sokushin Co., Ltd.
+000295|IP.Access Limited
+000296|Lectron Co,. Ltd.
+000297|C-COR.net
+000298|Broadframe Corporation
+000299|Apex, Inc.
+00029A|Storage Apps
+00029B|Kreatel Communications AB
+00029C|3COM
+00029D|Merix Corp.
+00029E|Information Equipment Co., Ltd.
+00029F|L-3 Communication Aviation Recorders
+0002A0|Flatstack Ltd.
+0002A1|World Wide Packets
+0002A2|Hilscher GmbH
+0002A3|ABB Switzerland Ltd, Power Systems
+0002A4|AddPac Technology Co., Ltd.
+0002A5|Hewlett-Packard Company
+0002A6|Effinet Systems Co., Ltd.
+0002A7|Vivace Networks
+0002A8|Air Link Technology
+0002A9|RACOM, s.r.o.
+0002AA|PLcom Co., Ltd.
+0002AB|CTC Union Technologies Co., Ltd.
+0002AC|3PAR data
+0002AD|HOYA Corporation
+0002AE|Scannex Electronics Ltd.
+0002AF|TeleCruz Technology, Inc.
+0002B0|Hokubu Communication & Industrial Co., Ltd.
+0002B1|Anritsu, Ltd.
+0002B2|Cablevision
+0002B3|Intel Corporate
+0002B4|DAPHNE
+0002B5|Avnet, Inc.
+0002B6|Acrosser Technology Co., Ltd.
+0002B7|Watanabe Electric Industry Co., Ltd.
+0002B8|WHI KONSULT AB
+0002B9|Cisco
+0002BA|Cisco
+0002BB|Continuous Computing Corp
+0002BC|LVL 7 Systems, Inc.
+0002BD|Bionet Co., Ltd.
+0002BE|Totsu Engineering, Inc.
+0002BF|dotRocket, Inc.
+0002C0|Bencent Tzeng Industry Co., Ltd.
+0002C1|Innovative Electronic Designs, Inc.
+0002C2|Net Vision Telecom
+0002C3|Arelnet Ltd.
+0002C4|Vector International BVBA
+0002C5|Evertz Microsystems Ltd.
+0002C6|Data Track Technology PLC
+0002C7|ALPS ELECTRIC Co., Ltd.
+0002C8|Technocom Communications Technology (pte) Ltd
+0002C9|Mellanox Technologies
+0002CA|EndPoints, Inc.
+0002CB|TriState Ltd.
+0002CC|M.C.C.I
+0002CD|TeleDream, Inc.
+0002CE|FoxJet, Inc.
+0002CF|ZyGate Communications, Inc.
+0002D0|Comdial Corporation
+0002D1|Vivotek, Inc.
+0002D2|Workstation AG
+0002D3|NetBotz, Inc.
+0002D4|PDA Peripherals, Inc.
+0002D5|ACR
+0002D6|NICE Systems
+0002D7|EMPEG Ltd
+0002D8|BRECIS Communications Corporation
+0002D9|Reliable Controls
+0002DA|ExiO Communications, Inc.
+0002DB|NETSEC
+0002DC|Fujitsu General Limited
+0002DD|Bromax Communications, Ltd.
+0002DE|Astrodesign, Inc.
+0002DF|Net Com Systems, Inc.
+0002E0|ETAS GmbH
+0002E1|Integrated Network Corporation
+0002E2|NDC Infared Engineering
+0002E3|LITE-ON Communications, Inc.
+0002E4|JC HYUN Systems, Inc.
+0002E5|Timeware Ltd.
+0002E6|Gould Instrument Systems, Inc.
+0002E7|CAB GmbH & Co KG
+0002E8|E.D.&A.
+0002E9|CS Systemes De Securite - C3S
+0002EA|Focus Enhancements
+0002EB|Pico Communications
+0002EC|Maschoff Design Engineering
+0002ED|DXO Telecom Co., Ltd.
+0002EE|Nokia Danmark A/S
+0002EF|CCC Network Systems Group Ltd.
+0002F0|AME Optimedia Technology Co., Ltd.
+0002F1|Pinetron Co., Ltd.
+0002F2|eDevice, Inc.
+0002F3|Media Serve Co., Ltd.
+0002F4|PCTEL, Inc.
+0002F5|VIVE Synergies, Inc.
+0002F6|Equipe Communications
+0002F7|ARM
+0002F8|SEAKR Engineering, Inc.
+0002F9|MIMOS Berhad
+0002FA|DX Antenna Co., Ltd.
+0002FB|Baumuller Aulugen-Systemtechnik GmbH
+0002FC|Cisco
+0002FD|Cisco
+0002FE|Viditec, Inc.
+0002FF|Handan BroadInfoCom
+000300|Barracuda Networks, Inc.
+000301|EXFO
+000302|Charles Industries, Ltd.
+000303|JAMA Electronics Co., Ltd.
+000304|Pacific Broadband Communications
+000305|MSC Vertriebs GmbH
+000306|Fusion In Tech Co., Ltd.
+000307|Secure Works, Inc.
+000308|AM Communications, Inc.
+000309|Texcel Technology PLC
+00030A|Argus Technologies
+00030B|Hunter Technology, Inc.
+00030C|Telesoft Technologies Ltd.
+00030D|Uniwill Computer Corp.
+00030E|Core Communications Co., Ltd.
+00030F|Digital China (Shanghai) Networks Ltd.
+000310|E-Globaledge Corporation
+000311|Micro Technology Co., Ltd.
+000312|TR-Systemtechnik GmbH
+000313|Access Media SPA
+000314|Teleware Network Systems
+000315|Cidco Incorporated
+000316|Nobell Communications, Inc.
+000317|Merlin Systems, Inc.
+000318|Cyras Systems, Inc.
+000319|Infineon AG
+00031A|Beijing Broad Telecom Ltd., China
+00031B|Cellvision Systems, Inc.
+00031C|Svenska Hardvarufabriken AB
+00031D|Taiwan Commate Computer, Inc.
+00031E|Optranet, Inc.
+00031F|Condev Ltd.
+000320|Xpeed, Inc.
+000321|Reco Research Co., Ltd.
+000322|IDIS Co., Ltd.
+000323|Cornet Technology, Inc.
+000324|SANYO Consumer Electronics Co., Ltd.
+000325|Arima Computer Corp.
+000326|Iwasaki Information Systems Co., Ltd.
+000327|ACT'L
+000328|Mace Group, Inc.
+000329|F3, Inc.
+00032A|UniData Communication Systems, Inc.
+00032B|GAI Datenfunksysteme GmbH
+00032C|ABB Switzerland Ltd
+00032D|IBASE Technology, Inc.
+00032E|Scope Information Management, Ltd.
+00032F|Global Sun Technology, Inc.
+000330|Imagenics, Co., Ltd.
+000331|Cisco
+000332|Cisco
+000333|Digitel Co., Ltd.
+000334|Newport Electronics
+000335|Mirae Technology
+000336|Zetes Technologies
+000337|Vaone, Inc.
+000338|Oak Technology
+000339|Eurologic Systems, Ltd.
+00033A|Silicon Wave, Inc.
+00033B|TAMI Tech Co., Ltd.
+00033C|Daiden Co., Ltd.
+00033D|ILSHin Lab
+00033E|Tateyama System Laboratory Co., Ltd.
+00033F|BigBand Networks, Ltd.
+000340|Floware Wireless Systems, Ltd.
+000341|Axon Digital Design
+000342|Nortel Networks
+000343|Martin Professional A/S
+000344|Tietech.Co., Ltd.
+000345|Routrek Networks Corporation
+000346|Hitachi Kokusai Electric, Inc.
+000347|Intel Corporate
+000348|Norscan Instruments, Ltd.
+000349|Vidicode Datacommunicatie B.V.
+00034A|RIAS Corporation
+00034B|Nortel Networks
+00034C|Shanghai DigiVision Technology Co., Ltd.
+00034D|Chiaro Networks, Ltd.
+00034E|Pos Data Company, Ltd.
+00034F|Sur-Gard Security
+000350|BTICINO SPA
+000351|Diebold, Inc.
+000352|Colubris Networks
+000353|Mitac, Inc.
+000354|Fiber Logic Communications
+000355|TeraBeam Internet Systems
+000356|Wincor Nixdorf International GmbH
+000357|Intervoice-Brite, Inc.
+000358|Hanyang Digitech Co., Ltd.
+000359|DigitalSis
+00035A|Photron Limited
+00035B|BridgeWave Communications
+00035C|Saint Song Corp.
+00035D|Bosung Hi-Net Co., Ltd.
+00035E|Metropolitan Area Networks, Inc.
+00035F|Pruftechnik Condition Monitoring GmbH & Co. KG
+000360|PAC Interactive Technology, Inc.
+000361|Widcomm, Inc.
+000362|Vodtel Communications, Inc.
+000363|Miraesys Co., Ltd.
+000364|Scenix Semiconductor, Inc.
+000365|Kira Information & Communications, Ltd.
+000366|ASM Pacific Technology
+000367|Jasmine Networks, Inc.
+000368|Embedone Co., Ltd.
+000369|Nippon Antenna Co., Ltd.
+00036A|Mainnet, Ltd.
+00036B|Cisco
+00036C|Cisco
+00036D|Runtop, Inc.
+00036E|Nicon Systems (Pty) Limited
+00036F|Telsey SPA
+000370|NXTV, Inc.
+000371|Acomz Networks Corp.
+000372|ULAN
+000373|Aselsan A.S
+000374|Control Microsystems
+000375|NetMedia, Inc.
+000376|Graphtec Technology, Inc.
+000377|Gigabit Wireless
+000378|HUMAX Co., Ltd.
+000379|Proscend Communications, Inc.
+00037A|Taiyo Yuden Co., Ltd.
+00037B|IDEC IZUMI Corporation
+00037C|Coax Media
+00037D|Stellcom
+00037E|PORTech Communications, Inc.
+00037F|Atheros Communications, Inc.
+000380|SSH Communications Security Corp.
+000381|Ingenico International
+000382|A-One Co., Ltd.
+000383|Metera Networks, Inc.
+000384|AETA
+000385|Actelis Networks, Inc.
+000386|Ho Net, Inc.
+000387|Blaze Network Products
+000388|Fastfame Technology Co., Ltd.
+000389|Plantronics
+00038A|America Online, Inc.
+00038B|PLUS-ONE I&T, Inc.
+00038C|Total Impact
+00038D|PCS Revenue Control Systems, Inc.
+00038E|Atoga Systems, Inc.
+00038F|Weinschel Corporation
+000390|Digital Video Communications, Inc.
+000391|Advanced Digital Broadcast, Ltd.
+000392|Hyundai Teletek Co., Ltd.
+000393|Apple
+000394|Connect One
+000395|California Amplifier
+000396|EZ Cast Co., Ltd.
+000397|Watchfront Limited
+000398|WISI
+000399|Dongju Informations & Communications Co., Ltd.
+00039A|SiConnect
+00039B|NetChip Technology, Inc.
+00039C|OptiMight Communications, Inc.
+00039D|Qisda Corporation
+00039E|Tera System Co., Ltd.
+00039F|Cisco
+0003A0|Cisco
+0003A1|HIPER Information & Communication, Inc.
+0003A2|Catapult Communications
+0003A3|MAVIX, Ltd.
+0003A4|Imation Corp.
+0003A5|Medea Corporation
+0003A6|Traxit Technology, Inc.
+0003A7|Unixtar Technology, Inc.
+0003A8|IDOT Computers, Inc.
+0003A9|AXCENT Media AG
+0003AA|Watlow
+0003AB|Bridge Information Systems
+0003AC|Fronius Schweissmaschinen
+0003AD|Emerson Energy Systems AB
+0003AE|Allied Advanced Manufacturing Pte, Ltd.
+0003AF|Paragea Communications
+0003B0|Xsense Technology Corp.
+0003B1|Hospira Inc.
+0003B2|Radware
+0003B3|IA Link Systems Co., Ltd.
+0003B4|Macrotek International Corp.
+0003B5|Entra Technology Co.
+0003B6|QSI Corporation
+0003B7|ZACCESS Systems
+0003B8|NetKit Solutions, LLC
+0003B9|Hualong Telecom Co., Ltd.
+0003BA|Oracle Corporation
+0003BB|Signal Communications Limited
+0003BC|COT GmbH
+0003BD|OmniCluster Technologies, Inc.
+0003BE|Netility
+0003BF|Centerpoint Broadband Technologies, Inc.
+0003C0|RFTNC Co., Ltd.
+0003C1|Packet Dynamics Ltd
+0003C2|Solphone K.K.
+0003C3|Micronik Multimedia
+0003C4|Tomra Systems ASA
+0003C5|Mobotix AG
+0003C6|ICUE Systems, Inc.
+0003C7|hopf Elektronik GmbH
+0003C8|CML Emergency Services
+0003C9|TECOM Co., Ltd.
+0003CA|MTS Systems Corp.
+0003CB|Nippon Systems Development Co., Ltd.
+0003CC|Momentum Computer, Inc.
+0003CD|Clovertech, Inc.
+0003CE|ETEN Technologies, Inc.
+0003CF|Muxcom, Inc.
+0003D0|KOANKEISO Co., Ltd.
+0003D1|Takaya Corporation
+0003D2|Crossbeam Systems, Inc.
+0003D3|Internet Energy Systems, Inc.
+0003D4|Alloptic, Inc.
+0003D5|Advanced Communications Co., Ltd.
+0003D6|RADVision, Ltd.
+0003D7|NextNet Wireless, Inc.
+0003D8|iMPath Networks, Inc.
+0003D9|Secheron SA
+0003DA|Takamisawa Cybernetics Co., Ltd.
+0003DB|Apogee Electronics Corp.
+0003DC|Lexar Media, Inc.
+0003DD|Comark Corp.
+0003DE|OTC Wireless
+0003DF|Desana Systems
+0003E0|ARRIS Group, Inc.
+0003E1|Winmate Communication, Inc.
+0003E2|Comspace Corporation
+0003E3|Cisco
+0003E4|Cisco
+0003E5|Hermstedt SG
+0003E6|Entone, Inc.
+0003E7|Logostek Co. Ltd.
+0003E8|Wavelength Digital Limited
+0003E9|Akara Canada, Inc.
+0003EA|Mega System Technologies, Inc.
+0003EB|Atrica
+0003EC|ICG Research, Inc.
+0003ED|Shinkawa Electric Co., Ltd.
+0003EE|MKNet Corporation
+0003EF|Oneline AG
+0003F0|Redfern Broadband Networks
+0003F1|Cicada Semiconductor, Inc.
+0003F2|Seneca Networks
+0003F3|Dazzle Multimedia, Inc.
+0003F4|NetBurner
+0003F5|Chip2Chip
+0003F6|Allegro Networks, Inc.
+0003F7|Plast-Control GmbH
+0003F8|SanCastle Technologies, Inc.
+0003F9|Pleiades Communications, Inc.
+0003FA|TiMetra Networks
+0003FB|ENEGATE Co.,Ltd.
+0003FC|Intertex Data AB
+0003FD|Cisco
+0003FE|Cisco
+0003FF|Microsoft
+000400|LEXMARK INTERNATIONAL, INC.
+000401|Osaki Electric Co., Ltd.
+000402|Nexsan Technologies, Ltd.
+000403|Nexsi Corporation
+000404|Makino Milling Machine Co., Ltd.
+000405|ACN Technologies
+000406|Fa. Metabox AG
+000407|Topcon Positioning Systems, Inc.
+000408|Sanko Electronics Co., Ltd.
+000409|Cratos Networks
+00040A|Sage Systems
+00040B|3com Europe Ltd.
+00040C|Kanno Works, Ltd.
+00040D|Avaya, Inc.
+00040E|AVM GmbH
+00040F|Asus Network Technologies, Inc.
+000410|Spinnaker Networks, Inc.
+000411|Inkra Networks, Inc.
+000412|WaveSmith Networks, Inc.
+000413|SNOM Technology AG
+000414|Umezawa Musen Denki Co., Ltd.
+000415|Rasteme Systems Co., Ltd.
+000416|Parks S/A Comunicacoes Digitais
+000417|ELAU AG
+000418|Teltronic S.A.U.
+000419|Fibercycle Networks, Inc.
+00041A|Ines Test and Measurement GmbH & CoKG
+00041B|Bridgeworks Ltd.
+00041C|ipDialog, Inc.
+00041D|Corega of America
+00041E|Shikoku Instrumentation Co., Ltd.
+00041F|Sony Computer Entertainment, Inc.
+000420|Slim Devices, Inc.
+000421|Ocular Networks
+000422|Gordon Kapes, Inc.
+000423|Intel Corporate
+000424|TMC s.r.l.
+000425|Atmel Corporation
+000426|Autosys
+000427|Cisco
+000428|Cisco
+000429|Pixord Corporation
+00042A|Wireless Networks, Inc.
+00042B|IT Access Co., Ltd.
+00042C|Minet, Inc.
+00042D|Sarian Systems, Ltd.
+00042E|Netous Technologies, Ltd.
+00042F|International Communications Products, Inc.
+000430|Netgem
+000431|GlobalStreams, Inc.
+000432|Voyetra Turtle Beach, Inc.
+000433|Cyberboard A/S
+000434|Accelent Systems, Inc.
+000435|Comptek International, Inc.
+000436|ELANsat Technologies, Inc.
+000437|Powin Information Technology, Inc.
+000438|Nortel Networks
+000439|Rosco Entertainment Technology, Inc.
+00043A|Intelligent Telecommunications, Inc.
+00043B|Lava Computer Mfg., Inc.
+00043C|SONOS Co., Ltd.
+00043D|INDEL AG
+00043E|Telencomm
+00043F|ESTeem Wireless Modems, Inc
+000440|cyberPIXIE, Inc.
+000441|Half Dome Systems, Inc.
+000442|NACT
+000443|Agilent Technologies, Inc.
+000444|Western Multiplex Corporation
+000445|LMS Skalar Instruments GmbH
+000446|CYZENTECH Co., Ltd.
+000447|Acrowave Systems Co., Ltd.
+000448|Polaroid Corporation
+000449|Mapletree Networks
+00044A|iPolicy Networks, Inc.
+00044B|NVIDIA
+00044C|JENOPTIK
+00044D|Cisco
+00044E|Cisco
+00044F|Leukhardt Systemelektronik GmbH
+000450|DMD Computers SRL
+000451|Medrad, Inc.
+000452|RocketLogix, Inc.
+000453|YottaYotta, Inc.
+000454|Quadriga UK
+000455|ANTARA.net
+000456|Cambium Networks Limited
+000457|Universal Access Technology, Inc.
+000458|Fusion X Co., Ltd.
+000459|Veristar Corporation
+00045A|The Linksys Group, Inc.
+00045B|Techsan Electronics Co., Ltd.
+00045C|Mobiwave Pte Ltd
+00045D|BEKA Elektronik
+00045E|PolyTrax Information Technology AG
+00045F|Avalue Technology, Inc.
+000460|Knilink Technology, Inc.
+000461|EPOX Computer Co., Ltd.
+000462|DAKOS Data & Communication Co., Ltd.
+000463|Bosch Security Systems
+000464|Pulse-Link Inc
+000465|i.s.t isdn-support technik GmbH
+000466|ARMITEL Co.
+000467|Wuhan Research Institute of MII
+000468|Vivity, Inc.
+000469|Innocom, Inc.
+00046A|Navini Networks
+00046B|Palm Wireless, Inc.
+00046C|Cyber Technology Co., Ltd.
+00046D|Cisco
+00046E|Cisco
+00046F|Digitel S/A Industria Eletronica
+000470|ipUnplugged AB
+000471|IPrad
+000472|Telelynx, Inc.
+000473|Photonex Corporation
+000474|LEGRAND
+000475|3 Com Corporation
+000476|3 Com Corporation
+000477|Scalant Systems, Inc.
+000478|G. Star Technology Corporation
+000479|Radius Co., Ltd.
+00047A|AXXESSIT ASA
+00047B|Schlumberger
+00047C|Skidata AG
+00047D|Pelco
+00047E|Siqura B.V.
+00047F|Chr. Mayr GmbH & Co. KG
+000480|Brocade Communications Systems, Inc
+000481|Econolite Control Products, Inc.
+000482|Medialogic Corp.
+000483|Deltron Technology, Inc.
+000484|Amann GmbH
+000485|PicoLight
+000486|ITTC, University of Kansas
+000487|Cogency Semiconductor, Inc.
+000488|Eurotherm Controls
+000489|YAFO Networks, Inc.
+00048A|Temia Vertriebs GmbH
+00048B|Poscon Corporation
+00048C|Nayna Networks, Inc.
+00048D| Teo Technologies, Inc
+00048E|Ohm Tech Labs, Inc.
+00048F|TD Systems Corporation
+000490|Optical Access
+000491|Technovision, Inc.
+000492|Hive Internet, Ltd.
+000493|Tsinghua Unisplendour Co., Ltd.
+000494|Breezecom, Ltd.
+000495|Tejas Networks India Limited
+000496|Extreme Networks
+000497|MacroSystem Digital Video AG
+000498|Mahi Networks
+000499|Chino Corporation
+00049A|Cisco
+00049B|Cisco
+00049C|Surgient Networks, Inc.
+00049D|Ipanema Technologies
+00049E|Wirelink Co., Ltd.
+00049F|Freescale Semiconductor
+0004A0|Verity Instruments, Inc.
+0004A1|Pathway Connectivity
+0004A2|L.S.I. Japan Co., Ltd.
+0004A3|Microchip Technology, Inc.
+0004A4|NetEnabled, Inc.
+0004A5|Barco Projection Systems NV
+0004A6|SAF Tehnika Ltd.
+0004A7|FabiaTech Corporation
+0004A8|Broadmax Technologies, Inc.
+0004A9|SandStream Technologies, Inc.
+0004AA|Jetstream Communications
+0004AB|Comverse Network Systems, Inc.
+0004AC|IBM Corp
+0004AD|Malibu Networks
+0004AE|Sullair Corporation
+0004AF|Digital Fountain, Inc.
+0004B0|ELESIGN Co., Ltd.
+0004B1|Signal Technology, Inc.
+0004B2|ESSEGI SRL
+0004B3|Videotek, Inc.
+0004B4|CIAC
+0004B5|Equitrac Corporation
+0004B6|Stratex Networks, Inc.
+0004B7|AMB i.t. Holding
+0004B8|Kumahira Co., Ltd.
+0004B9|S.I. Soubou, Inc.
+0004BA|KDD Media Will Corporation
+0004BB|Bardac Corporation
+0004BC|Giantec, Inc.
+0004BD|ARRIS Group, Inc.
+0004BE|OptXCon, Inc.
+0004BF|VersaLogic Corp.
+0004C0|Cisco
+0004C1|Cisco
+0004C2|Magnipix, Inc.
+0004C3|CASTOR Informatique
+0004C4|Allen & Heath Limited
+0004C5|ASE Technologies, USA
+0004C6|Yamaha Motor Co., Ltd.
+0004C7|NetMount
+0004C8|LIBA Maschinenfabrik GmbH
+0004C9|Micro Electron Co., Ltd.
+0004CA|FreeMs Corp.
+0004CB|Tdsoft Communication, Ltd.
+0004CC|Peek Traffic B.V.
+0004CD|Extenway Solutions Inc
+0004CE|Patria Ailon
+0004CF|Seagate Technology
+0004D0|Softlink s.r.o.
+0004D1|Drew Technologies, Inc.
+0004D2|Adcon Telemetry GmbH
+0004D3|Toyokeiki Co., Ltd.
+0004D4|Proview Electronics Co., Ltd.
+0004D5|Hitachi Information & Communication Engineering, Ltd.
+0004D6|Takagi Industrial Co., Ltd.
+0004D7|Omitec Instrumentation Ltd.
+0004D8|IPWireless, Inc.
+0004D9|Titan Electronics, Inc.
+0004DA|Relax Technology, Inc.
+0004DB|Tellus Group Corp.
+0004DC|Nortel Networks
+0004DD|Cisco
+0004DE|Cisco
+0004DF|Teracom Telematica Ltda.
+0004E0|Procket Networks
+0004E1|Infinior Microsystems
+0004E2|SMC Networks, Inc.
+0004E3|Accton Technology Corp.
+0004E4|Daeryung Ind., Inc.
+0004E5|Glonet Systems, Inc.
+0004E6|Banyan Network Private Limited
+0004E7|Lightpointe Communications, Inc
+0004E8|IER, Inc.
+0004E9|Infiniswitch Corporation
+0004EA|Hewlett-Packard Company
+0004EB|Paxonet Communications, Inc.
+0004EC|Memobox SA
+0004ED|Billion Electric Co., Ltd.
+0004EE|Lincoln Electric Company
+0004EF|Polestar Corp.
+0004F0|International Computers, Ltd
+0004F1|WhereNet
+0004F2|Polycom
+0004F3|FS FORTH-SYSTEME GmbH
+0004F4|Infinite Electronics Inc.
+0004F5|SnowShore Networks, Inc.
+0004F6|Amphus
+0004F7|Omega Band, Inc.
+0004F8|QUALICABLE TV Industria E Com., Ltda
+0004F9|Xtera Communications, Inc.
+0004FA|NBS Technologies Inc.
+0004FB|Commtech, Inc.
+0004FC|Stratus Computer (DE), Inc.
+0004FD|Japan Control Engineering Co., Ltd.
+0004FE|Pelago Networks
+0004FF|Acronet Co., Ltd.
+000500|Cisco
+000501|Cisco
+000502|Apple
+000503|ICONAG
+000504|Naray Information & Communication Enterprise
+000505|Systems Integration Solutions, Inc.
+000506|Reddo Networks AB
+000507|Fine Appliance Corp.
+000508|Inetcam, Inc.
+000509|AVOC Nishimura Ltd.
+00050A|ICS Spa
+00050B|SICOM Systems, Inc.
+00050C|Network Photonics, Inc.
+00050D|Midstream Technologies, Inc.
+00050E|3ware, Inc.
+00050F|Tanaka S/S Ltd.
+000510|Infinite Shanghai Communication Terminals Ltd.
+000511|Complementary Technologies Ltd
+000512|Zebra Technologies Inc
+000513|VTLinx Multimedia Systems, Inc.
+000514|KDT Systems Co., Ltd.
+000515|Nuark Co., Ltd.
+000516|SMART Modular Technologies
+000517|Shellcomm, Inc.
+000518|Jupiters Technology
+000519|Siemens Building Technologies AG,
+00051A|3Com Europe Ltd.
+00051B|Magic Control Technology Corporation
+00051C|Xnet Technology Corp.
+00051D|Airocon, Inc.
+00051E|Brocade Communications Systems, Inc.
+00051F|Taijin Media Co., Ltd.
+000520|Smartronix, Inc.
+000521|Control Microsystems
+000522|LEA*D Corporation, Inc.
+000523|AVL List GmbH
+000524|BTL System (HK) Limited
+000525|Puretek Industrial Co., Ltd.
+000526|IPAS GmbH
+000527|SJ Tek Co. Ltd
+000528|New Focus, Inc.
+000529|Shanghai Broadan Communication Technology Co., Ltd
+00052A|Ikegami Tsushinki Co., Ltd.
+00052B|HORIBA, Ltd.
+00052C|Supreme Magic Corporation
+00052D|Zoltrix International Limited
+00052E|Cinta Networks
+00052F|Leviton Network Solutions
+000530|Andiamo Systems, Inc.
+000531|Cisco
+000532|Cisco
+000533|Brocade Communications Systems, Inc.
+000534|Northstar Engineering Ltd.
+000535|Chip PC Ltd.
+000536|Danam Communications, Inc.
+000537|Nets Technology Co., Ltd.
+000538|Merilus, Inc.
+000539|A Brand New World in Sweden AB
+00053A|Willowglen Services Pte Ltd
+00053B|Harbour Networks Ltd., Co. Beijing
+00053C|Xircom
+00053D|Agere Systems
+00053E|KID Systeme GmbH
+00053F|VisionTek, Inc.
+000540|FAST Corporation
+000541|Advanced Systems Co., Ltd.
+000542|Otari, Inc.
+000543|IQ Wireless GmbH
+000544|Valley Technologies, Inc.
+000545|Internet Photonics
+000546|KDDI Network & Solultions Inc.
+000547|Starent Networks
+000548|Disco Corporation
+000549|Salira Optical Network Systems
+00054A|Ario Data Networks, Inc.
+00054B|Eaton Automation AG
+00054C|RF Innovations Pty Ltd
+00054D|Brans Technologies, Inc.
+00054E|Philips
+00054F|Garmin International 
+000550|Vcomms Connect Limited
+000551|F & S Elektronik Systeme GmbH
+000552|Xycotec Computer GmbH
+000553|DVC Company, Inc.
+000554|Rangestar Wireless
+000555|Japan Cash Machine Co., Ltd.
+000556|360 Systems
+000557|Agile TV Corporation
+000558|Synchronous, Inc.
+000559|Intracom S.A.
+00055A|Power Dsine Ltd.
+00055B|Charles Industries, Ltd.
+00055C|Kowa Company, Ltd.
+00055D|D-Link Systems, Inc.
+00055E|Cisco
+00055F|Cisco
+000560|LEADER COMM.CO., LTD
+000561|nac Image Technology, Inc.
+000562|Digital View Limited
+000563|J-Works, Inc.
+000564|Tsinghua Bitway Co., Ltd.
+000565|Tailyn Communication Company Ltd.
+000566|Secui.com Corporation
+000567|Etymonic Design, Inc.
+000568|Piltofish Networks AB
+000569|VMware, Inc.
+00056A|Heuft Systemtechnik GmbH
+00056B|C.P. Technology Co., Ltd.
+00056C|Hung Chang Co., Ltd.
+00056D|Pacific Corporation
+00056E|National Enhance Technology, Inc.
+00056F|Innomedia Technologies Pvt. Ltd.
+000570|Baydel Ltd.
+000571|Seiwa Electronics Co.
+000572|Deonet Co., Ltd.
+000573|Cisco
+000574|Cisco
+000575|CDS-Electronics BV
+000576|NSM Technology Ltd.
+000577|SM Information & Communication
+000578|Odic, Inc. 
+000579|Universal Control Solution Corp.
+00057A|Overture Networks
+00057B|Chung Nam Electronic Co., Ltd.
+00057C|RCO Security AB
+00057D|Sun Communications, Inc.
+00057E|Eckelmann Steuerungstechnik GmbH
+00057F|Acqis Technology
+000580|FibroLAN Ltd.
+000581|Snell
+000582|ClearCube Technology
+000583|ImageCom Limited
+000584|AbsoluteValue Systems, Inc.
+000585|Juniper Networks, Inc.
+000586|Lucent Technologies
+000587|Locus, Incorporated
+000588|Sensoria Corp.
+000589|National Datacomputer
+00058A|Netcom Co., Ltd.
+00058B|IPmental, Inc.
+00058C|Opentech Inc.
+00058D|Lynx Photonic Networks, Inc.
+00058E|Flextronics International GmbH & Co. Nfg. KG
+00058F|CLCsoft co.
+000590|Swissvoice Ltd.
+000591|Active Silicon Ltd
+000592|Pultek Corp.
+000593|Grammar Engine Inc.
+000594|IXXAT Automation GmbH
+000595|Alesis Corporation
+000596|Genotech Co., Ltd.
+000597|Eagle Traffic Control Systems
+000598|CRONOS S.r.l.
+000599|DRS Test and Energy Management or DRS-TEM
+00059A|Cisco
+00059B|Cisco
+00059C|Kleinknecht GmbH, Ing. Buro
+00059D|Daniel Computing Systems, Inc.
+00059E|Zinwell Corporation
+00059F|Yotta Networks, Inc.
+0005A0|MOBILINE Kft.
+0005A1|Zenocom
+0005A2|CELOX Networks
+0005A3|QEI, Inc.
+0005A4|Lucid Voice Ltd.
+0005A5|KOTT
+0005A6|Extron Electronics
+0005A7|Hyperchip, Inc.
+0005A8|WYLE ELECTRONICS
+0005A9|Princeton Networks, Inc.
+0005AA|Moore Industries International Inc.
+0005AB|Cyber Fone, Inc.
+0005AC|Northern Digital, Inc.
+0005AD|Topspin Communications, Inc.
+0005AE|Mediaport USA
+0005AF|InnoScan Computing A/S
+0005B0|Korea Computer Technology Co., Ltd.
+0005B1|ASB Technology BV
+0005B2|Medison Co., Ltd.
+0005B3|Asahi-Engineering Co., Ltd.
+0005B4|Aceex Corporation
+0005B5|Broadcom Technologies
+0005B6|INSYS Microelectronics GmbH
+0005B7|Arbor Technology Corp.
+0005B8|Electronic Design Associates, Inc.
+0005B9|Airvana, Inc.
+0005BA|Area Netwoeks, Inc.
+0005BB|Myspace AB
+0005BC|Resource Data Management Ltd
+0005BD|ROAX BV
+0005BE|Kongsberg Seatex AS
+0005BF|JustEzy Technology, Inc.
+0005C0|Digital Network Alacarte Co., Ltd.
+0005C1|A-Kyung Motion, Inc.
+0005C2|Soronti, Inc.
+0005C3|Pacific Instruments, Inc.
+0005C4|Telect, Inc.
+0005C5|Flaga HF
+0005C6|Triz Communications
+0005C7|I/F-COM A/S
+0005C8|VERYTECH
+0005C9|LG Innotek Co., Ltd.
+0005CA|Hitron Technology, Inc.
+0005CB|ROIS Technologies, Inc.
+0005CC|Sumtel Communications, Inc.
+0005CD|Denon, Ltd.
+0005CE|Prolink Microsystems Corporation
+0005CF|Thunder River Technologies, Inc.
+0005D0|Solinet Systems
+0005D1|Metavector Technologies
+0005D2|DAP Technologies
+0005D3|eProduction Solutions, Inc.
+0005D4|FutureSmart Networks, Inc.
+0005D5|Speedcom Wireless
+0005D6|L-3 Linkabit
+0005D7|Vista Imaging, Inc.
+0005D8|Arescom, Inc.
+0005D9|Techno Valley, Inc.
+0005DA|Apex Automationstechnik
+0005DB|PSI Nentec GmbH
+0005DC|Cisco
+0005DD|Cisco
+0005DE|Gi Fone Korea, Inc.
+0005DF|Electronic Innovation, Inc.
+0005E0|Empirix Corp.
+0005E1|Trellis Photonics, Ltd.
+0005E2|Creativ Network Technologies
+0005E3|LightSand Communications, Inc.
+0005E4|Red Lion Controls Inc.
+0005E5|Renishaw PLC
+0005E6|Egenera, Inc.
+0005E7|Netrake an AudioCodes Company
+0005E8|TurboWave, Inc.
+0005E9|Unicess Network, Inc.
+0005EA|Rednix
+0005EB|Blue Ridge Networks, Inc.
+0005EC|Mosaic Systems Inc.
+0005ED|Technikum Joanneum GmbH
+0005EE|Siemens AB, Infrastructure & Cities, Building Technologies Division, IC BT SSP SP BA PR
+0005EF|ADOIR Digital Technology
+0005F0|SATEC
+0005F1|Vrcom, Inc.
+0005F2|Power R, Inc.
+0005F3|Webyn
+0005F4|System Base Co., Ltd.
+0005F5|Geospace Technologies
+0005F6|Young Chang Co. Ltd.
+0005F7|Analog Devices, Inc.
+0005F8|Real Time Access, Inc.
+0005F9|TOA Corporation
+0005FA|IPOptical, Inc.
+0005FB|ShareGate, Inc.
+0005FC|Schenck Pegasus Corp.
+0005FD|PacketLight Networks Ltd.
+0005FE|Traficon N.V.
+0005FF|SNS Solutions, Inc.
+000600|Toshiba Teli Corporation
+000601|Otanikeiki Co., Ltd.
+000602|Cirkitech Electronics Co.
+000603|Baker Hughes Inc.
+000604|@Track Communications, Inc.
+000605|Inncom International, Inc.
+000606|RapidWAN, Inc.
+000607|Omni Directional Control Technology Inc.
+000608|At-Sky SAS
+000609|Crossport Systems
+00060A|Blue2space
+00060B|Artesyn Embedded Technologies
+00060C|Melco Industries, Inc.
+00060D|Wave7 Optics
+00060E|IGYS Systems, Inc.
+00060F|Narad Networks Inc
+000610|Abeona Networks Inc
+000611|Zeus Wireless, Inc.
+000612|Accusys, Inc.
+000613|Kawasaki Microelectronics Incorporated
+000614|Prism Holdings
+000615|Kimoto Electric Co., Ltd.
+000616|Tel Net Co., Ltd.
+000617|Redswitch Inc.
+000618|DigiPower Manufacturing Inc.
+000619|Connection Technology Systems
+00061A|Zetari Inc.
+00061B|Notebook Development Lab.  Lenovo Japan Ltd.
+00061C|Hoshino Metal Industries, Ltd.
+00061D|MIP Telecom, Inc.
+00061E|Maxan Systems
+00061F|Vision Components GmbH
+000620|Serial System Ltd.
+000621|Hinox, Co., Ltd.
+000622|Chung Fu Chen Yeh Enterprise Corp.
+000623|MGE UPS Systems France
+000624|Gentner Communications Corp.
+000625|The Linksys Group, Inc.
+000626|MWE GmbH
+000627|Uniwide Technologies, Inc.
+000628|Cisco
+000629|IBM Corp
+00062A|Cisco
+00062B|INTRASERVER TECHNOLOGY
+00062C|Bivio Networks
+00062D|TouchStar Technologies, L.L.C.
+00062E|Aristos Logic Corp.
+00062F|Pivotech Systems Inc.
+000630|Adtranz Sweden
+000631|Calix
+000632|Mesco Engineering GmbH
+000633|Cross Match Technologies GmbH
+000634|GTE Airfone Inc.
+000635|PacketAir Networks, Inc.
+000636|Jedai Broadband Networks
+000637|Toptrend-Meta Information (ShenZhen) Inc.
+000638|Sungjin C&C Co., Ltd.
+000639|Newtec
+00063A|Dura Micro, Inc.
+00063B|Arcturus Networks Inc.
+00063C|Intrinsyc Software International Inc.
+00063D|Microwave Data Systems Inc.
+00063E|Opthos Inc.
+00063F|Everex Communications Inc.
+000640|White Rock Networks
+000641|ITCN
+000642|Genetel Systems Inc.
+000643|SONO Computer Co., Ltd.
+000644|neix,Inc
+000645|Meisei Electric Co. Ltd.
+000646|ShenZhen XunBao Network Technology Co Ltd
+000647|Etrali S.A.
+000648|Seedsware, Inc.
+000649|3M Deutschland GmbH
+00064A|Honeywell Co., Ltd. (KOREA)
+00064B|Alexon Co., Ltd.
+00064C|Invicta Networks, Inc.
+00064D|Sencore
+00064E|Broad Net Technology Inc.
+00064F|PRO-NETS Technology Corporation
+000650|Tiburon Networks, Inc.
+000651|Aspen Networks Inc.
+000652|Cisco
+000653|Cisco
+000654|Winpresa Building Automation Technologies GmbH
+000655|Yipee, Inc.
+000656|Tactel AB
+000657|Market Central, Inc.
+000658|Helmut Fischer GmbH Institut fur Elektronik und Messtechnik
+000659|EAL (Apeldoorn) B.V.
+00065A|Strix Systems
+00065B|Dell Computer Corp.
+00065C|Malachite Technologies, Inc.
+00065D|Heidelberg Web Systems
+00065E|Photuris, Inc.
+00065F|ECI Telecom - NGTS Ltd.
+000660|NADEX Co., Ltd.
+000661|NIA Home Technologies Corp.
+000662|MBM Technology Ltd.
+000663|Human Technology Co., Ltd.
+000664|Fostex Corporation
+000665|Sunny Giken, Inc.
+000666|Roving Networks
+000667|Tripp Lite
+000668|Vicon Industries Inc.
+000669|Datasound Laboratories Ltd
+00066A|InfiniCon Systems, Inc.
+00066B|Sysmex Corporation
+00066C|Robinson Corporation
+00066D|Compuprint S.P.A.
+00066E|Delta Electronics, Inc.
+00066F|Korea Data Systems
+000670|Upponetti Oy
+000671|Softing AG
+000672|Netezza
+000673|TKH Security Solutions USA
+000674|Spectrum Control, Inc.
+000675|Banderacom, Inc.
+000676|Novra Technologies Inc.
+000677|SICK AG
+000678|Marantz Brand Company
+000679|Konami Corporation
+00067A|JMP Systems
+00067B|Toplink C&C Corporation
+00067C|Cisco
+00067D|Takasago Ltd.
+00067E|WinCom Systems, Inc.
+00067F|Digeo, Inc.
+000680|Card Access, Inc.
+000681|Goepel Electronic GmbH
+000682|Convedia
+000683|Bravara Communications, Inc.
+000684|Biacore AB
+000685|NetNearU Corporation
+000686|ZARDCOM Co., Ltd.
+000687|Omnitron Systems Technology, Inc.
+000688|Telways Communication Co., Ltd.
+000689|yLez Technologies Pte Ltd
+00068A|NeuronNet Co. Ltd. R&D Center
+00068B|AirRunner Technologies, Inc.
+00068C|3Com Corporation
+00068D|SEPATON, Inc.
+00068E|HID Corporation
+00068F|Telemonitor, Inc.
+000690|Euracom Communication GmbH
+000691|PT Inovacao
+000692|Intruvert Networks, Inc.
+000693|Flexus Computer Technology, Inc.
+000694|Mobillian Corporation
+000695|Ensure Technologies, Inc.
+000696|Advent Networks
+000697|R & D Center
+000698|egnite GmbH
+000699|Vida Design Co.
+00069A|e & Tel
+00069B|AVT Audio Video Technologies GmbH
+00069C|Transmode Systems AB
+00069D|Petards Ltd
+00069E|UNIQA, Inc.
+00069F|Kuokoa Networks
+0006A0|Mx Imaging
+0006A1|Celsian Technologies, Inc.
+0006A2|Microtune, Inc.
+0006A3|Bitran Corporation
+0006A4|INNOWELL Corp.
+0006A5|PINON Corp.
+0006A6|Artistic Licence Engineering Ltd
+0006A7|Primarion
+0006A8|KC Technology, Inc.
+0006A9|Universal Instruments Corp.
+0006AA|VT Miltope
+0006AB|W-Link Systems, Inc.
+0006AC|Intersoft Co.
+0006AD|KB Electronics Ltd.
+0006AE|Himachal Futuristic Communications Ltd
+0006AF|Xalted Networks
+0006B0|Comtech EF Data Corp.
+0006B1|Sonicwall
+0006B2|Linxtek Co.
+0006B3|Diagraph Corporation
+0006B4|Vorne Industries, Inc.
+0006B5|Source Photonics, Inc.
+0006B6|Nir-Or Israel Ltd.
+0006B7|TELEM GmbH
+0006B8|Bandspeed Pty Ltd
+0006B9|A5TEK Corp.
+0006BA|Westwave Communications
+0006BB|ATI Technologies Inc.
+0006BC|Macrolink, Inc.
+0006BD|BNTECHNOLOGY Co., Ltd.
+0006BE|Baumer Optronic GmbH
+0006BF|Accella Technologies Co., Ltd.
+0006C0|United Internetworks, Inc.
+0006C1|Cisco
+0006C2|Smartmatic Corporation
+0006C3|Schindler Elevator Ltd.
+0006C4|Piolink Inc.
+0006C5|INNOVI Technologies Limited
+0006C6|lesswire AG
+0006C7|RFNET Technologies Pte Ltd (S)
+0006C8|Sumitomo Metal Micro Devices, Inc.
+0006C9|Technical Marketing Research, Inc.
+0006CA|American Computer & Digital Components, Inc. (ACDC)
+0006CB|Jotron Electronics A/S
+0006CC|JMI Electronics Co., Ltd.
+0006CD|Leaf Imaging Ltd.
+0006CE|DATENO
+0006CF|Thales Avionics In-Flight Systems, LLC
+0006D0|Elgar Electronics Corp.
+0006D1|Tahoe Networks, Inc.
+0006D2|Tundra Semiconductor Corp.
+0006D3|Alpha Telecom, Inc. U.S.A.
+0006D4|Interactive Objects, Inc.
+0006D5|Diamond Systems Corp.
+0006D6|Cisco
+0006D7|Cisco
+0006D8|Maple Optical Systems
+0006D9|IPM-Net S.p.A.
+0006DA|ITRAN Communications Ltd.
+0006DB|ICHIPS Co., Ltd.
+0006DC|Syabas Technology (Amquest)
+0006DD|AT & T Laboratories - Cambridge Ltd
+0006DE|Flash Technology
+0006DF|AIDONIC Corporation
+0006E0|MAT Co., Ltd.
+0006E1|Techno Trade s.a
+0006E2|Ceemax Technology Co., Ltd.
+0006E3|Quantitative Imaging Corporation
+0006E4|Citel Technologies Ltd.
+0006E5|Fujian Newland Computer Ltd. Co.
+0006E6|DongYang Telecom Co., Ltd.
+0006E7|Bit Blitz Communications Inc.
+0006E8|Optical Network Testing, Inc.
+0006E9|Intime Corp.
+0006EA|ELZET80 Mikrocomputer GmbH&Co. KG
+0006EB|Global Data
+0006EC|Harris Corporation
+0006ED|Inara Networks
+0006EE|Shenyang Neu-era Information & Technology Stock Co., Ltd
+0006EF|Maxxan Systems, Inc.
+0006F0|Digeo, Inc.
+0006F1|Optillion
+0006F2|Platys Communications
+0006F3|AcceLight Networks
+0006F4|Prime Electronics & Satellitics Inc.
+0006F5|ALPS Co,. Ltd.
+0006F6|Cisco
+0006F7|ALPS Co,. Ltd.
+0006F8|The Boeing Company
+0006F9|Mitsui Zosen Systems Research Inc.
+0006FA|IP SQUARE Co, Ltd.
+0006FB|Hitachi Printing Solutions, Ltd.
+0006FC|Fnet Co., Ltd.
+0006FD|Comjet Information Systems Corp.
+0006FE|Ambrado, Inc
+0006FF|Sheba Systems Co., Ltd.
+000700|Zettamedia Korea
+000701|RACAL-DATACOM
+000702|Varian Medical Systems
+000703|CSEE Transport
+000704|ALPS Co,. Ltd.
+000705|Endress & Hauser GmbH & Co
+000706|Sanritz Corporation
+000707|Interalia Inc.
+000708|Bitrage Inc.
+000709|Westerstrand Urfabrik AB
+00070A|Unicom Automation Co., Ltd.
+00070B|Novabase SGPS, SA
+00070C|SVA-Intrusion.com Co. Ltd.
+00070D|Cisco
+00070E|Cisco
+00070F|Fujant, Inc.
+000710|Adax, Inc.
+000711|Acterna
+000712|JAL Information Technology
+000713|IP One, Inc.
+000714|Brightcom
+000715|General Research of Electronics, Inc.
+000716|J & S Marine Ltd.
+000717|Wieland Electric GmbH
+000718|iCanTek Co., Ltd.
+000719|Mobiis Co., Ltd.
+00071A|Finedigital Inc.
+00071B|CDVI Americas Ltd
+00071C|AT&T Fixed Wireless Services
+00071D|Satelsa Sistemas Y Aplicaciones De Telecomunicaciones, S.A.
+00071E|Tri-M Engineering / Nupak Dev. Corp.
+00071F|European Systems Integration
+000720|Trutzschler GmbH & Co. KG
+000721|Formac Elektronik GmbH
+000722|The Nielsen Company
+000723|ELCON Systemtechnik GmbH
+000724|Telemax Co., Ltd.
+000725|Bematech International Corp.
+000726|Shenzhen Gongjin Electronics Co., Ltd.
+000727|Zi Corporation (HK) Ltd.
+000728|Neo Telecom
+000729|Kistler Instrumente AG
+00072A|Innovance Networks
+00072B|Jung Myung Telecom Co., Ltd.
+00072C|Fabricom
+00072D|CNSystems
+00072E|North Node AB
+00072F|Intransa, Inc.
+000730|Hutchison OPTEL Telecom Technology Co., Ltd.
+000731|Ophir-Spiricon LLC
+000732|AAEON Technology Inc.
+000733|DANCONTROL Engineering
+000734|ONStor, Inc.
+000735|Flarion Technologies, Inc.
+000736|Data Video Technologies Co., Ltd.
+000737|Soriya Co. Ltd.
+000738|Young Technology Co., Ltd.
+000739|Scotty Group Austria Gmbh
+00073A|Inventel Systemes
+00073B|Tenovis GmbH & Co KG
+00073C|Telecom Design
+00073D|Nanjing Postel Telecommunications Co., Ltd.
+00073E|China Great-Wall Computer Shenzhen Co., Ltd.
+00073F|Woojyun Systec Co., Ltd.
+000740|Buffalo Inc.
+000741|Sierra Automated Systems
+000742|Ormazabal
+000743|Chelsio Communications
+000744|Unico, Inc.
+000745|Radlan Computer Communications Ltd.
+000746|TURCK, Inc.
+000747|Mecalc
+000748|The Imaging Source Europe
+000749|CENiX Inc.
+00074A|Carl Valentin GmbH
+00074B|Daihen Corporation
+00074C|Beicom Inc.
+00074D|Zebra Technologies Corp.
+00074E|IPFRONT Inc
+00074F|Cisco
+000750|Cisco
+000751|m-u-t AG
+000752|Rhythm Watch Co., Ltd.
+000753|Beijing Qxcomm Technology Co., Ltd.
+000754|Xyterra Computing, Inc.
+000755|Lafon
+000756|Juyoung Telecom
+000757|Topcall International AG
+000758|Dragonwave
+000759|Boris Manufacturing Corp.
+00075A|Air Products and Chemicals, Inc.
+00075B|Gibson Guitars
+00075C|Eastman Kodak Company
+00075D|Celleritas Inc.
+00075E|Ametek Power Instruments
+00075F|VCS Video Communication Systems AG
+000760|TOMIS Information & Telecom Corp.
+000761|Logitech Europe SA
+000762|Group Sense Limited
+000763|Sunniwell Cyber Tech. Co., Ltd.
+000764|YoungWoo Telecom Co. Ltd.
+000765|Jade Quantum Technologies, Inc.
+000766|Chou Chin Industrial Co., Ltd.
+000767|Yuxing Electronics Company Limited
+000768|Danfoss A/S
+000769|Italiana Macchi SpA
+00076A|NEXTEYE Co., Ltd.
+00076B|Stralfors AB
+00076C|Daehanet, Inc.
+00076D|Flexlight Networks
+00076E|Sinetica Corporation Limited
+00076F|Synoptics Limited
+000770|Ubiquoss Inc
+000771|Embedded System Corporation
+000772|Alcatel Shanghai Bell Co., Ltd.
+000773|Ascom Powerline Communications Ltd.
+000774|GuangZhou Thinker Technology Co. Ltd.
+000775|Valence Semiconductor, Inc.
+000776|Federal APD
+000777|Motah Ltd.
+000778|GERSTEL GmbH & Co. KG
+000779|Sungil Telecom Co., Ltd.
+00077A|Infoware System Co., Ltd.
+00077B|Millimetrix Broadband Networks
+00077C|Westermo Teleindustri AB
+00077D|Cisco
+00077E|Elrest GmbH
+00077F|J Communications Co., Ltd.
+000780|Bluegiga Technologies OY
+000781|Itron Inc.
+000782|Oracle Corporation
+000783|SynCom Network, Inc.
+000784|Cisco
+000785|Cisco
+000786|Wireless Networks Inc.
+000787|Idea System Co., Ltd.
+000788|Clipcomm, Inc.
+000789|DONGWON SYSTEMS
+00078A|Mentor Data System Inc.
+00078B|Wegener Communications, Inc.
+00078C|Elektronikspecialisten i Borlange AB
+00078D|NetEngines Ltd.
+00078E|Garz & Friche GmbH
+00078F|Emkay Innovative Products
+000790|Tri-M Technologies (s) Limited
+000791|International Data Communications, Inc.
+000792|Sutron Electronic GmbH
+000793|Shin Satellite Public Company Limited
+000794|Simple Devices, Inc.
+000795|Elitegroup Computer System Co. (ECS)
+000796|LSI Systems, Inc.
+000797|Netpower Co., Ltd.
+000798|Selea SRL
+000799|Tipping Point Technologies, Inc.
+00079A|Verint Systems Inc
+00079B|Aurora Networks
+00079C|Golden Electronics Technology Co., Ltd.
+00079D|Musashi Co., Ltd.
+00079E|Ilinx Co., Ltd.
+00079F|Action Digital Inc.
+0007A0|e-Watch Inc.
+0007A1|VIASYS Healthcare GmbH
+0007A2|Opteon Corporation
+0007A3|Ositis Software, Inc.
+0007A4|GN Netcom Ltd.
+0007A5|Y.D.K Co. Ltd.
+0007A6|Home Automation, Inc.
+0007A7|A-Z Inc.
+0007A8|Haier Group Technologies Ltd.
+0007A9|Novasonics
+0007AA|Quantum Data Inc.
+0007AB|Samsung
+0007AC|Eolring
+0007AD|Pentacon GmbH Foto-und Feinwerktechnik
+0007AE|Britestream Networks, Inc.
+0007AF|Red Lion Controls, LP
+0007B0|Office Details, Inc.
+0007B1|Equator Technologies
+0007B2|Transaccess S.A.
+0007B3|Cisco
+0007B4|Cisco
+0007B5|Any One Wireless Ltd.
+0007B6|Telecom Technology Ltd.
+0007B7|Samurai Ind. Prods Eletronicos Ltda
+0007B8|Corvalent Corporation
+0007B9|Ginganet Corporation
+0007BA|UTStarcom, Inc.
+0007BB|Candera Inc.
+0007BC|Identix Inc.
+0007BD|Radionet Ltd.
+0007BE|DataLogic SpA
+0007BF|Armillaire Technologies, Inc.
+0007C0|NetZerver Inc.
+0007C1|Overture Networks, Inc.
+0007C2|Netsys Telecom
+0007C3|Thomson
+0007C4|JEAN Co. Ltd.
+0007C5|Gcom, Inc.
+0007C6|VDS Vosskuhler GmbH
+0007C7|Synectics Systems Limited
+0007C8|Brain21, Inc.
+0007C9|Technol Seven Co., Ltd.
+0007CA|Creatix Polymedia Ges Fur Kommunikaitonssysteme
+0007CB|Freebox SA
+0007CC|Kaba Benzing GmbH
+0007CD|Kumoh Electronic Co, Ltd
+0007CE|Cabletime Limited
+0007CF|Anoto AB
+0007D0|Automat Engenharia de Automacao Ltda.
+0007D1|Spectrum Signal Processing Inc.
+0007D2|Logopak Systeme GmbH & Co. KG
+0007D3|SPGPrints B.V.
+0007D4|Zhejiang Yutong Network Communication Co Ltd.
+0007D5|3e Technologies Int;., Inc.
+0007D6|Commil Ltd.
+0007D7|Caporis Networks AG
+0007D8|Hitron Systems Inc.
+0007D9|Splicecom
+0007DA|Neuro Telecom Co., Ltd.
+0007DB|Kirana Networks, Inc.
+0007DC|Atek Co, Ltd.
+0007DD|Cradle Technologies
+0007DE|eCopilt AB
+0007DF|Vbrick Systems Inc.
+0007E0|Palm Inc.
+0007E1|WIS Communications Co. Ltd.
+0007E2|Bitworks, Inc.
+0007E3|Navcom Technology, Inc.
+0007E4|SoftRadio Co., Ltd.
+0007E5|Coup Corporation
+0007E6|edgeflow Canada Inc.
+0007E7|FreeWave Technologies
+0007E8|EdgeWave
+0007E9|Intel Corporate
+0007EA|Massana, Inc.
+0007EB|Cisco
+0007EC|Cisco
+0007ED|Altera Corporation
+0007EE|telco Informationssysteme GmbH
+0007EF|Lockheed Martin Tactical Systems
+0007F0|LogiSync LLC
+0007F1|TeraBurst Networks Inc.
+0007F2|IOA Corporation
+0007F3|Thinkengine Networks
+0007F4|Eletex Co., Ltd.
+0007F5|Bridgeco Co AG
+0007F6|Qqest Software Systems
+0007F7|Galtronics
+0007F8|ITDevices, Inc.
+0007F9|Sensaphone
+0007FA|ITT Co., Ltd.
+0007FB|Giga Stream UMTS Technologies GmbH
+0007FC|Adept Systems Inc.
+0007FD|LANergy Ltd.
+0007FE|Rigaku Corporation
+0007FF|Gluon Networks
+000800|MULTITECH SYSTEMS, INC.
+000801|HighSpeed Surfing Inc.
+000802|Hewlett-Packard Company
+000803|Cos Tron
+000804|ICA Inc.
+000805|Techno-Holon Corporation
+000806|Raonet Systems, Inc.
+000807|Access Devices Limited
+000808|PPT Vision, Inc.
+000809|Systemonic AG
+00080A|Espera-Werke GmbH
+00080B|Birka BPA Informationssystem AB
+00080C|VDA Elettronica spa
+00080D|Toshiba
+00080E|ARRIS Group, Inc.
+00080F|Proximion Fiber Optics AB
+000810|Key Technology, Inc.
+000811|VOIX Corporation
+000812|GM-2 Corporation
+000813|Diskbank, Inc.
+000814|TIL Technologies
+000815|CATS Co., Ltd.
+000816|Bluelon ApS
+000817|EmergeCore Networks LLC
+000818|Pixelworks, Inc.
+000819|Banksys
+00081A|Sanrad Intelligence Storage Communications (2000) Ltd.
+00081B|Windigo Systems
+00081C|@pos.com
+00081D|Ipsil, Incorporated
+00081E|Repeatit AB
+00081F|Pou Yuen Tech Corp. Ltd.
+000820|Cisco
+000821|Cisco
+000822|InPro Comm
+000823|Texa Corp.
+000824|Nuance Document Imaging
+000825|Acme Packet
+000826|Colorado Med Tech
+000827|ADB Broadband Italia
+000828|Koei Engineering Ltd.
+000829|Aval Nagasaki Corporation
+00082A|Powerwallz Network Security
+00082B|Wooksung Electronics, Inc.
+00082C|Homag AG
+00082D|Indus Teqsite Private Limited
+00082E|Multitone Electronics PLC
+00082F|Cisco
+000830|Cisco
+000831|Cisco
+000832|Cisco
+00084E|DivergeNet, Inc.
+00084F|Qualstar Corporation
+000850|Arizona Instrument Corp.
+000851|Canadian Bank Note Company, Ltd.
+000852|Davolink Co. Inc.
+000853|Schleicher GmbH & Co. Relaiswerke KG
+000854|Netronix, Inc.
+000855|NASA-Goddard Space Flight Center
+000856|Gamatronic Electronic Industries Ltd.
+000857|Polaris Networks, Inc.
+000858|Novatechnology Inc.
+000859|ShenZhen Unitone Electronics Co., Ltd.
+00085A|IntiGate Inc.
+00085B|Hanbit Electronics Co., Ltd.
+00085C|Shanghai Dare Technologies Co. Ltd.
+00085D|Aastra
+00085E|PCO AG
+00085F|Picanol N.V.
+000860|LodgeNet Entertainment Corp.
+000861|SoftEnergy Co., Ltd.
+000862|NEC Eluminant Technologies, Inc.
+000863|Entrisphere Inc.
+000864|Fasy S.p.A.
+000865|JASCOM CO., LTD
+000866|DSX Access Systems, Inc.
+000867|Uptime Devices
+000868|PurOptix
+000869|Command-e Technology Co.,Ltd.
+00086A|Securiton Gmbh
+00086B|MIPSYS
+00086C|Plasmon LMS
+00086D|Missouri FreeNet
+00086E|Hyglo AB
+00086F|Resources Computer Network Ltd.
+000870|Rasvia Systems, Inc.
+000871|NORTHDATA Co., Ltd.
+000872|Sorenson Communications
+000873|DapTechnology B.V.
+000874|Dell Computer Corp.
+000875|Acorp Electronics Corp.
+000876|SDSystem
+000877|Liebert-Hiross Spa
+000878|Benchmark Storage Innovations
+000879|CEM Corporation
+00087A|Wipotec GmbH
+00087B|RTX Telecom A/S
+00087C|Cisco
+00087D|Cisco
+00087E|Bon Electro-Telecom Inc.
+00087F|SPAUN electronic GmbH & Co. KG
+000880|BroadTel Canada Communications inc.
+000881|DIGITAL HANDS CO.,LTD.
+000882|SIGMA CORPORATION
+000883|Hewlett-Packard Company
+000884|Index Braille AB
+000885|EMS Dr. Thomas Wunsche
+000886|Hansung Teliann, Inc.
+000887|Maschinenfabrik Reinhausen GmbH
+000888|OULLIM Information Technology Inc,.
+000889|Echostar Technologies Corp
+00088A|Minds@Work
+00088B|Tropic Networks Inc.
+00088C|Quanta Network Systems Inc.
+00088D|Sigma-Links Inc.
+00088E|Nihon Computer Co., Ltd.
+00088F|ADVANCED DIGITAL TECHNOLOGY
+000890|AVILINKS SA
+000891|Lyan Inc.
+000892|EM Solutions
+000893|LE INFORMATION COMMUNICATION INC.
+000894|InnoVISION Multimedia Ltd.
+000895|DIRC Technologie GmbH & Co.KG
+000896|Printronix, Inc.
+000897|Quake Technologies
+000898|Gigabit Optics Corporation
+000899|Netbind, Inc.
+00089A|Alcatel Microelectronics
+00089B|ICP Electronics Inc.
+00089C|Elecs Industry Co., Ltd.
+00089D|UHD-Elektronik
+00089E|Beijing Enter-Net co.LTD
+00089F|EFM Networks
+0008A0|Stotz Feinmesstechnik GmbH
+0008A1|CNet Technology Inc.
+0008A2|ADI Engineering, Inc.
+0008A3|Cisco
+0008A4|Cisco
+0008A5|Peninsula Systems Inc.
+0008A6|Multiware & Image Co., Ltd.
+0008A7|iLogic Inc.
+0008A8|Systec Co., Ltd.
+0008A9|SangSang Technology, Inc.
+0008AA|KARAM
+0008AB|EnerLinx.com, Inc.
+0008AC|Eltromat GmbH
+0008AD|Toyo-Linx Co., Ltd.
+0008AE|PacketFront Network Products AB
+0008AF|Novatec Corporation
+0008B0|BKtel communications GmbH
+0008B1|ProQuent Systems
+0008B2|SHENZHEN COMPASS TECHNOLOGY DEVELOPMENT CO.,LTD
+0008B3|Fastwel
+0008B4|SYSPOL
+0008B5|TAI GUEN ENTERPRISE CO., LTD
+0008B6|RouteFree, Inc.
+0008B7|HIT Incorporated
+0008B8|E.F. Johnson
+0008B9|KAON MEDIA Co., Ltd.
+0008BA|Erskine Systems Ltd
+0008BB|NetExcell
+0008BC|Ilevo AB
+0008BD|TEPG-US
+0008BE|XENPAK MSA Group
+0008BF|Aptus Elektronik AB
+0008C0|ASA SYSTEMS
+0008C1|Avistar Communications Corporation
+0008C2|Cisco
+0008C3|Contex A/S
+0008C4|Hikari Co.,Ltd.
+0008C5|Liontech Co., Ltd.
+0008C6|Philips Consumer Communications
+0008C7|Hewlett-Packard Company
+0008C8|Soneticom, Inc.
+0008C9|TechniSat Digital GmbH
+0008CA|TwinHan Technology Co.,Ltd
+0008CB|Zeta Broadband Inc.
+0008CC|Remotec, Inc.
+0008CD|With-Net Inc
+0008CE|IPMobileNet Inc.
+0008CF|Nippon Koei Power Systems Co., Ltd.
+0008D0|Musashi Engineering Co., LTD.
+0008D1|KAREL INC.
+0008D2|ZOOM Networks Inc.
+0008D3|Hercules Technologies S.A.S.
+0008D4|IneoQuest Technologies, Inc
+0008D5|Vanguard Networks Solutions, LLC
+0008D6|HASSNET Inc.
+0008D7|HOW CORPORATION
+0008D8|Dowkey Microwave
+0008D9|Mitadenshi Co.,LTD
+0008DA|SofaWare Technologies Ltd.
+0008DB|Corrigent Systems
+0008DC|Wiznet
+0008DD|Telena Communications, Inc.
+0008DE|3UP Systems
+0008DF|Alistel Inc.
+0008E0|ATO Technology Ltd.
+0008E1|Barix AG
+0008E2|Cisco
+0008E3|Cisco
+0008E4|Envenergy Inc
+0008E5|IDK Corporation
+0008E6|Littlefeet
+0008E7|SHI ControlSystems,Ltd.
+0008E8|Excel Master Ltd.
+0008E9|NextGig
+0008EA|Motion Control Engineering, Inc
+0008EB|ROMWin Co.,Ltd.
+0008EC|Optical Zonu Corporation
+0008ED|ST&T Instrument Corp.
+0008EE|Logic Product Development
+0008EF|DIBAL,S.A.
+0008F0|Next Generation Systems, Inc.
+0008F1|Voltaire
+0008F2|C&S Technology
+0008F3|WANY
+0008F4|Bluetake Technology Co., Ltd.
+0008F5|YESTECHNOLOGY Co.,Ltd.
+0008F6|Sumitomo Electric System Solutions Co., Ltd.
+0008F7|Hitachi Ltd, Semiconductor & Integrated Circuits Gr
+0008F8|UTC CCS
+0008F9|Artesyn Embedded Technologies
+0008FA|Karl E.Brinkmann GmbH
+0008FB|SonoSite, Inc.
+0008FC|Gigaphoton Inc.
+0008FD|BlueKorea Co., Ltd.
+0008FE|UNIK C&C Co.,Ltd.
+0008FF|Trilogy Communications Ltd
+000900|TMT
+000901|Shenzhen Shixuntong Information & Technoligy Co
+000902|Redline Communications Inc.
+000903|Panasas, Inc
+000904|MONDIAL electronic
+000905|iTEC Technologies Ltd.
+000906|Esteem Networks
+000907|Chrysalis Development
+000908|VTech Technology Corp.
+000909|Telenor Connect A/S
+00090A|SnedFar Technology Co., Ltd.
+00090B|MTL  Instruments PLC
+00090C|Mayekawa Mfg. Co. Ltd.
+00090D|LEADER ELECTRONICS CORP.
+00090E|Helix Technology Inc.
+00090F|Fortinet Inc.
+000910|Simple Access Inc.
+000911|Cisco
+000912|Cisco
+000913|SystemK Corporation
+000914|COMPUTROLS INC.
+000915|CAS Corp.
+000916|Listman Home Technologies, Inc.
+000917|WEM Technology Inc
+000918|Samsung
+000919|MDS Gateways
+00091A|Macat Optics & Electronics Co., Ltd.
+00091B|Digital Generation Inc.
+00091C|CacheVision, Inc
+00091D|Proteam Computer Corporation
+00091E|Firstech Technology Corp.
+00091F|A&D Co., Ltd.
+000920|EpoX COMPUTER CO.,LTD.
+000921|Planmeca Oy
+000922|TST Biometrics GmbH
+000923|Heaman System Co., Ltd
+000924|Telebau GmbH
+000925|VSN Systemen BV
+000926|YODA COMMUNICATIONS, INC.
+000927|TOYOKEIKI CO.,LTD.
+000928|Telecore
+000929|Sanyo Industries (UK) Limited
+00092A|MYTECS Co.,Ltd.
+00092B|iQstor Networks, Inc.
+00092C|Hitpoint Inc.
+00092D|HTC Corporation
+00092E|B&Tech System Inc.
+00092F|Akom Technology Corporation
+000930|AeroConcierge Inc.
+000931|Future Internet, Inc.
+000932|Omnilux
+000933|Ophit Co.Ltd.
+000934|Dream-Multimedia-Tv GmbH
+000935|Sandvine Incorporated
+000936|Ipetronik GmbH & Co. KG
+000937|Inventec Appliance Corp
+000938|Allot Communications
+000939|ShibaSoku Co.,Ltd.
+00093A|Molex Fiber Optics
+00093B|HYUNDAI NETWORKS INC.
+00093C|Jacques Technologies P/L
+00093D|Newisys,Inc.
+00093E|C&I Technologies
+00093F|Double-Win Enterpirse CO., LTD
+000940|AGFEO GmbH & Co. KG
+000941|Allied Telesis K.K.
+000942|Wireless Technologies, Inc
+000943|Cisco
+000944|Cisco
+000945|Palmmicro Communications Inc
+000946|Cluster Labs GmbH
+000947|Aztek, Inc.
+000948|Vista Control Systems, Corp.
+000949|Glyph Technologies Inc.
+00094A|Homenet Communications
+00094B|FillFactory NV
+00094C|Communication Weaver Co.,Ltd.
+00094D|Braintree Communications Pty Ltd
+00094E|BARTECH SYSTEMS INTERNATIONAL, INC
+00094F|elmegt GmbH & Co. KG
+000950|Independent Storage Corporation
+000951|Apogee Imaging Systems
+000952|Auerswald GmbH & Co. KG
+000953|Linkage System Integration Co.Ltd.
+000954|AMiT spol. s. r. o.
+000955|Young Generation International Corp.
+000956|Network Systems Group, Ltd. (NSG)
+000957|Supercaller, Inc.
+000958|INTELNET S.A.
+000959|Sitecsoft
+00095A|RACEWOOD TECHNOLOGY
+00095B|Netgear
+00095C|Philips Medical Systems - Cardiac and Monitoring Systems (CM
+00095D|Dialogue Technology Corp.
+00095E|Masstech Group Inc.
+00095F|Telebyte, Inc.
+000960|YOZAN Inc.
+000961|Switchgear and Instrumentation Ltd
+000962|Sonitor Technologies AS
+000963|Dominion Lasercom Inc.
+000964|Hi-Techniques, Inc.
+000965|HyunJu Computer Co., Ltd.
+000966|Thales Navigation
+000967|Tachyon, Inc
+000968|TECHNOVENTURE, INC.
+000969|Meret Optical Communications
+00096A|Cloverleaf Communications Inc.
+00096B|IBM Corp
+00096C|Imedia Semiconductor Corp.
+00096D|Powernet Technologies Corp.
+00096E|GIANT ELECTRONICS LTD.
+00096F|Beijing Zhongqing Elegant Tech. Corp.,Limited
+000970|Vibration Research Corporation
+000971|Time Management, Inc.
+000972|Securebase,Inc
+000973|Lenten Technology Co., Ltd.
+000974|Innopia Technologies, Inc.
+000975|fSONA Communications Corporation
+000976|Datasoft ISDN Systems GmbH
+000977|Brunner Elektronik AG
+000978|AIJI System Co., Ltd.
+000979|Advanced Television Systems Committee, Inc.
+00097A|Louis Design Labs.
+00097B|Cisco
+00097C|Cisco
+00097D|SecWell Networks Oy
+00097E|IMI TECHNOLOGY CO., LTD
+00097F|Vsecure 2000 LTD.
+000980|Power Zenith Inc.
+000981|Newport Networks
+000982|Loewe Opta GmbH
+000983|GlobalTop Technology, Inc.
+000984|MyCasa Network Inc.
+000985|Auto Telecom Company
+000986|Metalink LTD.
+000987|NISHI NIPPON ELECTRIC WIRE & CABLE CO.,LTD.
+000988|Nudian Electron Co., Ltd.
+000989|VividLogic Inc.
+00098A|EqualLogic Inc
+00098B|Entropic Communications, Inc.
+00098C|Option Wireless Sweden
+00098D|Velocity Semiconductor
+00098E|ipcas GmbH
+00098F|Cetacean Networks
+000990|ACKSYS Communications & systems
+000991|GE Fanuc Automation Manufacturing, Inc.
+000992|InterEpoch Technology,INC.
+000993|Visteon Corporation
+000994|Cronyx Engineering
+000995|Castle Technology Ltd
+000996|RDI
+000997|Nortel Networks
+000998|Capinfo Company Limited
+000999|CP GEORGES RENAULT
+00099A|ELMO COMPANY, LIMITED
+00099B|Western Telematic Inc.
+00099C|Naval Research Laboratory
+00099D|Haliplex Communications
+00099E|Testech, Inc.
+00099F|VIDEX INC.
+0009A0|Microtechno Corporation
+0009A1|Telewise Communications, Inc.
+0009A2|Interface Co., Ltd.
+0009A3|Leadfly Techologies Corp. Ltd.
+0009A4|HARTEC Corporation
+0009A5|HANSUNG ELETRONIC INDUSTRIES DEVELOPMENT CO., LTD
+0009A6|Ignis Optics, Inc.
+0009A7|Bang & Olufsen A/S
+0009A8|Eastmode Pte Ltd
+0009A9|Ikanos Communications
+0009AA|Data Comm for Business, Inc.
+0009AB|Netcontrol Oy
+0009AC|LANVOICE
+0009AD|HYUNDAI SYSCOMM, INC.
+0009AE|OKANO ELECTRIC CO.,LTD
+0009AF|e-generis
+0009B0|Onkyo Corporation
+0009B1|Kanematsu Electronics, Ltd.
+0009B2|L&F Inc.
+0009B3|MCM Systems Ltd
+0009B4|KISAN TELECOM CO., LTD.
+0009B5|3J Tech. Co., Ltd.
+0009B6|Cisco
+0009B7|Cisco
+0009B8|Entise Systems
+0009B9|Action Imaging Solutions
+0009BA|MAKU Informationstechik GmbH
+0009BB|MathStar, Inc.
+0009BC|Digital Safety Technologies, Inc
+0009BD|Epygi Technologies, Ltd.
+0009BE|Mamiya-OP Co.,Ltd.
+0009BF|Nintendo Co., Ltd.
+0009C0|6WIND
+0009C1|PROCES-DATA A/S
+0009C2|Onity, Inc.
+0009C3|NETAS
+0009C4|Medicore Co., Ltd
+0009C5|KINGENE Technology Corporation
+0009C6|Visionics Corporation
+0009C7|Movistec
+0009C8|SINAGAWA TSUSHIN KEISOU SERVICE
+0009C9|BlueWINC Co., Ltd.
+0009CA|iMaxNetworks(Shenzhen)Limited.
+0009CB|HBrain
+0009CC|Moog GmbH
+0009CD|HUDSON SOFT CO.,LTD.
+0009CE|SpaceBridge Semiconductor Corp.
+0009CF|iAd GmbH
+0009D0|Solacom Technologies Inc.
+0009D1|SERANOA NETWORKS INC
+0009D2|Mai Logic Inc.
+0009D3|Western DataCom Co., Inc.
+0009D4|Transtech Networks
+0009D5|Signal Communication, Inc.
+0009D6|KNC One GmbH
+0009D7|DC Security Products
+0009D8|Falt Communications AB
+0009D9|Neoscale Systems, Inc
+0009DA|Control Module Inc.
+0009DB|eSpace
+0009DC|Galaxis Technology AG
+0009DD|Mavin Technology Inc.
+0009DE|Samjin Information & Communications Co., Ltd.
+0009DF|Vestel Komunikasyon Sanayi ve Ticaret A.S.
+0009E0|XEMICS S.A.
+0009E1|Gemtek Technology Co., Ltd.
+0009E2|Sinbon Electronics Co., Ltd.
+0009E3|Angel Iglesias S.A.
+0009E4|K Tech Infosystem Inc.
+0009E5|Hottinger Baldwin Messtechnik GmbH
+0009E6|Cyber Switching Inc.
+0009E7|ADC Techonology
+0009E8|Cisco
+0009E9|Cisco
+0009EA|YEM Inc.
+0009EB|HuMANDATA LTD.
+0009EC|Daktronics, Inc.
+0009ED|CipherOptics
+0009EE|MEIKYO ELECTRIC CO.,LTD
+0009EF|Vocera Communications
+0009F0|Shimizu Technology Inc.
+0009F1|Yamaki Electric Corporation
+0009F2|Cohu, Inc., Electronics Division
+0009F3|WELL Communication Corp.
+0009F4|Alcon Laboratories, Inc.
+0009F5|Emerson Network Power Co.,Ltd
+0009F6|Shenzhen Eastern Digital Tech Ltd.
+0009F7|SED, a division of Calian
+0009F8|UNIMO TECHNOLOGY CO., LTD.
+0009F9|ART JAPAN CO., LTD.
+0009FB|Philips Patient Monitoring
+0009FC|IPFLEX Inc.
+0009FD|Ubinetics Limited
+0009FE|Daisy Technologies, Inc.
+0009FF|X.net 2000 GmbH
+000A00|Mediatek Corp.
+000A01|SOHOware, Inc.
+000A02|ANNSO CO., LTD.
+000A03|ENDESA SERVICIOS, S.L.
+000A04|3Com Ltd
+000A05|Widax Corp.
+000A06|Teledex LLC
+000A07|WebWayOne Ltd
+000A08|ALPINE ELECTRONICS, INC.
+000A09|TaraCom Integrated Products, Inc.
+000A0A|SUNIX Co., Ltd.
+000A0B|Sealevel Systems, Inc.
+000A0C|Scientific Research Corporation
+000A0D|FCI Deutschland GmbH
+000A0E|Invivo Research Inc.
+000A0F|Ilryung Telesys, Inc
+000A10|FAST media integrations AG
+000A11|ExPet Technologies, Inc
+000A12|Azylex Technology, Inc
+000A13|Honeywell Video Systems
+000A14|TECO a.s.
+000A15|Silicon Data, Inc
+000A16|Lassen Research
+000A17|NESTAR COMMUNICATIONS, INC
+000A18|Vichel Inc.
+000A19|Valere Power, Inc.
+000A1A|Imerge Ltd
+000A1B|Stream Labs
+000A1C|Bridge Information Co., Ltd.
+000A1D|Optical Communications Products Inc.
+000A1E|Red-M Products Limited
+000A1F|ART WARE Telecommunication Co., Ltd.
+000A20|SVA Networks, Inc.
+000A21|Integra Telecom Co. Ltd
+000A22|Amperion Inc
+000A23|Parama Networks Inc
+000A24|Octave Communications
+000A25|CERAGON NETWORKS
+000A26|CEIA S.p.A.
+000A27|Apple
+000A28|Motorola
+000A29|Pan Dacom Networking AG
+000A2A|QSI Systems Inc.
+000A2B|Etherstuff
+000A2C|Active Tchnology Corporation
+000A2D|Cabot Communications Limited
+000A2E|MAPLE NETWORKS CO., LTD
+000A2F|Artnix Inc.
+000A30|Visteon Corporation
+000A31|HCV Consulting
+000A32|Xsido Corporation
+000A33|Emulex Corporation
+000A34|Identicard Systems Incorporated
+000A35|Xilinx
+000A36|Synelec Telecom Multimedia
+000A37|Procera Networks, Inc.
+000A38|Apani Networks
+000A39|LoPA Information Technology
+000A3A|J-THREE INTERNATIONAL Holding Co., Ltd.
+000A3B|GCT Semiconductor, Inc
+000A3C|Enerpoint Ltd.
+000A3D|Elo Sistemas Eletronicos S.A.
+000A3E|EADS Telecom
+000A3F|Data East Corporation
+000A40|Crown Audio -- Harmanm International
+000A41|Cisco
+000A42|Cisco
+000A43|Chunghwa Telecom Co., Ltd.
+000A44|Avery Dennison Deutschland GmbH
+000A45|Audio-Technica Corp.
+000A46|ARO WELDING TECHNOLOGIES SAS
+000A47|Allied Vision Technologies
+000A48|Albatron Technology
+000A49|F5 Networks, Inc.
+000A4A|Targa Systems Ltd.
+000A4B|DataPower Technology, Inc.
+000A4C|Molecular Devices Corporation
+000A4D|Noritz Corporation
+000A4E|UNITEK Electronics INC.
+000A4F|Brain Boxes Limited
+000A50|REMOTEK CORPORATION
+000A51|GyroSignal Technology Co., Ltd.
+000A52|AsiaRF Ltd.
+000A53|Intronics, Incorporated
+000A54|Laguna Hills, Inc.
+000A55|MARKEM Corporation
+000A56|HITACHI Maxell Ltd.
+000A57|Hewlett-Packard Company - Standards
+000A58|Freyer & Siegel Elektronik GmbH & Co. KG
+000A59|HW server
+000A5A|GreenNET Technologies Co.,Ltd.
+000A5B|Power-One as
+000A5C|Carel s.p.a.
+000A5D|FingerTec Worldwide Sdn Bhd
+000A5E|3COM Corporation
+000A5F|almedio inc.
+000A60|Autostar Technology Pte Ltd
+000A61|Cellinx Systems Inc.
+000A62|Crinis Networks, Inc.
+000A63|DHD GmbH
+000A64|Eracom Technologies
+000A65|GentechMedia.co.,ltd.
+000A66|MITSUBISHI ELECTRIC SYSTEM & SERVICE CO.,LTD.
+000A67|OngCorp
+000A68|SolarFlare Communications, Inc.
+000A69|SUNNY bell Technology Co., Ltd.
+000A6A|SVM Microwaves s.r.o.
+000A6B|Tadiran Telecom Business Systems LTD
+000A6C|Walchem Corporation
+000A6D|EKS Elektronikservice GmbH
+000A6E|Harmonic, Inc
+000A6F|ZyFLEX Technologies Inc
+000A70|MPLS Forum
+000A71|Avrio Technologies, Inc
+000A72|STEC, INC.
+000A73|Scientific Atlanta
+000A74|Manticom Networks Inc.
+000A75|Caterpillar, Inc
+000A76|Beida Jade Bird Huaguang Technology Co.,Ltd
+000A77|Bluewire Technologies LLC
+000A78|OLITEC
+000A79|corega K.K
+000A7A|Kyoritsu Electric Co., Ltd.
+000A7B|Cornelius Consult
+000A7C|Tecton Ltd
+000A7D|Valo, Inc.
+000A7E|The Advantage Group
+000A7F|Teradon Industries, Inc
+000A80|Telkonet Inc.
+000A81|TEIMA Audiotex S.L.
+000A82|TATSUTA SYSTEM ELECTRONICS CO.,LTD.
+000A83|SALTO SYSTEMS S.L.
+000A84|Rainsun Enterprise Co., Ltd.
+000A85|PLAT'C2,Inc
+000A86|Lenze
+000A87|Integrated Micromachines Inc.
+000A88|InCypher S.A.
+000A89|Creval Systems, Inc.
+000A8A|Cisco
+000A8B|Cisco
+000A8C|Guardware Systems Ltd.
+000A8D|EUROTHERM LIMITED
+000A8E|Invacom Ltd
+000A8F|Aska International Inc.
+000A90|Bayside Interactive, Inc.
+000A91|HemoCue AB
+000A92|Presonus Corporation
+000A93|W2 Networks, Inc.
+000A94|ShangHai cellink CO., LTD
+000A95|Apple
+000A96|MEWTEL TECHNOLOGY INC.
+000A97|SONICblue, Inc.
+000A98|M+F Gwinner GmbH & Co
+000A99|Calamp Wireless Networks Inc
+000A9A|Aiptek International Inc
+000A9B|TB Group Inc
+000A9C|Server Technology, Inc.
+000A9D|King Young Technology Co. Ltd.
+000A9E|BroadWeb Corportation
+000A9F|Pannaway Technologies, Inc.
+000AA0|Cedar Point Communications
+000AA1|V V S Limited
+000AA2|SYSTEK INC.
+000AA3|SHIMAFUJI ELECTRIC CO.,LTD.
+000AA4|SHANGHAI SURVEILLANCE TECHNOLOGY CO,LTD
+000AA5|MAXLINK INDUSTRIES LIMITED
+000AA6|Hochiki Corporation
+000AA7|FEI Electron Optics
+000AA8|ePipe Pty. Ltd.
+000AA9|Brooks Automation GmbH
+000AAA|AltiGen Communications Inc.
+000AAB|Toyota Technical Development Corporation
+000AAC|TerraTec Electronic GmbH
+000AAD|Stargames Corporation
+000AAE|Rosemount Process Analytical
+000AAF|Pipal Systems
+000AB0|LOYTEC electronics GmbH
+000AB1|GENETEC Corporation
+000AB2|Fresnel Wireless Systems
+000AB3|Fa. GIRA
+000AB4|ETIC Telecommunications
+000AB5|Digital Electronic Network
+000AB6|COMPUNETIX, INC
+000AB7|Cisco
+000AB8|Cisco
+000AB9|Astera Technologies Corp.
+000ABA|Arcon Technology Limited
+000ABB|Taiwan Secom Co,. Ltd
+000ABC|Seabridge Ltd.
+000ABD|Rupprecht & Patashnick Co.
+000ABE|OPNET Technologies CO., LTD.
+000ABF|HIROTA SS
+000AC0|Fuyoh Video Industry CO., LTD.
+000AC1|Futuretel
+000AC2|FiberHome Telecommunication Technologies CO.,LTD
+000AC3|eM Technics Co., Ltd.
+000AC4|Daewoo Teletech Co., Ltd
+000AC5|Color Kinetics
+000AC6|Overture Networks.
+000AC7|Unication Group
+000AC8|ZPSYS CO.,LTD. (Planning&Management)
+000AC9|Zambeel Inc
+000ACA|YOKOYAMA SHOKAI CO.,Ltd.
+000ACB|XPAK MSA Group
+000ACC|Winnow Networks, Inc.
+000ACD|Sunrich Technology Limited
+000ACE|RADIANTECH, INC.
+000ACF|PROVIDEO Multimedia Co. Ltd.
+000AD0|Niigata Develoment Center,  F.I.T. Co., Ltd.
+000AD1|MWS
+000AD2|JEPICO Corporation
+000AD3|INITECH Co., Ltd
+000AD4|CoreBell Systems Inc.
+000AD5|Brainchild Electronic Co., Ltd.
+000AD6|BeamReach Networks
+000AD7|Origin ELECTRIC CO.,LTD.
+000AD8|IPCserv Technology Corp.
+000AD9|Sony Ericsson Mobile Communications AB
+000ADA|Vindicator Technologies
+000ADB|SkyPilot Network, Inc
+000ADC|RuggedCom Inc.
+000ADD|Allworx Corp.
+000ADE|Happy Communication Co., Ltd.
+000ADF|Gennum Corporation
+000AE0|Fujitsu Softek
+000AE1|EG Technology
+000AE2|Binatone Electronics International, Ltd
+000AE3|YANG MEI TECHNOLOGY CO., LTD
+000AE4|Wistron Corp.
+000AE5|ScottCare Corporation
+000AE6|Elitegroup Computer System Co. (ECS)
+000AE7|ELIOP S.A.
+000AE8|Cathay Roxus Information Technology Co. LTD
+000AE9|AirVast Technology Inc.
+000AEA|ADAM ELEKTRONIK LTD. STI
+000AEB|Shenzhen Tp-Link Technology Co; Ltd.
+000AEC|Koatsu Gas Kogyo Co., Ltd.
+000AED|HARTING Systems GmbH & Co KG
+000AEE|GCD Hard- & Software GmbH
+000AEF|OTRUM ASA
+000AF0|SHIN-OH ELECTRONICS CO., LTD. R&D
+000AF1|Clarity Design, Inc.
+000AF2|NeoAxiom Corp.
+000AF3|Cisco
+000AF4|Cisco
+000AF5|Airgo Networks, Inc.
+000AF6|Emerson Climate Technologies Retail Solutions, Inc.
+000AF7|Broadcom Corp.
+000AF8|American Telecare Inc.
+000AF9|HiConnect, Inc.
+000AFA|Traverse Technologies Australia
+000AFB|Ambri Limited
+000AFC|Core Tec Communications, LLC
+000AFD|Kentec Electronics
+000AFE|NovaPal Ltd
+000AFF|Kilchherr Elektronik AG
+000B00|FUJIAN START COMPUTER EQUIPMENT CO.,LTD
+000B01|DAIICHI ELECTRONICS CO., LTD.
+000B02|Dallmeier electronic
+000B03|Taekwang Industrial Co., Ltd
+000B04|Volktek Corporation
+000B05|Pacific Broadband Networks
+000B06|ARRIS Group, Inc.
+000B07|Voxpath Networks
+000B08|Pillar Data Systems
+000B09|Ifoundry Systems Singapore
+000B0A|dBm Optics
+000B0B|Corrent Corporation
+000B0C|Agile Systems Inc.
+000B0D|Air2U, Inc.
+000B0E|Trapeze Networks
+000B0F|Bosch Rexroth
+000B10|11wave Technonlogy Co.,Ltd
+000B11|HIMEJI ABC TRADING CO.,LTD.
+000B12|NURI Telecom Co., Ltd.
+000B13|ZETRON INC
+000B14|ViewSonic Corporation
+000B15|Platypus Technology
+000B16|Communication Machinery Corporation
+000B17|MKS Instruments
+000B18|ASSIGNED - PRIVATE REGISTRATION 
+000B19|Vernier Networks, Inc.
+000B1A|Industrial Defender, Inc.
+000B1B|Systronix, Inc.
+000B1C|SIBCO bv
+000B1D|LayerZero Power Systems, Inc.
+000B1E|KAPPA opto-electronics GmbH
+000B1F|I CON Computer Co.
+000B20|Hirata corporation
+000B21|G-Star Communications Inc.
+000B22|Environmental Systems and Services
+000B23|Siemens Subscriber Networks
+000B24|AirLogic
+000B25|Aeluros
+000B26|Wetek Corporation
+000B27|Scion Corporation
+000B28|Quatech Inc.
+000B29|LS(LG) Industrial Systems co., Ltd
+000B2A|HOWTEL Co., Ltd.
+000B2B|HOSTNET CORPORATION
+000B2C|Eiki Industrial Co. Ltd.
+000B2D|Danfoss Inc.
+000B2E|Cal-Comp Electronics (Thailand) Public Company Limited Taipe
+000B2F|bplan GmbH
+000B30|Beijing Gongye Science & Technology Co.,Ltd
+000B31|Yantai ZhiYang Scientific and technology industry CO., LTD
+000B32|VORMETRIC, INC.
+000B33|Vivato Technologies
+000B34|ShangHai Broadband Technologies CO.LTD
+000B35|Quad Bit System co., Ltd.
+000B36|Productivity Systems, Inc.
+000B37|MANUFACTURE DES MONTRES ROLEX SA
+000B38|Knurr GmbH
+000B39|Keisoku Giken Co.,Ltd.
+000B3A|QuStream Corporation
+000B3B|devolo AG
+000B3C|Cygnal Integrated Products, Inc.
+000B3D|CONTAL OK Ltd.
+000B3E|BittWare, Inc
+000B3F|Anthology Solutions Inc.
+000B40|Oclaro
+000B41|Ing. Buro Dr. Beutlhauser
+000B42|commax Co., Ltd.
+000B43|Microscan Systems, Inc.
+000B44|Concord IDea Corp.
+000B45|Cisco
+000B46|Cisco
+000B47|Advanced Energy
+000B48|sofrel
+000B49|RF-Link System Inc.
+000B4A|Visimetrics (UK) Ltd
+000B4B|VISIOWAVE SA
+000B4C|Clarion (M) Sdn Bhd
+000B4D|Emuzed
+000B4E|VertexRSI, General Dynamics SatCOM Technologies, Inc.
+000B4F|Verifone, INC.
+000B50|Oxygnet
+000B51|Micetek International Inc.
+000B52|JOYMAX ELECTRONICS CO. LTD.
+000B53|INITIUM Co., Ltd.
+000B54|BiTMICRO Networks, Inc.
+000B55|ADInstruments
+000B56|Cybernetics
+000B57|Silicon Laboratories
+000B58|Astronautics C.A  LTD
+000B59|ScriptPro, LLC
+000B5A|HyperEdge
+000B5B|Rincon Research Corporation
+000B5C|Newtech Co.,Ltd
+000B5D|FUJITSU LIMITED
+000B5E|Audio Engineering Society Inc.
+000B5F|Cisco
+000B60|Cisco
+000B61|Friedrich Lutze GmbH & Co. KG
+000B62|ib-mohnen KG
+000B63|Kaleidescape
+000B64|Kieback & Peter GmbH & Co KG
+000B65|Sy.A.C. srl
+000B66|Teralink Communications
+000B67|Topview Technology Corporation
+000B68|Addvalue Communications Pte Ltd
+000B69|Franke Finland Oy
+000B6A|Asiarock Incorporation
+000B6B|Wistron Neweb Corp.
+000B6C|Sychip Inc.
+000B6D|SOLECTRON JAPAN NAKANIIDA
+000B6E|Neff Instrument Corp.
+000B6F|Media Streaming Networks Inc
+000B70|Load Technology, Inc.
+000B71|Litchfield Communications Inc.
+000B72|Lawo AG
+000B73|Kodeos Communications
+000B74|Kingwave Technology Co., Ltd.
+000B75|Iosoft Ltd.
+000B76|ET&T Technology Co. Ltd.
+000B77|Cogent Systems, Inc.
+000B78|TAIFATECH INC.
+000B79|X-COM, Inc.
+000B7A|L-3 Linkabit
+000B7B|Test-Um Inc.
+000B7C|Telex Communications
+000B7D|SOLOMON EXTREME INTERNATIONAL LTD.
+000B7E|SAGINOMIYA Seisakusho Inc.
+000B7F|Align Engineering LLC
+000B80|Lycium Networks
+000B81|Kaparel Corporation
+000B82|Grandstream Networks, Inc.
+000B83|DATAWATT B.V.
+000B84|BODET
+000B85|Cisco
+000B86|Aruba Networks
+000B87|American Reliance Inc.
+000B88|Vidisco ltd.
+000B89|Top Global Technology, Ltd.
+000B8A|MITEQ Inc.
+000B8B|KERAJET, S.A.
+000B8C|Flextronics
+000B8D|Avvio Networks
+000B8E|Ascent Corporation
+000B8F|AKITA ELECTRONICS SYSTEMS CO.,LTD.
+000B90|ADVA Optical Networking Ltd.
+000B91|Aglaia Gesellschaft fur Bildverarbeitung und Kommunikation mbH
+000B92|Ascom Danmark A/S
+000B93|Ritter Elektronik
+000B94|Digital Monitoring Products, Inc.
+000B95|eBet Gaming Systems Pty Ltd
+000B96|Innotrac Diagnostics Oy
+000B97|Matsushita Electric Industrial Co.,Ltd.
+000B98|NiceTechVision
+000B99|SensAble Technologies, Inc.
+000B9A|Shanghai Ulink Telecom Equipment Co. Ltd.
+000B9B|Sirius System Co, Ltd.
+000B9C|TriBeam Technologies, Inc.
+000B9D|TwinMOS Technologies Inc.
+000B9E|Yasing Technology Corp.
+000B9F|Neue ELSA GmbH
+000BA0|T&L Information Inc.
+000BA1|SYSCOM Ltd.
+000BA2|Sumitomo Electric Networks, Inc
+000BA3|Siemens AG, I&S
+000BA4|Shiron Satellite Communications Ltd. (1996)
+000BA5|Quasar Cipta Mandiri, PT
+000BA6|Miyakawa Electric Works Ltd.
+000BA7|Maranti Networks
+000BA8|HANBACK ELECTRONICS CO., LTD.
+000BA9|CloudShield Technologies, Inc.
+000BAA|Aiphone co., Ltd
+000BAB|Advantech Technology (CHINA) Co., Ltd.
+000BAC|3Com Ltd
+000BAD|PC-PoS Inc.
+000BAE|Vitals System Inc.
+000BAF|WOOJU COMMUNICATIONS Co,.Ltd
+000BB0|Sysnet Telematica srl
+000BB1|Super Star Technology Co., Ltd.
+000BB2|SMALLBIG TECHNOLOGY
+000BB3|RiT technologies Ltd.
+000BB4|RDC Semiconductor Inc.,
+000BB5|nStor Technologies, Inc.
+000BB6|Metalligence Technology Corp.
+000BB7|Micro Systems Co.,Ltd.
+000BB8|Kihoku Electronic Co.
+000BB9|Imsys AB
+000BBA|Harmonic, Inc
+000BBB|Etin Systems Co., Ltd
+000BBC|En Garde Systems, Inc.
+000BBD|Connexionz Limited
+000BBE|Cisco
+000BBF|Cisco
+000BC0|China IWNComm Co., Ltd.
+000BC1|Bay Microsystems, Inc.
+000BC2|Corinex Communication Corp.
+000BC3|Multiplex, Inc.
+000BC4|BIOTRONIK GmbH & Co
+000BC5|SMC Networks, Inc.
+000BC6|ISAC, Inc.
+000BC7|ICET S.p.A.
+000BC8|AirFlow Networks
+000BC9|Electroline Equipment
+000BCA|DATAVAN International Corporation
+000BCB|Fagor Automation , S. Coop
+000BCC|JUSAN, S.A.
+000BCD|Hewlett-Packard Company
+000BCE|Free2move AB
+000BCF|AGFA NDT INC.
+000BD0|XiMeta Technology Americas Inc.
+000BD1|Aeronix, Inc.
+000BD2|Remopro Technology Inc.
+000BD3|cd3o
+000BD4|Beijing Wise Technology & Science Development Co.Ltd
+000BD5|Nvergence, Inc.
+000BD6|Paxton Access Ltd
+000BD7|DORMA Time + Access GmbH
+000BD8|Industrial Scientific Corp.
+000BD9|General Hydrogen
+000BDA|EyeCross Co.,Inc.
+000BDB|Dell Inc
+000BDC|AKCP
+000BDD|TOHOKU RICOH Co., LTD.
+000BDE|TELDIX GmbH
+000BDF|Shenzhen RouterD Networks Limited
+000BE0|SercoNet Ltd.
+000BE1|Nokia NET Product Operations
+000BE2|Lumenera Corporation
+000BE3|Key Stream Co., Ltd.
+000BE4|Hosiden Corporation
+000BE5|HIMS International Corporation
+000BE6|Datel Electronics
+000BE7|COMFLUX TECHNOLOGY INC.
+000BE8|AOIP
+000BE9|Actel Corporation
+000BEA|Zultys Technologies
+000BEB|Systegra AG
+000BEC|NIPPON ELECTRIC INSTRUMENT, INC.
+000BED|ELM Inc.
+000BEE|inc.jet, Incorporated
+000BEF|Code Corporation
+000BF0|MoTEX Products Co., Ltd.
+000BF1|LAP Laser Applikations
+000BF2|Chih-Kan Technology Co., Ltd.
+000BF3|BAE SYSTEMS
+000BF4|ASSIGNED - PRIVATE REGISTRATION 
+000BF5|Shanghai Sibo Telecom Technology Co.,Ltd
+000BF6|Nitgen Co., Ltd
+000BF7|NIDEK CO.,LTD
+000BF8|Infinera
+000BF9|Gemstone communications, Inc.
+000BFA|EXEMYS SRL
+000BFB|D-NET International Corporation
+000BFC|Cisco
+000BFD|Cisco
+000BFE|CASTEL Broadband Limited
+000BFF|Berkeley Camera Engineering
+000C00|BEB Industrie-Elektronik AG
+000C01|Abatron AG
+000C02|ABB Oy
+000C03|HDMI Licensing, LLC
+000C04|Tecnova
+000C05|RPA Reserch Co., Ltd.
+000C06|Nixvue Systems  Pte Ltd
+000C07|Iftest AG
+000C08|HUMEX Technologies Corp.
+000C09|Hitachi IE Systems Co., Ltd
+000C0A|Guangdong Province Electronic Technology Research Institute
+000C0B|Broadbus Technologies
+000C0C|APPRO TECHNOLOGY INC.
+000C0D|Communications & Power Industries / Satcom Division
+000C0E|XtremeSpectrum, Inc.
+000C0F|Techno-One Co., Ltd
+000C10|PNI Corporation
+000C11|NIPPON DEMPA CO.,LTD.
+000C12|Micro-Optronic-Messtechnik GmbH
+000C13|MediaQ
+000C14|Diagnostic Instruments, Inc.
+000C15|CyberPower Systems, Inc.
+000C16|Concorde Microsystems Inc.
+000C17|AJA Video Systems Inc
+000C18|Zenisu Keisoku Inc.
+000C19|Telio Communications GmbH
+000C1A|Quest Technical Solutions Inc.
+000C1B|ORACOM Co, Ltd.
+000C1C|MicroWeb Co., Ltd.
+000C1D|Mettler & Fuchs AG
+000C1E|Global Cache
+000C1F|Glimmerglass Networks
+000C20|Fi WIn, Inc.
+000C21|Faculty of Science and Technology, Keio University
+000C22|Double D Electronics Ltd
+000C23|Beijing Lanchuan Tech. Co., Ltd.
+000C24|ANATOR
+000C25|Allied Telesis Labs, Inc.
+000C26|Weintek Labs. Inc.
+000C27|Sammy Corporation
+000C28|RIFATRON
+000C29|VMware, Inc.
+000C2A|OCTTEL Communication Co., Ltd.
+000C2B|ELIAS Technology, Inc.
+000C2C|Enwiser Inc.
+000C2D|FullWave Technology Co., Ltd.
+000C2E|Openet information technology(shenzhen) Co., Ltd.
+000C2F|SeorimTechnology Co.,Ltd.
+000C30|Cisco
+000C31|Cisco
+000C32|Avionic Design Development GmbH
+000C33|Compucase Enterprise Co. Ltd.
+000C34|Vixen Co., Ltd.
+000C35|KaVo Dental GmbH & Co. KG
+000C36|SHARP TAKAYA ELECTRONICS INDUSTRY CO.,LTD.
+000C37|Geomation, Inc.
+000C38|TelcoBridges Inc.
+000C39|Sentinel Wireless Inc.
+000C3A|Oxance
+000C3B|Orion Electric Co., Ltd.
+000C3C|MediaChorus, Inc.
+000C3D|Glsystech Co., Ltd.
+000C3E|Crest Audio
+000C3F|Cogent Defence & Security Networks,
+000C40|Altech Controls
+000C41|Cisco
+000C42|Routerboard.com
+000C43|Ralink Technology, Corp.
+000C44|Automated Interfaces, Inc.
+000C45|Animation Technologies Inc.
+000C46|Allied Telesyn Inc.
+000C47|SK Teletech(R&D Planning Team)
+000C48|QoStek Corporation
+000C49|Dangaard Telecom RTC Division A/S
+000C4A|Cygnus Microsystems (P) Limited
+000C4B|Cheops Elektronik
+000C4C|Arcor AG&Co.
+000C4D|Curtiss-Wright Controls Avionics & Electronics
+000C4E|Winbest Technology CO,LT
+000C4F|UDTech Japan Corporation
+000C50|Seagate Technology
+000C51|Scientific Technologies Inc.
+000C52|Roll Systems Inc.
+000C53|ASSIGNED - PRIVATE REGISTRATION 
+000C54|Pedestal Networks, Inc
+000C55|Microlink Communications Inc.
+000C56|Megatel Computer (1986) Corp.
+000C57|MACKIE Engineering Services Belgium BVBA
+000C58|M&S Systems
+000C59|Indyme Electronics, Inc.
+000C5A|IBSmm Embedded Electronics Consulting
+000C5B|HANWANG TECHNOLOGY CO.,LTD
+000C5C|GTN Systems B.V.
+000C5D|CHIC TECHNOLOGY (CHINA) CORP.
+000C5E|Calypso Medical
+000C5F|Avtec, Inc.
+000C60|ACM Systems
+000C61|AC Tech corporation DBA Advanced Digital
+000C62|ABB AB, Cewe-Control
+000C63|Zenith Electronics Corporation
+000C64|X2 MSA Group
+000C65|Sunin Telecom
+000C66|Pronto Networks Inc
+000C67|OYO ELECTRIC CO.,LTD
+000C68|SigmaTel, Inc.
+000C69|National Radio Astronomy Observatory
+000C6A|MBARI
+000C6B|Kurz Industrie-Elektronik GmbH
+000C6C|Elgato Systems LLC
+000C6D|Edwards Ltd.
+000C6E|ASUSTEK COMPUTER INC.
+000C6F|Amtek system co., LTD.
+000C70|ACC GmbH
+000C71|Wybron, Inc
+000C72|Tempearl Industrial Co., Ltd.
+000C73|TELSON ELECTRONICS CO., LTD
+000C74|RIVERTEC CORPORATION
+000C75|Oriental integrated electronics. LTD
+000C76|MICRO-STAR INTERNATIONAL CO., LTD.
+000C77|Life Racing Ltd
+000C78|In-Tech Electronics Limited
+000C79|Extel Communications P/L
+000C7A|DaTARIUS Technologies GmbH
+000C7B|ALPHA PROJECT Co.,Ltd.
+000C7C|Internet Information Image Inc.
+000C7D|TEIKOKU ELECTRIC MFG. CO., LTD
+000C7E|Tellium Incorporated
+000C7F|synertronixx GmbH
+000C80|Opelcomm Inc.
+000C81|Schneider Electric (Australia)
+000C82|NETWORK TECHNOLOGIES INC
+000C83|Logical Solutions
+000C84|Eazix, Inc.
+000C85|Cisco
+000C86|Cisco
+000C87|AMD
+000C88|Apache Micro Peripherals, Inc.
+000C89|AC Electric Vehicles, Ltd.
+000C8A|Bose Corporation
+000C8B|Connect Tech Inc
+000C8C|KODICOM CO.,LTD.
+000C8D|MATRIX VISION GmbH
+000C8E|Mentor Engineering Inc
+000C8F|Nergal s.r.l.
+000C90|Octasic Inc.
+000C91|Riverhead Networks Inc.
+000C92|WolfVision Gmbh
+000C93|Xeline Co., Ltd.
+000C94|United Electronic Industries, Inc. (EUI)
+000C95|PrimeNet
+000C96|OQO, Inc.
+000C97|NV ADB TTV Technologies SA
+000C98|LETEK Communications Inc.
+000C99|HITEL LINK Co.,Ltd
+000C9A|Hitech Electronics Corp.
+000C9B|EE Solutions, Inc
+000C9C|Chongho information & communications
+000C9D|UbeeAirWalk, Inc.
+000C9E|MemoryLink Corp.
+000C9F|NKE Corporation
+000CA0|StorCase Technology, Inc.
+000CA1|SIGMACOM Co., LTD.
+000CA2|Harmonic Video Network
+000CA3|Rancho Technology, Inc.
+000CA4|Prompttec Product Management GmbH
+000CA5|Naman NZ LTd
+000CA6|Mintera Corporation
+000CA7|Metro (Suzhou) Technologies Co., Ltd.
+000CA8|Garuda Networks Corporation
+000CA9|Ebtron Inc.
+000CAA|Cubic Transportation Systems Inc
+000CAB|COMMEND International
+000CAC|Citizen Watch Co., Ltd.
+000CAD|BTU International
+000CAE|Ailocom Oy
+000CAF|TRI TERM CO.,LTD.
+000CB0|Star Semiconductor Corporation
+000CB1|Salland Engineering (Europe) BV
+000CB2|UNION co., ltd.
+000CB3|ROUND Co.,Ltd.
+000CB4|AutoCell Laboratories, Inc.
+000CB5|Premier Technolgies, Inc
+000CB6|NANJING SEU MOBILE & INTERNET TECHNOLOGY CO.,LTD
+000CB7|Nanjing Huazhuo Electronics Co., Ltd.
+000CB8|MEDION AG
+000CB9|LEA
+000CBA|Jamex, Inc.
+000CBB|ISKRAEMECO
+000CBC|Iscutum
+000CBD|Interface Masters, Inc
+000CBE|Innominate Security Technologies AG
+000CBF|Holy Stone Ent. Co., Ltd.
+000CC0|Genera Oy
+000CC1|Cooper Industries Inc.
+000CC2|ControlNet (India) Private Limited
+000CC3|BeWAN systems
+000CC4|Tiptel AG
+000CC5|Nextlink Co., Ltd.
+000CC6|Ka-Ro electronics GmbH
+000CC7|Intelligent Computer Solutions Inc.
+000CC8|Xytronix Research & Design, Inc.
+000CC9|ILWOO DATA & TECHNOLOGY CO.,LTD
+000CCA|HGST a Western Digital Company
+000CCB|Design Combus Ltd
+000CCC|Aeroscout Ltd.
+000CCD|IEC - TC57
+000CCE|Cisco
+000CCF|Cisco
+000CD0|Symetrix
+000CD1|SFOM Technology Corp.
+000CD2|Schaffner EMV AG
+000CD3|Prettl Elektronik Radeberg GmbH
+000CD4|Positron Public Safety Systems inc.
+000CD5|Passave Inc.
+000CD6|PARTNER TECH
+000CD7|Nallatech Ltd
+000CD8|M. K. Juchheim GmbH & Co
+000CD9|Itcare Co., Ltd
+000CDA|FreeHand Systems, Inc.
+000CDB|Brocade Communications Systems, Inc
+000CDC|BECS Technology, Inc
+000CDD|AOS Technologies AG
+000CDE|ABB STOTZ-KONTAKT GmbH
+000CDF|PULNiX America, Inc
+000CE0|Trek Diagnostics Inc.
+000CE1|The Open Group
+000CE2|Rolls-Royce
+000CE3|Option International N.V.
+000CE4|NeuroCom International, Inc.
+000CE5|ARRIS Group, Inc.
+000CE6|Meru Networks Inc
+000CE7|MediaTek Inc.
+000CE8|GuangZhou AnJuBao Co., Ltd
+000CE9|BLOOMBERG L.P.
+000CEA|aphona Kommunikationssysteme
+000CEB|CNMP Networks, Inc.
+000CEC|Spectracom Corp.
+000CED|Real Digital Media
+000CEE|jp-embedded
+000CEF|Open Networks Engineering Ltd
+000CF0|M & N GmbH
+000CF1|Intel Corporate
+000CF2|GAMESA Eolica
+000CF3|CALL IMAGE SA
+000CF4|AKATSUKI ELECTRIC MFG.CO.,LTD.
+000CF5|InfoExpress
+000CF6|Sitecom Europe BV
+000CF7|Nortel Networks
+000CF8|Nortel Networks
+000CF9|Xylem Water Solutions
+000CFA|Digital Systems Corp
+000CFB|Korea Network Systems
+000CFC|S2io Technologies Corp
+000CFD|Hyundai ImageQuest Co.,Ltd.
+000CFE|Grand Electronic Co., Ltd
+000CFF|MRO-TEK LIMITED
+000D00|Seaway Networks Inc.
+000D01|P&E Microcomputer Systems, Inc.
+000D02|NEC Platforms, Ltd.
+000D03|Matrics, Inc.
+000D04|Foxboro Eckardt Development GmbH
+000D05|cybernet manufacturing inc.
+000D06|Compulogic Limited
+000D07|Calrec Audio Ltd
+000D08|AboveCable, Inc.
+000D09|Yuehua(Zhuhai) Electronic CO. LTD
+000D0A|Projectiondesign as
+000D0B|Buffalo Inc.
+000D0C|MDI Security Systems
+000D0D|ITSupported, LLC
+000D0E|Inqnet Systems, Inc.
+000D0F|Finlux Ltd
+000D10|Embedtronics Oy
+000D11|DENTSPLY - Gendex
+000D12|AXELL Corporation
+000D13|Wilhelm Rutenbeck GmbH&Co.KG
+000D14|Vtech Innovation LP dba Advanced American Telephones
+000D15|Voipac s.r.o.
+000D16|UHS Systems Pty Ltd
+000D17|Turbo Networks Co.Ltd
+000D18|Mega-Trend Electronics CO., LTD.
+000D19|ROBE Show lighting
+000D1A|Mustek System Inc.
+000D1B|Kyoto Electronics Manufacturing Co., Ltd.
+000D1C|Amesys Defense
+000D1D|HIGH-TEK HARNESS ENT. CO., LTD.
+000D1E|Control Techniques
+000D1F|AV Digital
+000D20|ASAHIKASEI TECHNOSYSTEM CO.,LTD.
+000D21|WISCORE Inc.
+000D22|Unitronics LTD
+000D23|Smart Solution, Inc
+000D24|SENTEC E&E CO., LTD.
+000D25|SANDEN CORPORATION
+000D26|Primagraphics Limited
+000D27|MICROPLEX Printware AG
+000D28|Cisco
+000D29|Cisco
+000D2A|Scanmatic AS
+000D2B|Racal Instruments
+000D2C|Patapsco Designs Ltd
+000D2D|NCT Deutschland GmbH
+000D2E|Matsushita Avionics Systems Corporation
+000D2F|AIN Comm.Tech.Co., LTD
+000D30|IceFyre Semiconductor
+000D31|Compellent Technologies, Inc.
+000D32|DispenseSource, Inc.
+000D33|Prediwave Corp.
+000D34|Shell International Exploration and Production, Inc.
+000D35|PAC International Ltd
+000D36|Wu Han Routon Electronic Co., Ltd
+000D37|WIPLUG
+000D38|NISSIN INC.
+000D39|Network Electronics
+000D3A|Microsoft
+000D3B|Microelectronics Technology Inc.
+000D3C|i.Tech Dynamic Ltd
+000D3D|Hammerhead Systems, Inc.
+000D3E|APLUX Communications Ltd.
+000D3F|VTI Instruments Corporation
+000D40|Verint Loronix Video Solutions
+000D41|Siemens AG ICM MP UC RD IT KLF1
+000D42|Newbest Development Limited
+000D43|DRS Tactical Systems Inc.
+000D44|Audio BU - Logitech
+000D45|Tottori SANYO Electric Co., Ltd.
+000D46|Parker SSD Drives
+000D47|Collex
+000D48|AEWIN Technologies Co., Ltd.
+000D49|Triton Systems of Delaware, Inc.
+000D4A|Steag ETA-Optik
+000D4B|Roku, LLC
+000D4C|Outline Electronics Ltd.
+000D4D|Ninelanes
+000D4E|NDR Co.,LTD.
+000D4F|Kenwood Corporation
+000D50|Galazar Networks
+000D51|DIVR Systems, Inc.
+000D52|Comart system
+000D53|Beijing 5w Communication Corp.
+000D54|3Com Ltd
+000D55|SANYCOM Technology Co.,Ltd
+000D56|Dell Inc
+000D57|Fujitsu I-Network Systems Limited.
+000D58|Opti-cell, Inc. 
+000D59|Amity Systems, Inc.
+000D5A|Tiesse SpA
+000D5B|Smart Empire Investments Limited
+000D5C|Robert Bosch GmbH, VT-ATMO
+000D5D|Raritan Computer, Inc
+000D5E|NEC Personal Products
+000D5F|Minds Inc
+000D60|IBM Corp
+000D61|Giga-Byte Technology Co., Ltd.
+000D62|Funkwerk Dabendorf GmbH
+000D63|DENT Instruments, Inc.
+000D64|COMAG Handels AG
+000D65|Cisco
+000D66|Cisco
+000D67|Ericsson
+000D68|Vinci Systems, Inc.
+000D69|TMT&D Corporation
+000D6A|Redwood Technologies LTD
+000D6B|Mita-Teknik A/S
+000D6C|M-Audio
+000D6D|K-Tech Devices Corp.
+000D6E|K-Patents Oy
+000D6F|Ember Corporation
+000D70|Datamax Corporation
+000D71|boca systems
+000D72|2Wire, Inc
+000D73|Technical Support, Inc.
+000D74|Sand Network Systems, Inc.
+000D75|Kobian Pte Ltd - Taiwan Branch
+000D76|Hokuto Denshi Co,. Ltd.
+000D77|FalconStor Software
+000D78|Engineering & Security
+000D79|Dynamic Solutions Co,.Ltd.
+000D7A|DiGATTO Asia Pacific Pte Ltd
+000D7B|Consensys Computers Inc.
+000D7C|Codian Ltd
+000D7D|Afco Systems
+000D7E|Axiowave Networks, Inc.
+000D7F|MIDAS  COMMUNICATION TECHNOLOGIES PTE LTD ( Foreign Branch)
+000D80|Online Development Inc
+000D81|Pepperl+Fuchs GmbH
+000D82|PHS srl
+000D83|Sanmina-SCI Hungary  Ltd.
+000D84|Makus Inc.
+000D85|Tapwave, Inc.
+000D86|Huber + Suhner AG
+000D87|Elitegroup Computer System Co. (ECS)
+000D88|D-Link Corporation
+000D89|Bils Technology Inc
+000D8A|Winners Electronics Co., Ltd.
+000D8B|T&D Corporation
+000D8C|Shanghai Wedone Digital Ltd. CO.
+000D8D|Prosoft Technology, Inc
+000D8E|Koden Electronics Co., Ltd.
+000D8F|King Tsushin Kogyo Co., LTD.
+000D90|Factum Electronics AB
+000D91|Eclipse (HQ Espana) S.L.
+000D92|Arima Communication Corporation
+000D93|Apple
+000D94|AFAR Communications,Inc
+000D95|Opti-cell, Inc.
+000D96|Vtera Technology Inc.
+000D97|Tropos Networks, Inc.
+000D98|S.W.A.C. Schmitt-Walter Automation Consult GmbH
+000D99|Orbital Sciences Corp.; Launch Systems Group
+000D9A|INFOTEC LTD
+000D9B|Heraeus Electro-Nite International N.V.
+000D9C|Elan GmbH & Co KG
+000D9D|Hewlett-Packard Company
+000D9E|TOKUDEN OHIZUMI SEISAKUSYO Co.,Ltd.
+000D9F|RF Micro Devices
+000DA0|NEDAP N.V.
+000DA1|MIRAE ITS Co.,LTD.
+000DA2|Infrant Technologies, Inc.
+000DA3|Emerging Technologies Limited
+000DA4|DOSCH & AMAND SYSTEMS AG
+000DA5|Fabric7 Systems, Inc
+000DA6|Universal Switching Corporation
+000DA7|ASSIGNED - PRIVATE REGISTRATION 
+000DA8|Teletronics Technology Corporation
+000DA9|T.E.A.M. S.L.
+000DAA|S.A.Tehnology co., Ltd.
+000DAB|Parker Hannifin GmbH Electromechanical Division Europe
+000DAC|Japan CBM Corporation
+000DAD|Dataprobe, Inc.
+000DAE|Samsung
+000DAF|Plexus Corp (UK) Ltd
+000DB0|Olym-tech Co.,Ltd.
+000DB1|Japan Network Service Co., Ltd.
+000DB2|Ammasso, Inc.
+000DB3|SDO Communication Corperation
+000DB4|NETASQ
+000DB5|GLOBALSAT TECHNOLOGY CORPORATION
+000DB6|Broadcom Corporation
+000DB7|SANKO ELECTRIC CO,.LTD
+000DB8|SCHILLER AG
+000DB9|PC Engines GmbH
+000DBA|Oce Document Technologies GmbH
+000DBB|Nippon Dentsu Co.,Ltd.
+000DBC|Cisco
+000DBD|Cisco
+000DBE|Bel Fuse Europe Ltd.,UK
+000DBF|TekTone Sound & Signal Mfg., Inc.
+000DC0|Spagat AS
+000DC1|SafeWeb Inc
+000DC2|ASSIGNED - PRIVATE REGISTRATION 
+000DC3|First Communication, Inc.
+000DC4|Emcore Corporation
+000DC5|EchoStar Global B.V.
+000DC6|DigiRose Technology Co., Ltd.
+000DC7|COSMIC ENGINEERING INC.
+000DC8|AirMagnet, Inc
+000DC9|THALES Elektronik Systeme GmbH
+000DCA|Tait Electronics
+000DCB|Petcomkorea Co., Ltd.
+000DCC|NEOSMART Corp.
+000DCD|GROUPE TXCOM
+000DCE|Dynavac Technology Pte Ltd
+000DCF|Cidra Corp.
+000DD0|TetraTec Instruments GmbH
+000DD1|Stryker Corporation
+000DD2|Simrad Optronics ASA
+000DD3|SAMWOO Telecommunication Co.,Ltd.
+000DD4|Symantec Corporation
+000DD5|O'RITE TECHNOLOGY CO.,LTD
+000DD6|ITI    LTD
+000DD7|Bright
+000DD8|BBN
+000DD9|Anton Paar GmbH
+000DDA|ALLIED TELESIS K.K.
+000DDB|AIRWAVE TECHNOLOGIES INC.
+000DDC|VAC
+000DDD|Profilo Telra Elektronik Sanayi ve Ticaret. A.S
+000DDE|Joyteck Co., Ltd.
+000DDF|Japan Image & Network Inc.
+000DE0|ICPDAS Co.,LTD
+000DE1|Control Products, Inc.
+000DE2|CMZ Sistemi Elettronici
+000DE3|AT Sweden AB
+000DE4|DIGINICS, Inc.
+000DE5|Samsung
+000DE6|YOUNGBO ENGINEERING CO.,LTD
+000DE7|Snap-on OEM Group
+000DE8|Nasaco Electronics Pte. Ltd
+000DE9|Napatech Aps
+000DEA|Kingtel Telecommunication Corp.
+000DEB|CompXs Limited
+000DEC|Cisco
+000DED|Cisco
+000DEE|Andrew RF Power Amplifier Group
+000DEF|Soc. Coop. Bilanciai
+000DF0|QCOM TECHNOLOGY INC.
+000DF1|IONIX INC.
+000DF2|ASSIGNED - PRIVATE REGISTRATION 
+000DF3|Asmax Solutions
+000DF4|Watertek Co.
+000DF5|Teletronics International Inc.
+000DF6|Technology Thesaurus Corp.
+000DF7|Space Dynamics Lab
+000DF8|ORGA Kartensysteme GmbH
+000DF9|NDS Limited
+000DFA|Micro Control Systems Ltd.
+000DFB|Komax AG
+000DFC|ITFOR Inc.
+000DFD|Huges Hi-Tech Inc.,
+000DFE|Hauppauge Computer Works, Inc.
+000DFF|CHENMING MOLD INDUSTRY CORP.
+000E00|Atrie
+000E01|ASIP Technologies Inc.
+000E02|Advantech AMT Inc.
+000E03|Emulex Corporation
+000E04|CMA/Microdialysis AB
+000E05|WIRELESS MATRIX CORP.
+000E06|Team Simoco Ltd
+000E07|Sony Ericsson Mobile Communications AB
+000E08|Cisco
+000E09|Shenzhen Coship Software Co.,LTD.
+000E0A|SAKUMA DESIGN OFFICE
+000E0B|Netac Technology Co., Ltd.
+000E0C|Intel Corporate
+000E0D|Hesch Schroder GmbH
+000E0E|ESA elettronica S.P.A.
+000E0F|ERMME
+000E10|C-guys, Inc.
+000E11|BDT Buro und Datentechnik GmbH & Co.KG
+000E12|Adaptive Micro Systems Inc.
+000E13|Accu-Sort Systems inc.
+000E14|Visionary Solutions, Inc.
+000E15|Tadlys LTD
+000E16|SouthWing S.L.
+000E17|ASSIGNED - PRIVATE REGISTRATION 
+000E18|MyA Technology
+000E19|LogicaCMG Pty Ltd
+000E1A|JPS Communications
+000E1B|IAV GmbH
+000E1C|Hach Company
+000E1D|ARION Technology Inc.
+000E1E|QLogic Corporation
+000E1F|TCL Networks Equipment Co., Ltd.
+000E20|ACCESS Systems Americas, Inc.
+000E21|MTU Friedrichshafen GmbH
+000E22|ASSIGNED - PRIVATE REGISTRATION 
+000E23|Incipient, Inc.
+000E24|Huwell Technology Inc.
+000E25|Hannae Technology Co., Ltd
+000E26|Gincom Technology Corp.
+000E27|Crere Networks, Inc.
+000E28|Dynamic Ratings P/L
+000E29|Shester Communications Inc
+000E2A|ASSIGNED - PRIVATE REGISTRATION 
+000E2B|Safari Technologies
+000E2C|Netcodec co.
+000E2D|Hyundai Digital Technology Co.,Ltd.
+000E2E|Edimax Technology Co., Ltd.
+000E2F|Roche Diagnostics GmbH
+000E30|AERAS Networks, Inc.
+000E31|Olympus Soft Imaging Solutions GmbH
+000E32|Kontron Medical
+000E33|Shuko Electronics Co.,Ltd
+000E34|NexGen City, LP
+000E35|Intel Corp
+000E36|HEINESYS, Inc.
+000E37|Harms & Wende GmbH & Co.KG
+000E38|Cisco
+000E39|Cisco
+000E3A|Cirrus Logic
+000E3B|Hawking Technologies, Inc.
+000E3C|Transact Technologies Inc
+000E3D|Televic N.V.
+000E3E|Sun Optronics Inc
+000E3F|Soronti, Inc.
+000E40|Nortel Networks
+000E41|NIHON MECHATRONICS CO.,LTD.
+000E42|Motic Incoporation Ltd.
+000E43|G-Tek Electronics Sdn. Bhd.
+000E44|Digital 5, Inc.
+000E45|Beijing Newtry Electronic Technology Ltd
+000E46|Niigata Seimitsu Co.,Ltd.
+000E47|NCI System Co.,Ltd.
+000E48|Lipman TransAction Solutions
+000E49|Forsway Scandinavia AB
+000E4A|Changchun Huayu WEBPAD Co.,LTD
+000E4B|atrium c and i
+000E4C|Bermai Inc.
+000E4D|Numesa Inc.
+000E4E|Waveplus Technology Co., Ltd.
+000E4F|Trajet GmbH
+000E50|Thomson Telecom Belgium
+000E51|tecna elettronica srl
+000E52|Optium Corporation
+000E53|AV TECH CORPORATION
+000E54|AlphaCell Wireless Ltd.
+000E55|AUVITRAN
+000E56|4G Systems GmbH & Co. KG
+000E57|Iworld Networking, Inc.
+000E58|Sonos, Inc.
+000E59|SAGEM SA
+000E5A|TELEFIELD inc.
+000E5B|ParkerVision - Direct2Data
+000E5C|ARRIS Group, Inc.
+000E5D|Triple Play Technologies A/S
+000E5E|Raisecom Technology
+000E5F|activ-net GmbH & Co. KG
+000E60|360SUN Digital Broadband Corporation
+000E61|MICROTROL LIMITED
+000E62|Nortel Networks
+000E63|Lemke Diagnostics GmbH
+000E64|Elphel, Inc
+000E65|TransCore
+000E66|Hitachi Industry & Control Solutions, Ltd.
+000E67|Eltis Microelectronics Ltd.
+000E68|E-TOP Network Technology Inc.
+000E69|China Electric Power Research Institute
+000E6A|3Com Ltd
+000E6B|Janitza electronics GmbH
+000E6C|Device Drivers Limited
+000E6D|Murata Manufacturing Co., Ltd.
+000E6E|MAT S.A. (Mircrelec Advanced Technology)
+000E6F|IRIS Corporation Berhad
+000E70|in2 Networks
+000E71|Gemstar Technology Development Ltd.
+000E72|CTS electronics
+000E73|Tpack A/S
+000E74|Solar Telecom. Tech
+000E75|New York Air Brake Corp.
+000E76|GEMSOC INNOVISION INC.
+000E77|Decru, Inc.
+000E78|Amtelco
+000E79|Ample Communications Inc.
+000E7A|GemWon Communications Co., Ltd.
+000E7B|Toshiba
+000E7C|Televes S.A.
+000E7D|Electronics Line 3000 Ltd.
+000E7E|ionSign Oy
+000E7F|Hewlett-Packard Company
+000E80|Thomson Technology Inc
+000E81|Devicescape Software, Inc.
+000E82|Commtech Wireless
+000E83|Cisco
+000E84|Cisco
+000E85|Catalyst Enterprises, Inc.
+000E86|Alcatel North America
+000E87|adp Gauselmann GmbH
+000E88|VIDEOTRON CORP.
+000E89|CLEMATIC
+000E8A|Avara Technologies Pty. Ltd.
+000E8B|Astarte Technology Co, Ltd.
+000E8C|Siemens AG A&D ET
+000E8D|Systems in Progress Holding GmbH
+000E8E|SparkLAN Communications, Inc.
+000E8F|Sercomm Corp.
+000E90|PONICO CORP.
+000E91|Navico Auckland Ltd
+000E92|Open Telecom
+000E93|Milenio 3 Sistemas Electronicos, Lda.
+000E94|Maas International BV
+000E95|Fujiya Denki Seisakusho Co.,Ltd.
+000E96|Cubic Defense Applications, Inc.
+000E97|Ultracker Technology CO., Inc
+000E98|HME Clear-Com LTD.
+000E99|Spectrum Digital, Inc
+000E9A|BOE TECHNOLOGY GROUP CO.,LTD
+000E9B|Ambit Microsystems Corporation
+000E9C|Benchmark Electronics
+000E9D|Tiscali UK Ltd
+000E9E|Topfield Co., Ltd
+000E9F|TEMIC SDS GmbH
+000EA0|NetKlass Technology Inc.
+000EA1|Formosa Teletek Corporation
+000EA2|McAfee, Inc
+000EA3|CNCR-IT CO.,LTD,HangZhou P.R.CHINA
+000EA4|Certance Inc.
+000EA5|BLIP Systems
+000EA6|ASUSTEK COMPUTER INC.
+000EA7|Endace Technology
+000EA8|United Technologists Europe Limited
+000EA9|Shanghai Xun Shi Communications Equipment Ltd. Co.
+000EAA|Scalent Systems, Inc.
+000EAB|Cray Inc
+000EAC|MINTRON ENTERPRISE CO., LTD.
+000EAD|Metanoia Technologies, Inc.
+000EAE|GAWELL TECHNOLOGIES CORP.
+000EAF|CASTEL
+000EB0|Solutions Radio BV
+000EB1|Newcotech,Ltd
+000EB2|Micro-Research Finland Oy
+000EB3|Hewlett-Packard
+000EB4|GUANGZHOU GAOKE COMMUNICATIONS TECHNOLOGY CO.LTD.
+000EB5|Ecastle Electronics Co., Ltd.
+000EB6|Riverbed Technology, Inc.
+000EB7|Knovative, Inc.
+000EB8|Iiga co., Ltd
+000EB9|HASHIMOTO Electronics Industry Co.,Ltd.
+000EBA|HANMI SEMICONDUCTOR CO., LTD.
+000EBB|Everbee Networks
+000EBC|Paragon Fidelity GmbH
+000EBD|Burdick, a Quinton Compny
+000EBE|B&B Electronics Manufacturing Co.
+000EBF|Remsdaq Limited
+000EC0|Nortel Networks
+000EC1|MYNAH Technologies
+000EC2|Lowrance Electronics, Inc.
+000EC3|Logic Controls, Inc.
+000EC4|Iskra Transmission d.d.
+000EC5|Digital Multitools Inc
+000EC6|ASIX ELECTRONICS CORP.
+000EC7|Motorola
+000EC8|Zoran Corporation
+000EC9|YOKO Technology Corp.
+000ECA|WTSS Inc
+000ECB|VineSys Technology
+000ECC|Tableau, LLC
+000ECD|SKOV A/S
+000ECE|S.I.T.T.I. S.p.A.
+000ECF|PROFIBUS Nutzerorganisation e.V.
+000ED0|Privaris, Inc.
+000ED1|Osaka Micro Computer.
+000ED2|Filtronic plc
+000ED3|Epicenter, Inc.
+000ED4|CRESITT INDUSTRIE
+000ED5|COPAN Systems Inc.
+000ED6|Cisco
+000ED7|Cisco
+000ED8|Aktino, Inc.
+000ED9|Aksys, Ltd.
+000EDA|C-TECH UNITED CORP.
+000EDB|XiNCOM Corp.
+000EDC|Tellion INC.
+000EDD|SHURE INCORPORATED
+000EDE|REMEC, Inc.
+000EDF|PLX Technology
+000EE0|Mcharge
+000EE1|ExtremeSpeed Inc.
+000EE2|Custom Engineering
+000EE3|Chiyu Technology Co.,Ltd
+000EE4|BOE TECHNOLOGY GROUP CO.,LTD
+000EE5|bitWallet, Inc.
+000EE6|Adimos Systems LTD
+000EE7|AAC ELECTRONICS CORP.
+000EE8|zioncom
+000EE9|WayTech Development, Inc.
+000EEA|Shadong Luneng Jicheng Electronics,Co.,Ltd
+000EEB|Sandmartin(zhong shan)Electronics Co.,Ltd
+000EEC|Orban
+000EED|Nokia Danmark A/S
+000EEE|Muco Industrie BV
+000EEF|ASSIGNED - PRIVATE REGISTRATION 
+000EF0|Festo AG & Co. KG
+000EF1|EZQUEST INC.
+000EF2|Infinico Corporation
+000EF3|Smarthome
+000EF4|Kasda Networks Inc
+000EF5|iPAC Technology Co., Ltd.
+000EF6|E-TEN Information Systems Co., Ltd.
+000EF7|Vulcan Portals Inc
+000EF8|SBC ASI
+000EF9|REA Elektronik GmbH
+000EFA|Optoway Technology Incorporation
+000EFB|Macey Enterprises
+000EFC|JTAG Technologies B.V.
+000EFD|FUJINON CORPORATION
+000EFE|EndRun Technologies LLC
+000EFF|Megasolution,Inc.
+000F00|Legra Systems, Inc.
+000F01|DIGITALKS INC
+000F02|Digicube Technology Co., Ltd
+000F03|COM&C CO., LTD
+000F04|cim-usa inc
+000F05|3B SYSTEM INC.
+000F06|Nortel Networks
+000F07|Mangrove Systems, Inc.
+000F08|Indagon Oy
+000F09|ASSIGNED - PRIVATE REGISTRATION 
+000F0A|Clear Edge Networks
+000F0B|Kentima Technologies AB
+000F0C|SYNCHRONIC ENGINEERING
+000F0D|Hunt Electronic Co., Ltd.
+000F0E|WaveSplitter Technologies, Inc.
+000F0F|Real ID Technology Co., Ltd.
+000F10|RDM Corporation
+000F11|Prodrive B.V.
+000F12|Panasonic Europe Ltd.
+000F13|Nisca corporation
+000F14|Mindray Co., Ltd.
+000F15|Kjaerulff1 A/S
+000F16|JAY HOW TECHNOLOGY CO.,
+000F17|Insta Elektro GmbH
+000F18|Industrial Control Systems
+000F19|Boston Scientific
+000F1A|Gaming Support B.V.
+000F1B|Ego Systems Inc.
+000F1C|DigitAll World Co., Ltd
+000F1D|Cosmo Techs Co., Ltd.
+000F1E|Chengdu KT Electric Co.of High & New Technology
+000F1F|Dell Inc
+000F20|Hewlett-Packard Company
+000F21|Scientific Atlanta, Inc
+000F22|Helius, Inc.
+000F23|Cisco
+000F24|Cisco
+000F25|AimValley B.V.
+000F26|WorldAccxx  LLC
+000F27|TEAL Electronics, Inc.
+000F28|Itronix Corporation
+000F29|Augmentix Corporation
+000F2A|Cableware Electronics
+000F2B|GREENBELL SYSTEMS
+000F2C|Uplogix, Inc.
+000F2D|CHUNG-HSIN ELECTRIC & MACHINERY MFG.CORP.
+000F2E|Megapower International Corp.
+000F2F|W-LINX TECHNOLOGY CO., LTD.
+000F30|Raza Microelectronics Inc
+000F31|Allied Vision Technologies Canada Inc
+000F32|Lootom Telcovideo Network Wuxi Co Ltd
+000F33|DUALi Inc.
+000F34|Cisco
+000F35|Cisco
+000F36|Accurate Techhnologies, Inc.
+000F37|Xambala Incorporated
+000F38|Netstar
+000F39|IRIS SENSORS
+000F3A|HISHARP
+000F3B|Fuji System Machines Co., Ltd.
+000F3C|Endeleo Limited
+000F3D|D-Link Corporation
+000F3E|CardioNet, Inc
+000F3F|Big Bear Networks
+000F40|Optical Internetworking Forum
+000F41|Zipher Ltd
+000F42|Xalyo Systems
+000F43|Wasabi Systems Inc.
+000F44|Tivella Inc.
+000F45|Stretch, Inc.
+000F46|SINAR AG
+000F47|ROBOX SPA
+000F48|Polypix Inc.
+000F49|Northover Solutions Limited
+000F4A|Kyushu-kyohan co.,ltd
+000F4B|Oracle Corporation
+000F4C|Elextech INC
+000F4D|TalkSwitch
+000F4E|Cellink
+000F4F|Cadmus Technology Ltd
+000F50|StreamScale Limited
+000F51|Azul Systems, Inc.
+000F52|YORK Refrigeration, Marine & Controls
+000F53|Solarflare Communications Inc
+000F54|Entrelogic Corporation
+000F55|Datawire Communication Networks Inc.
+000F56|Continuum Photonics Inc
+000F57|CABLELOGIC Co., Ltd.
+000F58|Adder Technology Limited
+000F59|Phonak Communications AG
+000F5A|Peribit Networks
+000F5B|Delta Information Systems, Inc.
+000F5C|Day One Digital Media Limited
+000F5D|Genexis BV
+000F5E|Veo
+000F5F|Nicety Technologies Inc. (NTS)
+000F60|Lifetron Co.,Ltd
+000F61|Hewlett-Packard Company
+000F62|Alcatel Bell Space N.V.
+000F63|Obzerv Technologies
+000F64|D&R Electronica Weesp BV
+000F65|icube Corp.
+000F66|Cisco
+000F67|West Instruments
+000F68|Vavic Network Technology, Inc.
+000F69|SEW Eurodrive GmbH & Co. KG
+000F6A|Nortel Networks
+000F6B|GateWare Communications GmbH
+000F6C|ADDI-DATA GmbH
+000F6D|Midas Engineering
+000F6E|BBox
+000F6F|FTA Communication Technologies
+000F70|Wintec Industries, inc.
+000F71|Sanmei Electronics Co.,Ltd
+000F72|Sandburst
+000F73|RS Automation Co., Ltd
+000F74|Qamcom Technology AB
+000F75|First Silicon Solutions
+000F76|Digital Keystone, Inc.
+000F77|DENTUM CO.,LTD
+000F78|Datacap Systems Inc
+000F79|Bluetooth Interest Group Inc.
+000F7A|BeiJing NuQX Technology CO.,LTD
+000F7B|Arce Sistemas, S.A.
+000F7C|ACTi Corporation
+000F7D|Xirrus
+000F7E|Ablerex Electronics Co., LTD
+000F7F|UBSTORAGE Co.,Ltd.
+000F80|Trinity Security Systems,Inc.
+000F81|PAL Pacific Inc.
+000F82|Mortara Instrument, Inc.
+000F83|Brainium Technologies Inc.
+000F84|Astute Networks, Inc.
+000F85|ADDO-Japan Corporation
+000F86|Research In Motion Limited
+000F87|Maxcess International
+000F88|AMETEK, Inc.
+000F89|Winnertec System Co., Ltd.
+000F8A|WideView
+000F8B|Orion MultiSystems Inc
+000F8C|Gigawavetech Pte Ltd
+000F8D|FAST TV-Server AG
+000F8E|DONGYANG TELECOM CO.,LTD.
+000F8F|Cisco
+000F90|Cisco
+000F91|Aerotelecom Co.,Ltd.
+000F92|Microhard Systems Inc.
+000F93|Landis+Gyr Ltd.
+000F94|Genexis BV
+000F95|ELECOM Co.,LTD Laneed Division
+000F96|Telco Systems, Inc.
+000F97|Avanex Corporation
+000F98|Avamax Co. Ltd.
+000F99|APAC opto Electronics Inc.
+000F9A|Synchrony, Inc.
+000F9B|Ross Video Limited
+000F9C|Panduit Corp
+000F9D|DisplayLink (UK) Ltd
+000F9E|Murrelektronik GmbH
+000F9F|ARRIS Group, Inc.
+000FA0|CANON KOREA BUSINESS SOLUTIONS INC.
+000FA1|Gigabit Systems Inc.
+000FA2|2xWireless
+000FA3|Alpha Networks Inc.
+000FA4|Sprecher Automation GmbH
+000FA5|BWA Technology GmbH
+000FA6|S2 Security Corporation
+000FA7|Raptor Networks Technology
+000FA8|Photometrics, Inc.
+000FA9|PC Fabrik
+000FAA|Nexus Technologies
+000FAB|Kyushu Electronics Systems Inc.
+000FAC|IEEE 802.11
+000FAD|FMN communications GmbH
+000FAE|E2O Communications
+000FAF|Dialog Inc.
+000FB0|Compal Electronics,INC.
+000FB1|Cognio Inc.
+000FB2|Broadband Pacenet (India) Pvt. Ltd.
+000FB3|Actiontec Electronics, Inc
+000FB4|Timespace Technology
+000FB5|Netgear
+000FB6|Europlex Technologies
+000FB7|Cavium Networks
+000FB8|CallURL Inc.
+000FB9|Adaptive Instruments
+000FBA|Tevebox AB
+000FBB|Nokia Siemens Networks GmbH & Co. KG.
+000FBC|Onkey Technologies, Inc.
+000FBD|MRV Communications (Networks) LTD
+000FBE|e-w/you Inc.
+000FBF|DGT Sp. z o.o.
+000FC0|DELCOMp
+000FC1|WAVE Corporation
+000FC2|Uniwell Corporation
+000FC3|PalmPalm Technology, Inc.
+000FC4|NST co., LTD.
+000FC5|KeyMed Ltd
+000FC6|Eurocom Industries A/S
+000FC7|Dionica R&D Ltd.
+000FC8|Chantry Networks
+000FC9|Allnet GmbH
+000FCA|A-JIN TECHLINE CO, LTD
+000FCB|3Com Ltd
+000FCC|ARRIS Group, Inc.
+000FCD|Nortel Networks
+000FCE|Kikusui Electronics Corp.
+000FCF|Datawind Research
+000FD0|ASTRI
+000FD1|Applied Wireless Identifications Group, Inc.
+000FD2|EWA Technologies, Inc.
+000FD3|Digium
+000FD4|Soundcraft
+000FD5|Schwechat - RISE
+000FD6|Sarotech Co., Ltd
+000FD7|Harman Music Group
+000FD8|Force, Inc.
+000FD9|FlexDSL Telecommunications AG
+000FDA|YAZAKI CORPORATION
+000FDB|Westell Technologies
+000FDC|Ueda Japan  Radio Co., Ltd.
+000FDD|SORDIN AB
+000FDE|Sony Ericsson Mobile Communications AB
+000FDF|SOLOMON Technology Corp.
+000FE0|NComputing Co.,Ltd.
+000FE1|ID DIGITAL CORPORATION
+000FE2|Hangzhou H3C Technologies Co., Ltd.
+000FE3|Damm Cellular Systems A/S
+000FE4|Pantech Co.,Ltd
+000FE5|MERCURY SECURITY CORPORATION
+000FE6|MBTech Systems, Inc.
+000FE7|Lutron Electronics Co., Inc.
+000FE8|Lobos, Inc.
+000FE9|GW TECHNOLOGIES CO.,LTD.
+000FEA|Giga-Byte Technology Co.,LTD.
+000FEB|Cylon Controls
+000FEC|ARKUS Inc.
+000FED|Anam Electronics Co., Ltd
+000FEE|XTec, Incorporated
+000FEF|Thales e-Transactions GmbH
+000FF0|Sunray Co. Ltd.
+000FF1|nex-G Systems Pte.Ltd
+000FF2|Loud Technologies Inc.
+000FF3|Jung Myoung Communications&Technology
+000FF4|Guntermann & Drunck GmbH
+000FF5|GN&S company
+000FF6|Darfon Electronics Corp.
+000FF7|Cisco
+000FF8|Cisco
+000FF9|Valcretec, Inc.
+000FFA|Optinel Systems, Inc.
+000FFB|Nippon Denso Industry Co., Ltd.
+000FFC|Merit Li-Lin Ent.
+000FFD|Glorytek Network Inc.
+000FFE|G-PRO COMPUTER
+000FFF|Control4
+001000|CABLE TELEVISION LABORATORIES, INC.
+001001|Citel
+001002|ACTIA
+001003|IMATRON, INC.
+001004|THE BRANTLEY COILE COMPANY,INC
+001005|UEC COMMERCIAL
+001006|Thales Contact Solutions Ltd.
+001007|Cisco
+001008|VIENNA SYSTEMS CORPORATION
+001009|HORO QUARTZ
+00100A|WILLIAMS COMMUNICATIONS GROUP
+00100B|Cisco
+00100C|ITO CO., LTD.
+00100D|Cisco
+00100E|MICRO LINEAR COPORATION
+00100F|INDUSTRIAL CPU SYSTEMS
+001010|INITIO CORPORATION
+001011|Cisco
+001012|PROCESSOR SYSTEMS (I) PVT LTD
+001013|Kontron America, Inc.
+001014|Cisco
+001015|OOmon Inc.
+001016|T.SQWARE
+001017|Bosch Access Systems GmbH
+001018|BROADCOM CORPORATION
+001019|SIRONA DENTAL SYSTEMS GmbH & Co. KG
+00101A|PictureTel Corp.
+00101B|CORNET TECHNOLOGY, INC.
+00101C|OHM TECHNOLOGIES INTL, LLC
+00101D|WINBOND ELECTRONICS CORP.
+00101E|MATSUSHITA ELECTRONIC INSTRUMENTS CORP.
+00101F|Cisco
+001020|Hand Held Products Inc
+001021|ENCANTO NETWORKS, INC.
+001022|SatCom Media Corporation
+001023|Network Equipment Technologies
+001024|NAGOYA ELECTRIC WORKS CO., LTD
+001025|Grayhill, Inc
+001026|ACCELERATED NETWORKS, INC.
+001027|L-3 COMMUNICATIONS EAST
+001028|COMPUTER TECHNICA, INC.
+001029|Cisco
+00102A|ZF MICROSYSTEMS, INC.
+00102B|UMAX DATA SYSTEMS, INC.
+00102C|Lasat Networks A/S
+00102D|HITACHI SOFTWARE ENGINEERING
+00102E|NETWORK SYSTEMS & TECHNOLOGIES PVT. LTD.
+00102F|Cisco
+001030|EION Inc.
+001031|OBJECTIVE COMMUNICATIONS, INC.
+001032|ALTA TECHNOLOGY
+001033|ACCESSLAN COMMUNICATIONS, INC.
+001034|GNP Computers
+001035|ELITEGROUP COMPUTER SYSTEMS CO., LTD
+001036|INTER-TEL INTEGRATED SYSTEMS
+001037|CYQ've Technology Co., Ltd.
+001038|MICRO RESEARCH INSTITUTE, INC.
+001039|Vectron Systems AG
+00103A|DIAMOND NETWORK TECH
+00103B|HIPPI NETWORKING FORUM
+00103C|IC ENSEMBLE, INC.
+00103D|PHASECOM, LTD.
+00103E|NETSCHOOLS CORPORATION
+00103F|TOLLGRADE COMMUNICATIONS, INC.
+001040|INTERMEC CORPORATION
+001041|BRISTOL BABCOCK, INC.
+001042|Alacritech, Inc.
+001043|A2 CORPORATION
+001044|InnoLabs Corporation
+001045|Nortel Networks
+001046|ALCORN MCBRIDE INC.
+001047|ECHO ELETRIC CO. LTD.
+001048|HTRC AUTOMATION, INC.
+001049|ShoreTel, Inc
+00104A|The Parvus Corporation
+00104B|3COM CORPORATION
+00104C|Teledyne LeCroy, Inc
+00104D|SURTEC INDUSTRIES, INC.
+00104E|CEOLOGIC
+00104F|Oracle Corporation
+001050|RION CO., LTD.
+001051|CMICRO CORPORATION
+001052|METTLER-TOLEDO (ALBSTADT) GMBH
+001053|COMPUTER TECHNOLOGY CORP.
+001054|Cisco
+001055|FUJITSU MICROELECTRONICS, INC.
+001056|SODICK CO., LTD.
+001057|Rebel.com, Inc.
+001058|ArrowPoint Communications
+001059|DIABLO RESEARCH CO. LLC
+00105A|3COM CORPORATION
+00105B|NET INSIGHT AB
+00105C|QUANTUM DESIGNS (H.K.) LTD.
+00105D|Draeger Medical
+00105E|Spirent plc, Service Assurance Broadband
+00105F|ZODIAC DATA SYSTEMS
+001060|BILLIONTON SYSTEMS, INC.
+001061|HOSTLINK CORP.
+001062|NX SERVER, ILNC.
+001063|STARGUIDE DIGITAL NETWORKS
+001064|DNPG, LLC
+001065|RADYNE CORPORATION
+001066|ADVANCED CONTROL SYSTEMS, INC.
+001067|Ericsson
+001068|COMOS TELECOM
+001069|HELIOSS COMMUNICATIONS, INC.
+00106A|DIGITAL MICROWAVE CORPORATION
+00106B|SONUS NETWORKS, INC.
+00106C|EDNT GmbH
+00106D|Axxcelera Broadband Wireless
+00106E|TADIRAN COM. LTD.
+00106F|TRENTON TECHNOLOGY INC.
+001070|CARADON TREND LTD.
+001071|ADVANET INC.
+001072|GVN TECHNOLOGIES, INC.
+001073|Technobox, Inc.
+001074|ATEN INTERNATIONAL CO., LTD.
+001075|Segate Technology LLC
+001076|EUREM GmbH
+001077|SAF DRIVE SYSTEMS, LTD.
+001078|NUERA COMMUNICATIONS, INC.
+001079|Cisco
+00107A|AmbiCom, Inc.
+00107B|Cisco
+00107C|P-COM, INC.
+00107D|AURORA COMMUNICATIONS, LTD.
+00107E|BACHMANN ELECTRONIC GmbH
+00107F|CRESTRON ELECTRONICS, INC.
+001080|METAWAVE COMMUNICATIONS
+001081|DPS, INC.
+001082|JNA TELECOMMUNICATIONS LIMITED
+001083|HEWLETT-PACKARD COMPANY
+001084|K-BOT COMMUNICATIONS
+001085|POLARIS COMMUNICATIONS, INC.
+001086|ATTO Technology, Inc.
+001087|Xstreamis PLC
+001088|AMERICAN NETWORKS INC.
+001089|WebSonic
+00108A|TeraLogic, Inc.
+00108B|LASERANIMATION SOLLINGER GmbH
+00108C|FUJITSU TELECOMMUNICATIONS EUROPE, LTD.
+00108D|Johnson Controls, Inc.
+00108E|HUGH SYMONS CONCEPT Technologies Ltd.
+00108F|RAPTOR SYSTEMS
+001090|CIMETRICS, INC.
+001091|NO WIRES NEEDED BV
+001092|NETCORE INC.
+001093|CMS COMPUTERS, LTD.
+001094|Performance Analysis Broadband, Spirent plc
+001095|Thomson Inc.
+001096|TRACEWELL SYSTEMS, INC.
+001097|WinNet Metropolitan Communications Systems, Inc.
+001098|STARNET TECHNOLOGIES, INC.
+001099|InnoMedia, Inc.
+00109A|NETLINE
+00109B|Emulex Corporation
+00109C|M-SYSTEM CO., LTD.
+00109D|CLARINET SYSTEMS, INC.
+00109E|AWARE, INC.
+00109F|PAVO, INC.
+0010A0|INNOVEX TECHNOLOGIES, INC.
+0010A1|KENDIN SEMICONDUCTOR, INC.
+0010A2|TNS
+0010A3|OMNITRONIX, INC.
+0010A4|XIRCOM
+0010A5|OXFORD INSTRUMENTS
+0010A6|Cisco
+0010A7|UNEX TECHNOLOGY CORPORATION
+0010A8|RELIANCE COMPUTER CORP.
+0010A9|ADHOC TECHNOLOGIES
+0010AA|MEDIA4, INC.
+0010AB|KOITO ELECTRIC INDUSTRIES, LTD.
+0010AC|IMCI TECHNOLOGIES
+0010AD|SOFTRONICS USB, INC.
+0010AE|SHINKO ELECTRIC INDUSTRIES CO.
+0010AF|TAC SYSTEMS, INC.
+0010B0|MERIDIAN TECHNOLOGY CORP.
+0010B1|FOR-A CO., LTD.
+0010B2|COACTIVE AESTHETICS
+0010B3|NOKIA MULTIMEDIA TERMINALS
+0010B4|ATMOSPHERE NETWORKS
+0010B5|ACCTON TECHNOLOGY CORPORATION
+0010B6|ENTRATA COMMUNICATIONS CORP.
+0010B7|COYOTE TECHNOLOGIES, LLC
+0010B8|ISHIGAKI COMPUTER SYSTEM CO.
+0010B9|MAXTOR CORP.
+0010BA|MARTINHO-DAVIS SYSTEMS, INC.
+0010BB|DATA & INFORMATION TECHNOLOGY
+0010BC|Aastra Telecom
+0010BD|THE TELECOMMUNICATION TECHNOLOGY COMMITTEE (TTC)
+0010BE|MARCH NETWORKS CORPORATION
+0010BF|InterAir Wireless
+0010C0|ARMA, Inc.
+0010C1|OI ELECTRIC CO., LTD.
+0010C2|WILLNET, INC.
+0010C3|CSI-CONTROL SYSTEMS
+0010C4|MEDIA GLOBAL LINKS CO., LTD.
+0010C5|PROTOCOL TECHNOLOGIES, INC.
+0010C6|Universal Global Scientific Industrial Co., Ltd.
+0010C7|DATA TRANSMISSION NETWORK
+0010C8|COMMUNICATIONS ELECTRONICS SECURITY GROUP
+0010C9|MITSUBISHI ELECTRONICS LOGISTIC SUPPORT CO.
+0010CA|Telco Systems, Inc.
+0010CB|FACIT K.K.
+0010CC|CLP COMPUTER LOGISTIK PLANUNG GmbH
+0010CD|INTERFACE CONCEPT
+0010CE|VOLAMP, LTD.
+0010CF|FIBERLANE COMMUNICATIONS
+0010D0|WITCOM, LTD.
+0010D1|Top Layer Networks, Inc.
+0010D2|NITTO TSUSHINKI CO., LTD
+0010D3|GRIPS ELECTRONIC GMBH
+0010D4|STORAGE COMPUTER CORPORATION
+0010D5|IMASDE CANARIAS, S.A.
+0010D6|Exelis
+0010D7|ARGOSY RESEARCH INC.
+0010D8|CALISTA
+0010D9|IBM JAPAN, FUJISAWA MT+D
+0010DA|Kollmorgen Corp
+0010DB|Juniper Networks, Inc.
+0010DC|MICRO-STAR INTERNATIONAL CO., LTD.
+0010DD|ENABLE SEMICONDUCTOR, INC.
+0010DE|INTERNATIONAL DATACASTING CORPORATION
+0010DF|RISE COMPUTER INC.
+0010E0|Oracle Corporation
+0010E1|S.I. TECH, INC.
+0010E2|ArrayComm, Inc.
+0010E3|Hewlett-Packard Company
+0010E4|NSI CORPORATION
+0010E5|SOLECTRON TEXAS
+0010E6|APPLIED INTELLIGENT SYSTEMS, INC.
+0010E7|BreezeCom
+0010E8|TELOCITY, INCORPORATED
+0010E9|RAIDTEC LTD.
+0010EA|ADEPT TECHNOLOGY
+0010EB|SELSIUS SYSTEMS, INC.
+0010EC|RPCG, LLC
+0010ED|SUNDANCE TECHNOLOGY, INC.
+0010EE|CTI PRODUCTS, INC.
+0010EF|DBTEL INCORPORATED
+0010F0|RITTAL-WERK RUDOLF LOH GmbH & Co.
+0010F1|I-O CORPORATION
+0010F2|ANTEC
+0010F3|Nexcom International Co., Ltd.
+0010F4|Vertical Communications
+0010F5|AMHERST SYSTEMS, INC.
+0010F6|Cisco
+0010F7|IRIICHI TECHNOLOGIES Inc.
+0010F8|TEXIO TECHNOLOGY CORPORATION
+0010F9|UNIQUE SYSTEMS, INC.
+0010FA|Apple
+0010FB|ZIDA TECHNOLOGIES LIMITED
+0010FC|BROADBAND NETWORKS, INC.
+0010FD|COCOM A/S
+0010FE|DIGITAL EQUIPMENT CORPORATION
+0010FF|Cisco
+001100|Schneider Electric
+001101|CET Technologies Pte Ltd
+001102|Aurora Multimedia Corp.
+001103|kawamura electric inc.
+001104|TELEXY
+001105|Sunplus Technology Co., Ltd.
+001106|Siemens NV (Belgium)
+001107|RGB Networks Inc.
+001108|Orbital Data Corporation
+001109|Micro-Star International
+00110A|Hewlett-Packard Company
+00110B|Franklin Technology Systems
+00110C|Atmark Techno, Inc.
+00110D|SANBlaze Technology, Inc.
+00110E|Tsurusaki Sealand Transportation Co. Ltd.
+00110F|netplat,Inc.
+001110|Maxanna Technology Co., Ltd.
+001111|Intel Corporate
+001112|Honeywell CMSS
+001113|Fraunhofer FOKUS
+001114|EverFocus Electronics Corp.
+001115|EPIN Technologies, Inc.
+001116|COTEAU VERT CO., LTD.
+001117|CESNET
+001118|BLX IC Design Corp., Ltd.
+001119|Solteras, Inc.
+00111A|ARRIS Group, Inc.
+00111B|Targa Systems Div L-3 Communications Canada
+00111C|Pleora Technologies Inc.
+00111D|Hectrix Limited
+00111E|EPSG (Ethernet Powerlink Standardization Group)
+00111F|Doremi Labs, Inc.
+001120|Cisco
+001121|Cisco
+001122|CIMSYS Inc
+001123|Appointech, Inc.
+001124|Apple
+001125|IBM Corp
+001126|Venstar Inc.
+001127|TASI, Inc
+001128|Streamit
+001129|Paradise Datacom Ltd.
+00112A|Niko NV
+00112B|NetModule AG
+00112C|IZT GmbH
+00112D|iPulse Systems
+00112E|CEICOM
+00112F|ASUSTek Computer Inc.
+001130|Allied Telesis (Hong Kong) Ltd.
+001131|UNATECH. CO.,LTD
+001132|Synology Incorporated
+001133|Siemens Austria SIMEA
+001134|MediaCell, Inc.
+001135|Grandeye Ltd
+001136|Goodrich Sensor Systems
+001137|AICHI ELECTRIC CO., LTD.
+001138|TAISHIN CO., LTD.
+001139|STOEBER ANTRIEBSTECHNIK GmbH + Co. KG.
+00113A|SHINBORAM
+00113B|Micronet Communications Inc.
+00113C|Micronas GmbH
+00113D|KN SOLTEC CO.,LTD.
+00113E|JL Corporation
+00113F|Alcatel DI
+001140|Nanometrics Inc.
+001141|GoodMan Corporation
+001142|e-SMARTCOM  INC.
+001143|Dell Inc
+001144|Assurance Technology Corp
+001145|ValuePoint Networks
+001146|Telecard-Pribor Ltd
+001147|Secom-Industry co.LTD.
+001148|Prolon Control Systems
+001149|Proliphix Inc.
+00114A|KAYABA INDUSTRY Co,.Ltd.
+00114B|Francotyp-Postalia GmbH
+00114C|caffeina applied research ltd.
+00114D|Atsumi Electric Co.,LTD.
+00114E|690885 Ontario Inc.
+00114F|US Digital Television, Inc
+001150|Belkin Corporation
+001151|Mykotronx
+001152|Eidsvoll Electronics AS
+001153|Trident Tek, Inc.
+001154|Webpro Technologies Inc.
+001155|Sevis Systems
+001156|Pharos Systems NZ
+001157|OF Networks Co., Ltd.
+001158|Nortel Networks
+001159|MATISSE NETWORKS INC
+00115A|Ivoclar Vivadent AG
+00115B|Elitegroup Computer System Co. (ECS)
+00115C|Cisco
+00115D|Cisco
+00115E|ProMinent Dosiertechnik GmbH
+00115F|ITX Security Co., Ltd.
+001160|ARTDIO Company Co., LTD
+001161|NetStreams, LLC
+001162|STAR MICRONICS CO.,LTD.
+001163|SYSTEM SPA DEPT. ELECTRONICS
+001164|ACARD Technology Corp.
+001165|Znyx Networks
+001166|Taelim Electronics Co., Ltd.
+001167|Integrated System Solution Corp.
+001168|HomeLogic LLC
+001169|EMS Satcom
+00116A|Domo Ltd
+00116B|Digital Data Communications Asia Co.,Ltd
+00116C|Nanwang Multimedia Inc.,Ltd
+00116D|American Time and Signal
+00116E|PePLink Ltd.
+00116F|Netforyou Co., LTD.
+001170|GSC SRL
+001171|DEXTER Communications, Inc.
+001172|COTRON CORPORATION
+001173|SMART Storage Systems
+001174|Wibhu Technologies, Inc.
+001175|Intel Corporate
+001176|Intellambda Systems, Inc.
+001177|Coaxial Networks, Inc.
+001178|Chiron Technology Ltd
+001179|Singular Technology Co. Ltd.
+00117A|Singim International Corp.
+00117B|Buchi  Labortechnik AG
+00117C|e-zy.net
+00117D|ZMD America, Inc.
+00117E|Progeny, A division of Midmark Corp
+00117F|Neotune Information Technology Corporation,.LTD
+001180|ARRIS Group, Inc.
+001181|InterEnergy Co.Ltd,
+001182|IMI Norgren Ltd
+001183|Datalogic ADC, Inc.
+001184|Humo Laboratory,Ltd.
+001185|Hewlett-Packard Company
+001186|Prime Systems, Inc.
+001187|Category Solutions, Inc
+001188|Enterasys
+001189|Aerotech Inc
+00118A|Viewtran Technology Limited
+00118B|Alcatel-Lucent, Enterprise Business Group
+00118C|Missouri Department of Transportation
+00118D|Hanchang System Corp.
+00118E|Halytech Mace
+00118F|EUTECH INSTRUMENTS PTE. LTD.
+001190|Digital Design Corporation
+001191|CTS-Clima Temperatur Systeme GmbH
+001192|Cisco
+001193|Cisco
+001194|Chi Mei Communication Systems, Inc.
+001195|D-Link Corporation
+001196|Actuality Systems, Inc.
+001197|Monitoring Technologies Limited
+001198|Prism Media Products Limited
+001199|2wcom Systems GmbH
+00119A|Alkeria srl
+00119B|Telesynergy Research Inc.
+00119C|EP&T Energy
+00119D|Diginfo Technology Corporation
+00119E|Solectron Brazil
+00119F|Nokia Danmark A/S
+0011A0|Vtech Engineering Canada Ltd
+0011A1|VISION NETWARE CO.,LTD
+0011A2|Manufacturing Technology Inc
+0011A3|LanReady Technologies Inc.
+0011A4|JStream Technologies Inc.
+0011A5|Fortuna Electronic Corp.
+0011A6|Sypixx Networks
+0011A7|Infilco Degremont Inc.
+0011A8|Quest Technologies
+0011A9|MOIMSTONE Co., LTD
+0011AA|Uniclass Technology, Co., LTD
+0011AB|TRUSTABLE TECHNOLOGY CO.,LTD.
+0011AC|Simtec Electronics
+0011AD|Shanghai Ruijie Technology
+0011AE|ARRIS Group, Inc.
+0011AF|Medialink-i,Inc
+0011B0|Fortelink Inc.
+0011B1|BlueExpert Technology Corp.
+0011B2|2001 Technology Inc.
+0011B3|YOSHIMIYA CO.,LTD.
+0011B4|Westermo Teleindustri AB
+0011B5|Shenzhen Powercom Co.,Ltd
+0011B6|Open Systems International
+0011B7|Octalix B.V.
+0011B8|Liebherr - Elektronik GmbH
+0011B9|Inner Range Pty. Ltd.
+0011BA|Elexol Pty Ltd
+0011BB|Cisco
+0011BC|Cisco
+0011BD|Bombardier Transportation
+0011BE|AGP Telecom Co. Ltd
+0011BF|AESYS S.p.A.
+0011C0|Aday Technology Inc
+0011C1|4P MOBILE DATA PROCESSING
+0011C2|United Fiber Optic Communication
+0011C3|Transceiving System Technology Corporation
+0011C4|Terminales de Telecomunicacion Terrestre, S.L.
+0011C5|TEN Technology
+0011C6|Seagate Technology
+0011C7|Raymarine UK Ltd
+0011C8|Powercom Co., Ltd.
+0011C9|MTT Corporation
+0011CA|Long Range Systems, Inc.
+0011CB|Jacobsons AB
+0011CC|Guangzhou Jinpeng Group Co.,Ltd.
+0011CD|Axsun Technologies
+0011CE|Ubisense Limited
+0011CF|Thrane & Thrane A/S
+0011D0|Tandberg Data ASA
+0011D1|Soft Imaging System GmbH
+0011D2|Perception Digital Ltd
+0011D3|NextGenTel Holding ASA
+0011D4|NetEnrich, Inc
+0011D5|Hangzhou Sunyard System Engineering Co.,Ltd.
+0011D6|HandEra, Inc.
+0011D7|eWerks Inc
+0011D8|ASUSTek Computer Inc.
+0011D9|TiVo
+0011DA|Vivaas Technology Inc.
+0011DB|Land-Cellular Corporation
+0011DC|Glunz & Jensen
+0011DD|FROMUS TEC. Co., Ltd.
+0011DE|EURILOGIC
+0011DF|Current Energy
+0011E0|U-MEDIA Communications, Inc.
+0011E1|Arcelik A.S
+0011E2|Hua Jung Components Co., Ltd.
+0011E3|Thomson, Inc.
+0011E4|Danelec Electronics A/S
+0011E5|KCodes Corporation
+0011E6|Scientific Atlanta
+0011E7|WORLDSAT - Texas de France
+0011E8|Tixi.Com
+0011E9|STARNEX CO., LTD.
+0011EA|IWICS Inc.
+0011EB|Innovative Integration
+0011EC|AVIX INC.
+0011ED|802 Global
+0011EE|Estari, Inc.
+0011EF|Conitec Datensysteme GmbH
+0011F0|Wideful Limited
+0011F1|QinetiQ Ltd
+0011F2|Institute of Network Technologies
+0011F3|NeoMedia Europe AG
+0011F4|woori-net
+0011F5|ASKEY COMPUTER CORP.
+0011F6|Asia Pacific Microsystems , Inc.
+0011F7|Shenzhen Forward Industry Co., Ltd
+0011F8|AIRAYA Corp
+0011F9|Nortel Networks
+0011FA|Rane Corporation
+0011FB|Heidelberg Engineering GmbH
+0011FC|HARTING Electric Gmbh & Co.KG
+0011FD|KORG INC.
+0011FE|Keiyo System Research, Inc.
+0011FF|Digitro Tecnologia Ltda
+001200|Cisco
+001201|Cisco
+001202|Decrane Aerospace - Audio International Inc.
+001203|ActivNetworks
+001204|u10 Networks, Inc.
+001205|Terrasat Communications, Inc.
+001206|iQuest (NZ) Ltd
+001207|Head Strong International Limited
+001208|Gantner Instruments GmbH
+001209|Fastrax Ltd
+00120A|Emerson Climate Technologies GmbH
+00120B|Chinasys Technologies Limited
+00120C|CE-Infosys Pte Ltd
+00120D|Advanced Telecommunication Technologies, Inc.
+00120E|AboCom
+00120F|IEEE 802.3
+001210|WideRay Corp
+001211|Protechna Herbst GmbH & Co. KG
+001212|PLUS  Corporation
+001213|Metrohm AG
+001214|Koenig & Bauer AG
+001215|iStor Networks, Inc.
+001216|ICP Internet Communication Payment AG
+001217|Cisco
+001218|ARUZE Corporation
+001219|Ahead Communication Systems Inc
+00121A|Techno Soft Systemnics Inc.
+00121B|Sound Devices, LLC
+00121C|PARROT S.A.
+00121D|Netfabric Corporation
+00121E|Juniper Networks, Inc.
+00121F|Harding Instruments
+001220|Cadco Systems
+001221|B.Braun Melsungen AG
+001222|Skardin (UK) Ltd
+001223|Pixim
+001224|NexQL Corporation
+001225|ARRIS Group, Inc.
+001226|Japan Direx Corporation
+001227|Franklin Electric Co., Inc.
+001228|Data Ltd.
+001229|BroadEasy Technologies Co.,Ltd
+00122A|VTech Telecommunications Ltd.
+00122B|Virbiage Pty Ltd
+00122C|Soenen Controls N.V.
+00122D|SiNett Corporation
+00122E|Signal Technology - AISD
+00122F|Sanei Electric Inc.
+001230|Picaso Infocommunication CO., LTD.
+001231|Motion Control Systems, Inc.
+001232|LeWiz Communications Inc.
+001233|JRC TOKKI Co.,Ltd.
+001234|Camille Bauer
+001235|Andrew Corporation
+001236|ConSentry Networks
+001237|Texas Instruments
+001238|SetaBox Technology Co., Ltd.
+001239|S Net Systems Inc.
+00123A|Posystech Inc., Co.
+00123B|KeRo Systems ApS
+00123C|Second Rule LLC
+00123D|GES Co, Ltd
+00123E|ERUNE technology Co., Ltd.
+00123F|Dell Inc
+001240|AMOI ELECTRONICS CO.,LTD
+001241|a2i marketing center
+001242|Millennial Net
+001243|Cisco
+001244|Cisco
+001245|Zellweger Analytics, Inc.
+001246|T.O.M TECHNOLOGY INC..
+001247|Samsung
+001248|EMC Corporation (Kashya)
+001249|Delta Elettronica S.p.A.
+00124A|Dedicated Devices, Inc.
+00124B|Texas Instruments
+00124C|BBWM Corporation
+00124D|Inducon BV
+00124E|XAC AUTOMATION CORP.
+00124F|Pentair Thermal Management
+001250|Tokyo Aircaft Instrument Co., Ltd.
+001251|SILINK
+001252|Citronix, LLC
+001253|AudioDev AB
+001254|Spectra Technologies Holdings Company Ltd
+001255|NetEffect Incorporated
+001256|LG INFORMATION & COMM.
+001257|LeapComm Communication Technologies Inc.
+001258|Activis Polska
+001259|THERMO ELECTRON KARLSRUHE
+00125A|Microsoft
+00125B|KAIMEI ELECTRONI
+00125C|Green Hills Software, Inc.
+00125D|CyberNet Inc.
+00125E|CAEN
+00125F|AWIND Inc.
+001260|Stanton Magnetics,inc.
+001261|Adaptix, Inc
+001262|Nokia Danmark A/S
+001263|Data Voice Technologies GmbH
+001264|daum electronic gmbh
+001265|Enerdyne Technologies, Inc.
+001266|Swisscom Hospitality Services SA
+001267|Panasonic Corporation
+001268|IPS d.o.o.
+001269|Value Electronics
+00126A|OPTOELECTRONICS Co., Ltd.
+00126B|Ascalade Communications Limited
+00126C|Visonic Ltd.
+00126D|University of California, Berkeley
+00126E|Seidel Elektronik GmbH Nfg.KG
+00126F|Rayson Technology Co., Ltd.
+001270|NGES Denro Systems
+001271|Measurement Computing Corp
+001272|Redux Communications Ltd.
+001273|Stoke Inc
+001274|NIT lab
+001275|Sentilla Corporation
+001276|CG Power Systems Ireland Limited
+001277|Korenix Technologies Co., Ltd.
+001278|International Bar Code
+001279|Hewlett-Packard Company
+00127A|Sanyu Industry Co.,Ltd.
+00127B|VIA Networking Technologies, Inc.
+00127C|SWEGON AB
+00127D|MobileAria
+00127E|Digital Lifestyles Group, Inc.
+00127F|Cisco
+001280|Cisco
+001281|March Networks S.p.A.
+001282|Qovia
+001283|Nortel Networks
+001284|Lab33 Srl
+001285|Gizmondo Europe Ltd
+001286|ENDEVCO CORP
+001287|Digital Everywhere Unterhaltungselektronik GmbH
+001288|2Wire, Inc
+001289|Advance Sterilization Products
+00128A|ARRIS Group, Inc.
+00128B|Sensory Networks Inc
+00128C|Woodward Governor
+00128D|STB Datenservice GmbH
+00128E|Q-Free ASA
+00128F|Montilio
+001290|KYOWA Electric & Machinery Corp.
+001291|KWS Computersysteme GmbH
+001292|Griffin Technology
+001293|GE Energy
+001294|SUMITOMO ELECTRIC DEVICE INNOVATIONS, INC
+001295|Aiware Inc.
+001296|Addlogix
+001297|O2Micro, Inc.
+001298|MICO ELECTRIC(SHENZHEN) LIMITED
+001299|Ktech Telecommunications Inc
+00129A|IRT Electronics Pty Ltd
+00129B|E2S Electronic Engineering Solutions, S.L.
+00129C|Yulinet
+00129D|First International Computer do Brasil
+00129E|Surf Communications Inc.
+00129F|RAE Systems
+0012A0|NeoMeridian Sdn Bhd
+0012A1|BluePacket Communications Co., Ltd.
+0012A2|VITA
+0012A3|Trust International B.V.
+0012A4|ThingMagic, LLC
+0012A5|Stargen, Inc.
+0012A6|Dolby Australia
+0012A7|ISR TECHNOLOGIES Inc
+0012A8|intec GmbH
+0012A9|3Com Ltd
+0012AA|IEE, Inc.
+0012AB|WiLife, Inc.
+0012AC|ONTIMETEK INC.
+0012AD|IDS GmbH
+0012AE|HLS HARD-LINE Solutions Inc.
+0012AF|ELPRO Technologies
+0012B0|Efore Oyj   (Plc)
+0012B1|Dai Nippon Printing Co., Ltd
+0012B2|AVOLITES LTD.
+0012B3|Advance Wireless Technology Corp.
+0012B4|Work Microwave GmbH
+0012B5|Vialta, Inc.
+0012B6|Santa Barbara Infrared, Inc.
+0012B7|PTW Freiburg
+0012B8|G2 Microsystems
+0012B9|Fusion Digital Technology
+0012BA|FSI Systems, Inc.
+0012BB|Telecommunications Industry Association TR-41 Committee
+0012BC|Echolab LLC
+0012BD|Avantec Manufacturing Limited
+0012BE|Astek Corporation
+0012BF|Arcadyan Technology Corporation
+0012C0|HotLava Systems, Inc.
+0012C1|Check Point Software Technologies
+0012C2|Apex Electronics Factory
+0012C3|WIT S.A.
+0012C4|Viseon, Inc.
+0012C5|V-Show  Technology (China) Co.,Ltd
+0012C6|TGC America, Inc
+0012C7|SECURAY Technologies Ltd.Co.
+0012C8|Perfect tech
+0012C9|ARRIS Group, Inc.
+0012CA|Mechatronic Brick Aps
+0012CB|CSS Inc.
+0012CC|Bitatek CO., LTD
+0012CD|ASEM SpA
+0012CE|Advanced Cybernetics Group
+0012CF|Accton Technology Corporation
+0012D0|Gossen-Metrawatt-GmbH
+0012D1|Texas Instruments Inc
+0012D2|Texas Instruments
+0012D3|Zetta Systems, Inc.
+0012D4|Princeton Technology, Ltd
+0012D5|Motion Reality Inc.
+0012D6|Jiangsu Yitong High-Tech Co.,Ltd
+0012D7|Invento Networks, Inc.
+0012D8|International Games System Co., Ltd.
+0012D9|Cisco
+0012DA|Cisco
+0012DB|ZIEHL industrie-elektronik GmbH + Co KG
+0012DC|SunCorp Industrial Limited
+0012DD|Shengqu Information Technology (Shanghai) Co., Ltd.
+0012DE|Radio Components Sweden AB
+0012DF|Novomatic AG
+0012E0|Codan Limited
+0012E1|Alliant Networks, Inc
+0012E2|ALAXALA Networks Corporation
+0012E3|Agat-RT, Ltd.
+0012E4|ZIEHL industrie-electronik GmbH + Co KG
+0012E5|Time America, Inc.
+0012E6|SPECTEC COMPUTER CO., LTD.
+0012E7|Projectek Networking Electronics Corp.
+0012E8|Fraunhofer IMS
+0012E9|Abbey Systems Ltd
+0012EA|Trane
+0012EB|PDH Solutions, LLC
+0012EC|Movacolor b.v.
+0012ED|AVG Advanced Technologies
+0012EE|Sony Ericsson Mobile Communications AB
+0012EF|OneAccess SA
+0012F0|Intel Corporate
+0012F1|IFOTEC
+0012F2|Brocade Communications Systems, Inc
+0012F3|connectBlue AB
+0012F4|Belco International Co.,Ltd.
+0012F5|Imarda New Zealand Limited
+0012F6|MDK CO.,LTD.
+0012F7|Xiamen Xinglian Electronics Co., Ltd.
+0012F8|WNI Resources, LLC
+0012F9|URYU SEISAKU, LTD.
+0012FA|THX LTD
+0012FB|Samsung
+0012FC|PLANET System Co.,LTD
+0012FD|OPTIMUS IC S.A.
+0012FE|Lenovo Mobile Communication Technology Ltd.
+0012FF|Lely Industries N.V.
+001300|IT-FACTORY, INC.
+001301|IronGate S.L.
+001302|Intel Corporate
+001303|GateConnect
+001304|Flaircomm Technologies Co. LTD
+001305|Epicom, Inc.
+001306|Always On Wireless
+001307|Paravirtual Corporation
+001308|Nuvera Fuel Cells
+001309|Ocean Broadband Networks
+00130A|Nortel
+00130B|Mextal B.V.
+00130C|HF System Corporation
+00130D|GALILEO AVIONICA
+00130E|Focusrite Audio Engineering Limited
+00130F|EGEMEN Bilgisayar Muh San ve Tic LTD STI
+001310|Cisco
+001311|ARRIS International
+001312|Amedia Networks Inc.
+001313|GuangZhou Post & Telecom Equipment ltd
+001314|Asiamajor Inc.
+001315|SONY Computer Entertainment inc,
+001316|L-S-B Broadcast Technologies GmbH
+001317|GN Netcom as
+001318|DGSTATION Co., Ltd.
+001319|Cisco
+00131A|Cisco
+00131B|BeCell Innovations Corp.
+00131C|LiteTouch, Inc.
+00131D|Scanvaegt International A/S
+00131E|Peiker acustic GmbH & Co. KG
+00131F|NxtPhase T&D, Corp.
+001320|Intel Corporate
+001321|Hewlett-Packard Company
+001322|DAQ Electronics, Inc.
+001323|Cap Co., Ltd.
+001324|Schneider Electric Ultra Terminal
+001325|Cortina Systems Inc
+001326|ECM Systems Ltd
+001327|Data Acquisitions limited
+001328|Westech Korea Inc.,
+001329|VSST Co., LTD
+00132A|Sitronics Telecom Solutions
+00132B|Phoenix Digital
+00132C|MAZ Brandenburg GmbH
+00132D|iWise Communications
+00132E|ITian Coporation
+00132F|Interactek
+001330|EURO PROTECTION SURVEILLANCE
+001331|CellPoint Connect
+001332|Beijing Topsec Network Security Technology Co., Ltd.
+001333|BaudTec Corporation
+001334|Arkados, Inc.
+001335|VS Industry Berhad
+001336|Tianjin 712 Communication Broadcasting co., ltd.
+001337|Orient Power Home Network Ltd.
+001338|FRESENIUS-VIAL
+001339|CCV Deutschland GmbH
+00133A|VadaTech Inc.
+00133B|Speed Dragon Multimedia Limited
+00133C|QUINTRON SYSTEMS INC.
+00133D|Micro Memory Curtiss Wright Co
+00133E|MetaSwitch
+00133F|Eppendorf Instrumente GmbH
+001340|AD.EL s.r.l.
+001341|Shandong New Beiyang Information Technology Co.,Ltd
+001342|Vision Research, Inc.
+001343|Matsushita Electronic Components (Europe) GmbH
+001344|Fargo Electronics Inc.
+001345|Eaton Corporation
+001346|D-Link Corporation
+001347|Red Lion Controls, LP
+001348|Artila Electronics Co., Ltd.
+001349|ZyXEL Communications Corporation
+00134A|Engim, Inc.
+00134B|ToGoldenNet Technology Inc.
+00134C|YDT Technology International
+00134D|Inepro BV
+00134E|Valox Systems, Inc.
+00134F|Tranzeo Wireless Technologies Inc.
+001350|Silver Spring Networks, Inc
+001351|Niles Audio Corporation
+001352|Naztec, Inc.
+001353|HYDAC Filtertechnik GMBH
+001354|Zcomax Technologies, Inc.
+001355|TOMEN Cyber-business Solutions, Inc.
+001356|FLIR Radiation Inc
+001357|Soyal Technology Co., Ltd.
+001358|Realm Systems, Inc.
+001359|ProTelevision Technologies A/S
+00135A|Project T&E Limited
+00135B|PanelLink Cinema, LLC
+00135C|OnSite Systems, Inc.
+00135D|NTTPC Communications, Inc.
+00135E|EAB/RWI/K
+00135F|Cisco
+001360|Cisco
+001361|Biospace Co., Ltd.
+001362|ShinHeung Precision Co., Ltd.
+001363|Verascape, Inc.
+001364|Paradigm Technology Inc..
+001365|Nortel
+001366|Neturity Technologies Inc.
+001367|Narayon. Co., Ltd.
+001368|Saab Danmark A/S
+001369|Honda Electron Co., LED.
+00136A|Hach Lange Sarl
+00136B|E-TEC
+00136C|TomTom
+00136D|Tentaculus AB
+00136E|Techmetro Corp.
+00136F|PacketMotion, Inc.
+001370|Nokia Danmark A/S
+001371|ARRIS Group, Inc.
+001372|Dell Inc
+001373|BLwave Electronics Co., Ltd
+001374|Atheros Communications, Inc.
+001375|American Security Products Co.
+001376|Tabor Electronics Ltd.
+001377|Samsung
+001378|Qsan Technology, Inc.
+001379|PONDER INFORMATION INDUSTRIES LTD.
+00137A|Netvox Technology Co., Ltd.
+00137B|Movon Corporation
+00137C|Kaicom co., Ltd.
+00137D|Dynalab, Inc.
+00137E|CorEdge Networks, Inc.
+00137F|Cisco
+001380|Cisco
+001381|CHIPS & Systems, Inc.
+001382|Cetacea Networks Corporation
+001383|Application Technologies and Engineering Research Laboratory
+001384|Advanced Motion Controls
+001385|Add-On Technology Co., LTD.
+001386|ABB Inc./Totalflow
+001387|27M Technologies AB
+001388|WiMedia Alliance
+001389|Redes de Telefonia Movil S.A.
+00138A|QINGDAO GOERTEK ELECTRONICS CO.,LTD.
+00138B|Phantom Technologies LLC
+00138C|Kumyoung.Co.Ltd
+00138D|Kinghold
+00138E|FOAB Elektronik AB
+00138F|Asiarock Incorporation
+001390|Termtek Computer Co., Ltd
+001391|OUEN CO.,LTD.
+001392|Ruckus Wireless
+001393|Panta Systems, Inc.
+001394|Infohand Co.,Ltd
+001395|congatec AG
+001396|Acbel Polytech Inc.
+001397|Oracle Corporation
+001398|TrafficSim Co.,Ltd
+001399|STAC Corporation.
+00139A|K-ubique ID Corp.
+00139B|ioIMAGE Ltd.
+00139C|Exavera Technologies, Inc.
+00139D|Marvell Hispana S.L.
+00139E|Ciara Technologies Inc.
+00139F|Electronics Design Services, Co., Ltd.
+0013A0|ALGOSYSTEM Co., Ltd.
+0013A1|Crow Electronic Engeneering
+0013A2|MaxStream, Inc
+0013A3|Siemens Com CPE Devices
+0013A4|KeyEye Communications
+0013A5|General Solutions, LTD.
+0013A6|Extricom Ltd
+0013A7|BATTELLE MEMORIAL INSTITUTE
+0013A8|Tanisys Technology
+0013A9|Sony Corporation
+0013AA|ALS  & TEC Ltd.
+0013AB|Telemotive AG
+0013AC|Sunmyung Electronics Co., LTD
+0013AD|Sendo Ltd
+0013AE|Radiance Technologies, Inc.
+0013AF|NUMA Technology,Inc.
+0013B0|Jablotron
+0013B1|Intelligent Control Systems (Asia) Pte Ltd
+0013B2|Carallon Limited
+0013B3|Ecom Communications Technology Co., Ltd.
+0013B4|Appear TV
+0013B5|Wavesat
+0013B6|Sling Media, Inc.
+0013B7|Scantech ID
+0013B8|RyCo Electronic Systems Limited
+0013B9|BM SPA
+0013BA|ReadyLinks Inc
+0013BB|Smartvue Corporation
+0013BC|Artimi Ltd
+0013BD|HYMATOM SA
+0013BE|Virtual Conexions
+0013BF|Media System Planning Corp.
+0013C0|Trix Tecnologia Ltda.
+0013C1|Asoka USA Corporation
+0013C2|WACOM Co.,Ltd
+0013C3|Cisco
+0013C4|Cisco
+0013C5|LIGHTRON FIBER-OPTIC DEVICES INC.
+0013C6|OpenGear, Inc
+0013C7|IONOS Co.,Ltd.
+0013C8|ADB Broadband Italia
+0013C9|Beyond Achieve Enterprises Ltd.
+0013CA|Pico Digital
+0013CB|Zenitel Norway AS
+0013CC|Tall Maple Systems
+0013CD|MTI co. LTD
+0013CE|Intel Corporate
+0013CF|4Access Communications
+0013D0|t+ Medical Ltd
+0013D1|KIRK telecom A/S
+0013D2|PAGE IBERICA, S.A.
+0013D3|MICRO-STAR INTERNATIONAL CO., LTD.
+0013D4|ASUSTek COMPUTER INC.
+0013D5|RuggedCom
+0013D6|TII NETWORK TECHNOLOGIES, INC.
+0013D7|SPIDCOM Technologies SA
+0013D8|Princeton Instruments
+0013D9|Matrix Product Development, Inc.
+0013DA|Diskware Co., Ltd
+0013DB|SHOEI Electric Co.,Ltd
+0013DC|IBTEK INC.
+0013DD|Abbott Diagnostics
+0013DE|Adapt4, LLC
+0013DF|Ryvor Corp.
+0013E0|Murata Manufacturing Co., Ltd.
+0013E1|Iprobe AB
+0013E2|GeoVision Inc.
+0013E3|CoVi Technologies, Inc.
+0013E4|YANGJAE SYSTEMS CORP.
+0013E5|TENOSYS, INC.
+0013E6|Technolution
+0013E7|Halcro
+0013E8|Intel Corporate
+0013E9|VeriWave, Inc.
+0013EA|Kamstrup A/S
+0013EB|Sysmaster Corporation
+0013EC|Netsnapper Technologies SARL
+0013ED|PSIA
+0013EE|JBX Designs Inc.
+0013EF|Kingjon Digital Technology Co.,Ltd
+0013F0|Wavefront Semiconductor
+0013F1|AMOD Technology Co., Ltd.
+0013F2|Klas Ltd
+0013F3|Giga-byte Communications Inc.
+0013F4|Psitek (Pty) Ltd
+0013F5|Akimbi Systems
+0013F6|Cintech
+0013F7|SMC Networks, Inc.
+0013F8|Dex Security Solutions
+0013F9|Cavera Systems
+0013FA|LifeSize Communications, Inc
+0013FB|RKC INSTRUMENT INC.
+0013FC|SiCortex, Inc
+0013FD|Nokia Danmark A/S
+0013FE|GRANDTEC ELECTRONIC CORP.
+0013FF|Dage-MTI of MC, Inc.
+001400|MINERVA KOREA CO., LTD
+001401|Rivertree Networks Corp.
+001402|kk-electronic a/s
+001403|Renasis, LLC
+001404|ARRIS Group, Inc.
+001405|OpenIB, Inc.
+001406|Go Networks
+001407|Sperian Protection Instrumentation
+001408|Eka Systems Inc.
+001409|MAGNETI MARELLI   S.E. S.p.A.
+00140A|WEPIO Co., Ltd.
+00140B|FIRST INTERNATIONAL COMPUTER, INC.
+00140C|GKB CCTV CO., LTD.
+00140D|Nortel
+00140E|Nortel
+00140F|Federal State Unitary Enterprise Leningrad R&D Institute of
+001410|Suzhou Keda Technology CO.,Ltd
+001411|Deutschmann Automation GmbH & Co. KG
+001412|S-TEC electronics AG
+001413|Trebing & Himstedt ProzeBautomation GmbH & Co. KG
+001414|Jumpnode Systems LLC.
+001415|Intec Automation Inc.
+001416|Scosche Industries, Inc.
+001417|RSE Informations Technologie GmbH
+001418|C4Line
+001419|SIDSA
+00141A|DEICY CORPORATION
+00141B|Cisco
+00141C|Cisco
+00141D|LTi DRIVES GmbH
+00141E|P.A. Semi, Inc.
+00141F|SunKwang Electronics Co., Ltd
+001420|G-Links networking company
+001421|Total Wireless Technologies Pte. Ltd.
+001422|Dell Inc
+001423|J-S Co. NEUROCOM
+001424|Merry Electrics CO., LTD.
+001425|Galactic Computing Corp.
+001426|NL Technology
+001427|JazzMutant
+001428|Vocollect, Inc
+001429|V Center Technologies Co., Ltd.
+00142A|Elitegroup Computer System Co., Ltd
+00142B|Edata Communication Inc.
+00142C|Koncept International, Inc.
+00142D|Toradex AG
+00142E|77 Elektronika Kft.
+00142F|WildPackets
+001430|ViPowER, Inc
+001431|PDL Electronics Ltd
+001432|Tarallax Wireless, Inc.
+001433|Empower Technologies(Canada) Inc.
+001434|Keri Systems, Inc
+001435|CityCom Corp.
+001436|Qwerty Elektronik AB
+001437|GSTeletech Co.,Ltd.
+001438|Hewlett-Packard Company
+001439|Blonder Tongue Laboratories, Inc.
+00143A|RAYTALK INTERNATIONAL SRL
+00143B|Sensovation AG
+00143C|Rheinmetall Canada Inc.
+00143D|Aevoe Inc.
+00143E|AirLink Communications, Inc.
+00143F|Hotway Technology Corporation
+001440|ATOMIC Corporation
+001441|Innovation Sound Technology Co., LTD.
+001442|ATTO CORPORATION
+001443|Consultronics Europe Ltd
+001444|Grundfos Holding
+001445|Telefon-Gradnja d.o.o.
+001446|SuperVision Solutions LLC
+001447|BOAZ Inc.
+001448|Inventec Multimedia & Telecom Corporation
+001449|Sichuan Changhong Electric Ltd.
+00144A|Taiwan Thick-Film Ind. Corp.
+00144B|Hifn, Inc.
+00144C|General Meters Corp.
+00144D|Intelligent Systems
+00144E|SRISA
+00144F|Oracle Corporation
+001450|Heim Systems GmbH
+001451|Apple
+001452|CALCULEX,INC.
+001453|ADVANTECH TECHNOLOGIES CO.,LTD
+001454|Symwave
+001455|Coder Electronics Corporation
+001456|Edge Products
+001457|T-VIPS AS
+001458|HS Automatic ApS
+001459|Moram Co., Ltd.
+00145A|Neratec Solutions AG
+00145B|SeekerNet Inc.
+00145C|Intronics B.V.
+00145D|WJ Communications, Inc.
+00145E|IBM Corp
+00145F|ADITEC CO. LTD
+001460|Kyocera Wireless Corp.
+001461|CORONA CORPORATION
+001462|Digiwell Technology, inc
+001463|IDCS N.V.
+001464|Cryptosoft
+001465|Novo Nordisk A/S
+001466|Kleinhenz Elektronik GmbH
+001467|ArrowSpan Inc.
+001468|CelPlan International, Inc.
+001469|Cisco
+00146A|Cisco
+00146B|Anagran, Inc.
+00146C|Netgear
+00146D|RF Technologies
+00146E|H. Stoll GmbH & Co. KG
+00146F|Kohler Co
+001470|Prokom Software SA
+001471|Eastern Asia Technology Limited
+001472|China Broadband Wireless IP Standard Group
+001473|Bookham Inc
+001474|K40 Electronics
+001475|Wiline Networks, Inc.
+001476|MultiCom Industries Limited
+001477|Nertec  Inc.
+001478|ShenZhen TP-LINK Technologies Co., Ltd.
+001479|NEC Magnus Communications,Ltd.
+00147A|Eubus GmbH
+00147B|Iteris, Inc.
+00147C|3Com Ltd
+00147D|Aeon Digital International
+00147E|InnerWireless
+00147F|Thomson Telecom Belgium
+001480|Hitachi-LG Data Storage Korea, Inc
+001481|Multilink Inc
+001482|Aurora Networks
+001483|eXS Inc.
+001484|Cermate Technologies Inc.
+001485|Giga-Byte
+001486|Echo Digital Audio Corporation
+001487|American Technology Integrators
+001488|Akorri
+001489|B15402100 - JANDEI, S.L.
+00148A|Elin Ebg Traction Gmbh
+00148B|Globo Electronic GmbH & Co. KG
+00148C|Fortress Technologies
+00148D|Cubic Defense Simulation Systems
+00148E|Tele Power Inc.
+00148F|Protronic (Far East) Ltd.
+001490|ASP Corporation
+001491|Daniels Electronics Ltd. dbo Codan Rado Communications
+001492|Liteon, Mobile Media Solution SBU
+001493|Systimax Solutions
+001494|ESU AG
+001495|2Wire, Inc.
+001496|Phonic Corp.
+001497|ZHIYUAN Eletronics co.,ltd.
+001498|Viking Design Technology
+001499|Helicomm Inc
+00149A|ARRIS Group, Inc.
+00149B|Nokota Communications, LLC
+00149C|HF Company
+00149D|Sound ID Inc.
+00149E|UbONE Co., Ltd
+00149F|System and Chips, Inc.
+0014A0|Accsense, Inc.
+0014A1|Synchronous Communication Corp
+0014A2|Core Micro Systems Inc.
+0014A3|Vitelec BV
+0014A4|Hon Hai Precision Ind. Co., Ltd.
+0014A5|Gemtek Technology Co., Ltd.
+0014A6|Teranetics, Inc.
+0014A7|Nokia Danmark A/S
+0014A8|Cisco
+0014A9|Cisco
+0014AA|Ashly Audio, Inc.
+0014AB|Senhai Electronic Technology Co., Ltd.
+0014AC|Bountiful WiFi
+0014AD|Gassner Wiege- und MeBtechnik GmbH
+0014AE|Wizlogics Co., Ltd.
+0014AF|Datasym POS Inc.
+0014B0|Naeil Community
+0014B1|Axell Wireless Limited
+0014B2|mCubelogics Corporation
+0014B3|CoreStar International Corp
+0014B4|General Dynamics United Kingdom Ltd
+0014B5|PHYSIOMETRIX,INC
+0014B6|Enswer Technology Inc.
+0014B7|AR Infotek Inc.
+0014B8|Hill-Rom
+0014B9|MSTAR SEMICONDUCTOR
+0014BA|Carvers SA de CV
+0014BB|Open Interface North America
+0014BC|SYNECTIC TELECOM EXPORTS PVT. LTD.
+0014BD|incNETWORKS, Inc
+0014BE|Wink communication technology CO.LTD
+0014BF|Cisco
+0014C0|Symstream Technology Group Ltd
+0014C1|U.S. Robotics Corporation
+0014C2|Hewlett-Packard Company
+0014C3|Seagate Technology
+0014C4|Vitelcom Mobile Technology
+0014C5|Alive Technologies Pty Ltd
+0014C6|Quixant Ltd
+0014C7|Nortel
+0014C8|Contemporary Research Corp
+0014C9|Brocade Communications Systems, Inc.
+0014CA|Key Radio Systems Limited
+0014CB|LifeSync Corporation
+0014CC|Zetec, Inc.
+0014CD|DigitalZone Co., Ltd.
+0014CE|NF CORPORATION
+0014CF|INVISIO Communications
+0014D0|BTI Systems Inc.
+0014D1|TRENDnet
+0014D2|Kyuden Technosystems Corporation
+0014D3|SEPSA
+0014D4|K Technology Corporation
+0014D5|Datang Telecom Technology CO. , LCD,Optical Communication Br
+0014D6|Jeongmin Electronics Co.,Ltd.
+0014D7|Datastore Technology Corp
+0014D8|bio-logic SA
+0014D9|IP Fabrics, Inc.
+0014DA|Huntleigh Healthcare
+0014DB|Elma Trenew Electronic GmbH
+0014DC|Communication System Design & Manufacturing (CSDM)
+0014DD|Covergence Inc.
+0014DE|Sage Instruments Inc.
+0014DF|HI-P Tech Corporation
+0014E0|LET'S Corporation
+0014E1|Data Display AG
+0014E2|datacom systems inc.
+0014E3|mm-lab GmbH
+0014E4|infinias, LLC
+0014E5|Alticast
+0014E6|AIM Infrarotmodule GmbH
+0014E7|Stolinx,. Inc
+0014E8|ARRIS Group, Inc.
+0014E9|Nortech International
+0014EA|S Digm Inc. (Safe Paradigm Inc.)
+0014EB|AwarePoint Corporation
+0014EC|Acro Telecom
+0014ED|Airak, Inc.
+0014EE|Western Digital Technologies, Inc.
+0014EF|TZero Technologies, Inc.
+0014F0|Business Security OL AB
+0014F1|Cisco
+0014F2|Cisco
+0014F3|ViXS Systems Inc
+0014F4|DekTec Digital Video B.V.
+0014F5|OSI Security Devices
+0014F6|Juniper Networks, Inc.
+0014F7|CREVIS Co., LTD
+0014F8|Scientific Atlanta
+0014F9|Vantage Controls
+0014FA|AsGa S.A.
+0014FB|Technical Solutions Inc.
+0014FC|Extandon, Inc.
+0014FD|Thecus Technology Corp.
+0014FE|Artech Electronics
+0014FF|Precise Automation, Inc.
+001500|Intel Corporate
+001501|LexBox
+001502|BETA tech
+001503|PROFIcomms s.r.o.
+001504|GAME PLUS CO., LTD.
+001505|Actiontec Electronics, Inc
+001506|Neo Photonics
+001507|Renaissance Learning Inc
+001508|Global Target Enterprise Inc
+001509|Plus Technology Co., Ltd
+00150A|Sonoa Systems, Inc
+00150B|SAGE INFOTECH LTD.
+00150C|AVM GmbH
+00150D|Hoana Medical, Inc.
+00150E|OPENBRAIN TECHNOLOGIES CO., LTD.
+00150F|mingjong
+001510|Techsphere Co., Ltd
+001511|Data Center Systems
+001512|Zurich University of Applied Sciences
+001513|EFS sas
+001514|Hu Zhou NAVA Networks&Electronics Ltd.
+001515|Leipold+Co.GmbH
+001516|URIEL SYSTEMS INC.
+001517|Intel Corporate
+001518|Shenzhen 10MOONS Technology Development CO.,Ltd
+001519|StoreAge Networking Technologies
+00151A|Hunter Engineering Company
+00151B|Isilon Systems Inc.
+00151C|LENECO
+00151D|M2I CORPORATION
+00151E|Ethernet Powerlink Standardization Group (EPSG)
+00151F|Multivision Intelligent Surveillance (Hong Kong) Ltd
+001520|Radiocrafts AS
+001521|Horoquartz
+001522|Dea Security
+001523|Meteor Communications Corporation
+001524|Numatics, Inc.
+001525|Chamberlain Access Solutions
+001526|Remote Technologies Inc
+001527|Balboa Instruments
+001528|Beacon Medical Products LLC d.b.a. BeaconMedaes
+001529|N3 Corporation
+00152A|Nokia GmbH
+00152B|Cisco
+00152C|Cisco
+00152D|TenX Networks, LLC
+00152E|PacketHop, Inc.
+00152F|ARRIS Group, Inc.
+001530|EMC Corporation
+001531|KOCOM
+001532|Consumer Technologies Group, LLC
+001533|NADAM.CO.,LTD
+001534|A Beltronica-Companhia de Comunicacoes, Lda
+001535|OTE Spa
+001536|Powertech co., Ltd
+001537|Ventus Networks
+001538|RFID, Inc.
+001539|Technodrive SRL
+00153A|Shenzhen Syscan Technology Co.,Ltd.
+00153B|EMH metering GmbH & Co. KG
+00153C|Kprotech Co., Ltd.
+00153D|ELIM PRODUCT CO.
+00153E|Q-Matic Sweden AB
+00153F|Alcatel Alenia Space Italia
+001540|Nortel
+001541|StrataLight Communications, Inc.
+001542|MICROHARD S.R.L.
+001543|Aberdeen Test Center
+001544|coM.s.a.t. AG
+001545|SEECODE Co., Ltd.
+001546|ITG Worldwide Sdn Bhd
+001547|AiZen Solutions Inc.
+001548|CUBE TECHNOLOGIES
+001549|Dixtal Biomedica Ind. Com. Ltda
+00154A|WANSHIH ELECTRONIC CO., LTD
+00154B|Wonde Proud Technology Co., Ltd
+00154C|Saunders Electronics
+00154D|Netronome Systems, Inc.
+00154E|IEC
+00154F|one RF Technology
+001550|Nits Technology Inc
+001551|RadioPulse Inc.
+001552|Wi-Gear Inc.
+001553|Cytyc Corporation
+001554|Atalum Wireless S.A.
+001555|DFM GmbH
+001556|SAGEM COMMUNICATION
+001557|Olivetti
+001558|FOXCONN
+001559|Securaplane Technologies, Inc.
+00155A|DAINIPPON PHARMACEUTICAL CO., LTD.
+00155B|Sampo Corporation
+00155C|Dresser Wayne
+00155D|Microsoft
+00155E|Morgan Stanley
+00155F|GreenPeak Technologies
+001560|Hewlett-Packard Company
+001561|JJPlus Corporation
+001562|Cisco
+001563|Cisco
+001564|BEHRINGER Spezielle Studiotechnik GmbH
+001565|XIAMEN YEALINK NETWORK TECHNOLOGY CO.,LTD
+001566|A-First Technology Co., Ltd.
+001567|RADWIN Inc.
+001568|Dilithium Networks
+001569|PECO II, Inc.
+00156A|DG2L Technologies Pvt. Ltd.
+00156B|Perfisans Networks Corp.
+00156C|SANE SYSTEM CO., LTD
+00156D|Ubiquiti Networks
+00156E|A. W. Communication Systems Ltd
+00156F|Xiranet Communications GmbH
+001570|Zebra Technologies Inc
+001571|Nolan Systems
+001572|Red-Lemon
+001573|NewSoft  Technology Corporation
+001574|Horizon Semiconductors Ltd.
+001575|Nevis Networks Inc.
+001576|LABiTec - Labor Biomedical Technologies GmbH
+001577|Allied Telesis
+001578|Audio / Video Innovations
+001579|Lunatone Industrielle Elektronik GmbH
+00157A|Telefin S.p.A.
+00157B|Leuze electronic GmbH + Co. KG
+00157C|Dave Networks, Inc.
+00157D|POSDATA CO., LTD.
+00157E|Weidmuller Interface GmbH & Co. KG
+00157F|ChuanG International Holding CO.,LTD.
+001580|U-WAY CORPORATION
+001581|MAKUS Inc.
+001582|Pulse Eight Limited
+001583|IVT corporation
+001584|Schenck Process GmbH
+001585|Aonvision Technolopy Corp.
+001586|Xiamen Overseas Chinese Electronic Co., Ltd.
+001587|Takenaka Seisakusho Co.,Ltd
+001588|Salutica Allied Solutions Sdn Bhd
+001589|D-MAX Technology Co.,Ltd
+00158A|SURECOM Technology Corp.
+00158B|Park Air Systems Ltd
+00158C|Liab ApS
+00158D|Jennic Ltd
+00158E|Plustek.INC
+00158F|NTT Advanced Technology Corporation
+001590|Hectronic GmbH
+001591|RLW Inc.
+001592|Facom UK Ltd (Melksham)
+001593|U4EA Technologies Inc.
+001594|BIXOLON CO.,LTD
+001595|Quester Tangent Corporation
+001596|ARRIS International
+001597|AETA AUDIO SYSTEMS
+001598|Kolektor group
+001599|Samsung
+00159A|ARRIS Group, Inc.
+00159B|Nortel
+00159C|B-KYUNG SYSTEM Co.,Ltd.
+00159D|Tripp Lite
+00159E|Mad Catz Interactive Inc
+00159F|Terascala, Inc.
+0015A0|Nokia Danmark A/S
+0015A1|ECA-SINTERS
+0015A2|ARRIS International
+0015A3|ARRIS International
+0015A4|ARRIS International
+0015A5|DCI Co., Ltd.
+0015A6|Digital Electronics Products Ltd.
+0015A7|Robatech AG
+0015A8|ARRIS Group, Inc.
+0015A9|KWANG WOO I&C CO.,LTD
+0015AA|Rextechnik International Co.,
+0015AB|PRO CO SOUND INC
+0015AC|Capelon AB
+0015AD|Accedian Networks
+0015AE|kyung il
+0015AF|AzureWave Technologies, Inc.
+0015B0|AUTOTELENET CO.,LTD
+0015B1|Ambient Corporation
+0015B2|Advanced Industrial Computer, Inc.
+0015B3|Caretech AB
+0015B4|Polymap  Wireless LLC
+0015B5|CI Network Corp.
+0015B6|ShinMaywa Industries, Ltd.
+0015B7|Toshiba
+0015B8|Tahoe
+0015B9|Samsung
+0015BA|iba AG
+0015BB|SMA Solar Technology AG
+0015BC|Develco
+0015BD|Group 4 Technology Ltd
+0015BE|Iqua Ltd.
+0015BF|technicob
+0015C0|DIGITAL TELEMEDIA CO.,LTD.
+0015C1|SONY Computer Entertainment inc,
+0015C2|3M Germany
+0015C3|Ruf Telematik AG
+0015C4|FLOVEL CO., LTD.
+0015C5|Dell Inc
+0015C6|Cisco
+0015C7|Cisco
+0015C8|FlexiPanel Ltd
+0015C9|Gumstix, Inc
+0015CA|TeraRecon, Inc.
+0015CB|Surf Communication Solutions Ltd.
+0015CC|UQUEST, LTD.
+0015CD|Exartech International Corp.
+0015CE|ARRIS International
+0015CF|ARRIS International
+0015D0|ARRIS International
+0015D1|ARRIS Group, Inc.
+0015D2|Xantech Corporation
+0015D3|Pantech&Curitel Communications, Inc.
+0015D4|Emitor AB
+0015D5|NICEVT
+0015D6|OSLiNK Sp. z o.o.
+0015D7|Reti Corporation
+0015D8|Interlink Electronics
+0015D9|PKC Electronics Oy
+0015DA|IRITEL A.D.
+0015DB|Canesta Inc.
+0015DC|KT&C Co., Ltd.
+0015DD|IP Control Systems Ltd.
+0015DE|Nokia Danmark A/S
+0015DF|Clivet S.p.A.
+0015E0|Ericsson
+0015E1|Picochip Ltd
+0015E2|Dr.Ing. Herbert Knauer GmbH
+0015E3|Dream Technologies Corporation
+0015E4|Zimmer Elektromedizin
+0015E5|Cheertek Inc.
+0015E6|MOBILE TECHNIKA Inc.
+0015E7|Quantec Tontechnik
+0015E8|Nortel
+0015E9|D-Link Corporation
+0015EA|Tellumat (Pty) Ltd
+0015EB|ZTE CORPORATION
+0015EC|Boca Devices LLC
+0015ED|Fulcrum Microsystems, Inc.
+0015EE|Omnex Control Systems
+0015EF|NEC TOKIN Corporation
+0015F0|EGO BV
+0015F1|KYLINK Communications Corp.
+0015F2|ASUSTek COMPUTER INC.
+0015F3|PELTOR AB
+0015F4|Eventide
+0015F5|Sustainable Energy Systems
+0015F6|SCIENCE AND ENGINEERING SERVICES, INC.
+0015F7|Wintecronics Ltd.
+0015F8|Kingtronics Industrial Co. Ltd.
+0015F9|Cisco
+0015FA|Cisco
+0015FB|setex schermuly textile computer gmbh
+0015FC|Littelfuse Startco
+0015FD|Complete Media Systems
+0015FE|SCHILLING ROBOTICS LLC
+0015FF|Novatel Wireless, Inc.
+001600|CelleBrite Mobile Synchronization
+001601|Buffalo Inc.
+001602|CEYON TECHNOLOGY CO.,LTD.
+001603|COOLKSKY Co., LTD
+001604|Sigpro
+001605|YORKVILLE SOUND INC.
+001606|Ideal Industries
+001607|Curves International Inc.
+001608|Sequans Communications
+001609|Unitech electronics co., ltd.
+00160A|SWEEX Europe BV
+00160B|TVWorks LLC
+00160C|LPL  DEVELOPMENT S.A. DE C.V
+00160D|Be Here Corporation
+00160E|Optica Technologies Inc.
+00160F|BADGER METER INC
+001610|Carina Technology
+001611|Altecon Srl
+001612|Otsuka Electronics Co., Ltd.
+001613|LibreStream Technologies Inc.
+001614|Picosecond Pulse Labs
+001615|Nittan Company, Limited
+001616|BROWAN COMMUNICATION INC.
+001617|MSI
+001618|HIVION Co., Ltd.
+001619|Lancelan Technologies S.L.
+00161A|Dametric AB
+00161B|Micronet Corporation
+00161C|e:cue
+00161D|Innovative Wireless Technologies, Inc.
+00161E|Woojinnet
+00161F|SUNWAVETEC Co., Ltd.
+001620|Sony Ericsson Mobile Communications AB
+001621|Colorado Vnet
+001622|BBH SYSTEMS GMBH
+001623|Interval Media
+001624|Teneros, Inc.
+001625|Impinj, Inc.
+001626|ARRIS Group, Inc.
+001627|embedded-logic DESIGN AND MORE GmbH
+001628|Ultra Electronics Manufacturing and Card Systems
+001629|Nivus GmbH
+00162A|Antik computers & communications s.r.o.
+00162B|Togami Electric Mfg.co., Ltd.
+00162C|Xanboo
+00162D|STNet Co., Ltd.
+00162E|Space Shuttle Hi-Tech Co., Ltd.
+00162F|Geutebruck GmbH
+001630|Vativ Technologies
+001631|Xteam
+001632|Samsung
+001633|Oxford Diagnostics Ltd.
+001634|Mathtech, Inc.
+001635|Hewlett-Packard Company
+001636|Quanta Computer Inc.
+001637|CITEL SpA
+001638|TECOM Co., Ltd.
+001639|UBIQUAM Co.,Ltd
+00163A|YVES TECHNOLOGY CO., LTD.
+00163B|VertexRSI/General Dynamics
+00163C|Rebox B.V.
+00163D|Tsinghua Tongfang Legend Silicon Tech. Co., Ltd.
+00163E|Xensource, Inc.
+00163F|CReTE SYSTEMS Inc.
+001640|Asmobile Communication Inc.
+001641|Universal Global Scientific Industrial Co., Ltd.
+001642|Pangolin
+001643|Sunhillo Corporation
+001644|LITE-ON Technology Corp.
+001645|Power Distribution, Inc.
+001646|Cisco
+001647|Cisco
+001648|SSD Company Limited
+001649|SetOne GmbH
+00164A|Vibration Technology Limited
+00164B|Quorion Data Systems GmbH
+00164C|PLANET INT Co., Ltd
+00164D|Alcatel North America IP Division
+00164E|Nokia Danmark A/S
+00164F|World Ethnic Broadcastin Inc.
+001650|Herley General Microwave Israel.
+001651|Exeo Systems
+001652|Hoatech Technologies, Inc.
+001653|LEGO System A/S IE Electronics Division
+001654|Flex-P Industries Sdn. Bhd.
+001655|FUHO TECHNOLOGY Co., LTD
+001656|Nintendo Co., Ltd.
+001657|Aegate Ltd
+001658|Fusiontech Technologies Inc.
+001659|Z.M.P. RADWAG
+00165A|Harman Specialty Group
+00165B|Grip Audio
+00165C|Trackflow Ltd
+00165D|AirDefense, Inc.
+00165E|Precision I/O
+00165F|Fairmount Automation
+001660|Nortel
+001661|Novatium Solutions (P) Ltd
+001662|Liyuh Technology Ltd.
+001663|KBT Mobile
+001664|Prod-El SpA
+001665|Cellon France
+001666|Quantier Communication Inc.
+001667|A-TEC Subsystem INC.
+001668|Eishin Electronics
+001669|MRV Communication (Networks) LTD
+00166A|TPS
+00166B|Samsung
+00166C|Samsung
+00166D|Yulong Computer Telecommunication Scientific(shenzhen)Co.,Lt
+00166E|Arbitron Inc.
+00166F|Intel Corporate
+001670|SKNET Corporation
+001671|Symphox Information Co.
+001672|Zenway enterprise ltd
+001673|Bury GmbH & Co. KG
+001674|EuroCB (Phils.), Inc.
+001675|ARRIS Group, Inc.
+001676|Intel Corporate
+001677|Bihl + Wiedemann GmbH
+001678|SHENZHEN BAOAN GAOKE ELECTRONICS CO., LTD
+001679|eOn Communications
+00167A|Skyworth Overseas Dvelopment Ltd.
+00167B|Haver&Boecker
+00167C|iRex Technologies BV
+00167D|Sky-Line Information Co., Ltd.
+00167E|DIBOSS.CO.,LTD
+00167F|Bluebird Soft Inc.
+001680|Bally Gaming + Systems
+001681|Vector Informatik GmbH
+001682|Pro Dex, Inc
+001683|WEBIO International Co.,.Ltd.
+001684|Donjin Co.,Ltd.
+001685|Elisa Oyj
+001686|Karl Storz Imaging
+001687|Chubb CSC-Vendor AP
+001688|ServerEngines LLC
+001689|Pilkor Electronics Co., Ltd
+00168A|id-Confirm Inc
+00168B|Paralan Corporation
+00168C|DSL Partner AS
+00168D|KORWIN CO., Ltd.
+00168E|Vimicro corporation
+00168F|GN Netcom as
+001690|J-TEK INCORPORATION
+001691|Moser-Baer AG
+001692|Scientific-Atlanta, Inc.
+001693|PowerLink Technology Inc.
+001694|Sennheiser Communications A/S
+001695|AVC Technology (International) Limited
+001696|QDI Technology (H.K.) Limited
+001697|NEC Corporation
+001698|T&A Mobile Phones
+001699|Tonic DVB Marketing Ltd
+00169A|Quadrics Ltd
+00169B|Alstom Transport
+00169C|Cisco
+00169D|Cisco
+00169E|TV One Ltd
+00169F|Vimtron Electronics Co., Ltd.
+0016A0|Auto-Maskin
+0016A1|3Leaf Networks
+0016A2|CentraLite Systems, Inc.
+0016A3|Ingeteam Transmission&Distribution, S.A.
+0016A4|Ezurio Ltd
+0016A5|Tandberg Storage ASA
+0016A6|Dovado FZ-LLC
+0016A7|AWETA G&P
+0016A8|CWT CO., LTD.
+0016A9|2EI
+0016AA|Kei Communication Technology Inc.
+0016AB|Dansensor A/S
+0016AC|Toho Technology Corp.
+0016AD|BT-Links Company Limited
+0016AE|INVENTEL
+0016AF|Shenzhen Union Networks Equipment Co.,Ltd.
+0016B0|VK Corporation
+0016B1|KBS
+0016B2|DriveCam Inc
+0016B3|Photonicbridges (China) Co., Ltd.
+0016B4|ASSIGNED - PRIVATE REGISTRATION 
+0016B5|ARRIS Group, Inc.
+0016B6|Cisco
+0016B7|Seoul Commtech
+0016B8|Sony Ericsson Mobile Communications
+0016B9|ProCurve Networking
+0016BA|WEATHERNEWS INC.
+0016BB|Law-Chain Computer Technology Co Ltd
+0016BC|Nokia Danmark A/S
+0016BD|ATI Industrial Automation
+0016BE|INFRANET, Inc.
+0016BF|PaloDEx Group Oy
+0016C0|Semtech Corporation
+0016C1|Eleksen Ltd
+0016C2|Avtec Systems Inc
+0016C3|BA Systems Inc
+0016C4|SiRF Technology, Inc.
+0016C5|Shenzhen Xing Feng Industry Co.,Ltd
+0016C6|North Atlantic Industries
+0016C7|Cisco
+0016C8|Cisco
+0016C9|NAT Seattle, Inc.
+0016CA|Nortel
+0016CB|Apple
+0016CC|Xcute Mobile Corp.
+0016CD|HIJI HIGH-TECH CO., LTD.
+0016CE|Hon Hai Precision Ind. Co., Ltd.
+0016CF|Hon Hai Precision Ind. Co., Ltd.
+0016D0|ATech elektronika d.o.o.
+0016D1|ZAT a.s.
+0016D2|Caspian
+0016D3|Wistron Corporation
+0016D4|Compal Communications, Inc.
+0016D5|Synccom Co., Ltd
+0016D6|TDA Tech Pty Ltd
+0016D7|Sunways AG
+0016D8|Senea AB
+0016D9|NINGBO BIRD CO.,LTD.
+0016DA|Futronic Technology Co. Ltd.
+0016DB|Samsung
+0016DC|ARCHOS
+0016DD|Gigabeam Corporation
+0016DE|FAST Inc
+0016DF|Lundinova AB
+0016E0|3Com Ltd
+0016E1|SiliconStor, Inc.
+0016E2|American Fibertek, Inc.
+0016E3|ASKEY COMPUTER CORP.
+0016E4|VANGUARD SECURITY ENGINEERING CORP.
+0016E5|FORDLEY DEVELOPMENT LIMITED
+0016E6|GIGA-BYTE TECHNOLOGY CO.,LTD.
+0016E7|Dynamix Promotions Limited
+0016E8|Sigma Designs, Inc.
+0016E9|Tiba Medical Inc
+0016EA|Intel Corporate
+0016EB|Intel Corporate
+0016EC|Elitegroup Computer Systems Co., Ltd.
+0016ED|Digital Safety Technologies, Inc
+0016EE|RoyalDigital Inc.
+0016EF|Koko Fitness, Inc.
+0016F0|Dell
+0016F1|OmniSense, LLC
+0016F2|Dmobile System Co., Ltd.
+0016F3|CAST Information Co., Ltd
+0016F4|Eidicom Co., Ltd.
+0016F5|Dalian Golden Hualu Digital Technology Co.,Ltd
+0016F6|Video Products Group
+0016F7|L-3 Communications, Aviation Recorders
+0016F8|AVIQTECH TECHNOLOGY CO., LTD.
+0016F9|CETRTA POT, d.o.o., Kranj
+0016FA|ECI Telecom Ltd.
+0016FB|SHENZHEN MTC CO.,LTD.
+0016FC|TOHKEN CO.,LTD.
+0016FD|Jaty Electronics
+0016FE|Alps Electric Co., Ltd
+0016FF|Wamin Optocomm Mfg Corp
+001700|ARRIS Group, Inc.
+001701|KDE, Inc.
+001702|Osung Midicom Co., Ltd
+001703|MOSDAN Internation Co.,Ltd
+001704|Shinco Electronics Group Co.,Ltd
+001705|Methode Electronics
+001706|Techfaith Wireless Communication Technology Limited.
+001707|InGrid, Inc
+001708|Hewlett-Packard Company
+001709|Exalt Communications
+00170A|INEW DIGITAL COMPANY
+00170B|Contela, Inc.
+00170C|Twig Com Ltd.
+00170D|Dust Networks Inc.
+00170E|Cisco
+00170F|Cisco
+001710|Casa Systems Inc.
+001711|GE Healthcare Bio-Sciences AB
+001712|ISCO International
+001713|Tiger NetCom
+001714|BR Controls Nederland bv
+001715|Qstik
+001716|Qno Technology Inc.
+001717|Leica Geosystems AG
+001718|Vansco Electronics Oy
+001719|AudioCodes USA, Inc
+00171A|Winegard Company
+00171B|Innovation Lab Corp.
+00171C|NT MicroSystems, Inc.
+00171D|DIGIT
+00171E|Theo Benning GmbH & Co. KG
+00171F|IMV Corporation
+001720|Image Sensing Systems, Inc.
+001721|FITRE S.p.A.
+001722|Hanazeder Electronic GmbH
+001723|Summit Data Communications
+001724|Studer Professional Audio GmbH
+001725|Liquid Computing
+001726|m2c Electronic Technology Ltd.
+001727|Thermo Ramsey Italia s.r.l.
+001728|Selex Communications
+001729|Ubicod Co.LTD
+00172A|Proware Technology Corp.(By Unifosa)
+00172B|Global Technologies Inc.
+00172C|TAEJIN INFOTECH
+00172D|Axcen Photonics Corporation
+00172E|FXC Inc.
+00172F|NeuLion Incorporated
+001730|Automation Electronics
+001731|ASUSTek COMPUTER INC.
+001732|Science-Technical Center "RISSA"
+001733|SFR
+001734|ADC Telecommunications
+001735|ASSIGNED - PRIVATE REGISTRATION 
+001736|iiTron Inc.
+001737|Industrie Dial Face S.p.A.
+001738|International Business Machines
+001739|Bright Headphone Electronics Company
+00173A|Reach Systems Inc.
+00173B|Cisco
+00173C|Extreme Engineering Solutions
+00173D|Neology
+00173E|LeucotronEquipamentos Ltda.
+00173F|Belkin Corporation
+001740|Bluberi Gaming Technologies Inc
+001741|DEFIDEV
+001742|FUJITSU LIMITED
+001743|Deck Srl
+001744|Araneo Ltd.
+001745|INNOTZ CO., Ltd
+001746|Freedom9 Inc.
+001747|Trimble
+001748|Neokoros Brasil Ltda
+001749|HYUNDAE YONG-O-SA CO.,LTD
+00174A|SOCOMEC
+00174B|Nokia Danmark A/S
+00174C|Millipore
+00174D|DYNAMIC NETWORK FACTORY, INC.
+00174E|Parama-tech Co.,Ltd.
+00174F|iCatch Inc.
+001750|GSI Group, MicroE Systems
+001751|Online Corporation
+001752|DAGS, Inc
+001753|nFore Technology Inc.
+001754|Arkino HiTOP Corporation Limited
+001755|GE Security
+001756|Vinci Labs Oy
+001757|RIX TECHNOLOGY LIMITED
+001758|ThruVision Ltd
+001759|Cisco
+00175A|Cisco
+00175B|ACS Solutions Switzerland Ltd.
+00175C|SHARP CORPORATION
+00175D|Dongseo system.
+00175E|Zed-3
+00175F|XENOLINK Communications Co., Ltd.
+001760|Naito Densei Machida MFG.CO.,LTD
+001761|ZKSoftware Inc. 
+001762|Solar Technology, Inc.
+001763|Essentia S.p.A.
+001764|ATMedia GmbH
+001765|Nortel
+001766|Accense Technology, Inc.
+001767|Earforce AS
+001768|Zinwave Ltd
+001769|Cymphonix Corp
+00176A|Avago Technologies
+00176B|Kiyon, Inc.
+00176C|Pivot3, Inc.
+00176D|CORE CORPORATION
+00176E|DUCATI SISTEMI
+00176F|PAX Computer Technology(Shenzhen) Ltd.
+001770|Arti Industrial Electronics Ltd.
+001771|APD Communications Ltd
+001772|ASTRO Strobel Kommunikationssysteme GmbH
+001773|Laketune Technologies Co. Ltd
+001774|Elesta GmbH
+001775|TTE Germany GmbH
+001776|Meso Scale Diagnostics, LLC
+001777|Obsidian Research Corporation
+001778|Central Music Co.
+001779|QuickTel
+00177A|ASSA ABLOY AB
+00177B|Azalea Networks inc
+00177C|Smartlink Network Systems Limited
+00177D|IDT International Limited
+00177E|Meshcom Technologies Inc.
+00177F|Worldsmart Retech
+001780|Applied Biosystems B.V.
+001781|Greystone Data System, Inc.
+001782|LoBenn Inc.
+001783|Texas Instruments
+001784|ARRIS Group, Inc.
+001785|Sparr Electronics Ltd
+001786|wisembed
+001787|Brother, Brother & Sons ApS
+001788|Philips Lighting BV
+001789|Zenitron Corporation
+00178A|DARTS TECHNOLOGIES CORP.
+00178B|Teledyne Technologies Incorporated
+00178C|Independent Witness, Inc
+00178D|Checkpoint Systems, Inc.
+00178E|Gunnebo Cash Automation AB
+00178F|NINGBO YIDONG ELECTRONIC CO.,LTD.
+001790|HYUNDAI DIGITECH Co, Ltd.
+001791|LinTech GmbH
+001792|Falcom Wireless Comunications Gmbh
+001793|Tigi Corporation
+001794|Cisco
+001795|Cisco
+001796|Rittmeyer AG
+001797|Telsy Elettronica S.p.A.
+001798|Azonic Technology Co., LTD
+001799|SmarTire Systems Inc.
+00179A|D-Link Corporation
+00179B|Chant Sincere CO., LTD.
+00179C|DEPRAG SCHULZ GMBH u. CO.
+00179D|Kelman Limited
+00179E|Sirit Inc
+00179F|Apricorn
+0017A0|RoboTech srl
+0017A1|3soft inc.
+0017A2|Camrivox Ltd.
+0017A3|MIX s.r.l.
+0017A4|Hewlett-Packard Company
+0017A5|Ralink Technology Corp
+0017A6|YOSIN ELECTRONICS CO., LTD.
+0017A7|Mobile Computing Promotion Consortium
+0017A8|EDM Corporation
+0017A9|Sentivision
+0017AA|elab-experience inc.
+0017AB|Nintendo Co., Ltd.
+0017AC|O'Neil Product Development Inc.
+0017AD|AceNet Corporation
+0017AE|GAI-Tronics
+0017AF|Enermet
+0017B0|Nokia Danmark A/S
+0017B1|ACIST Medical Systems, Inc.
+0017B2|SK Telesys
+0017B3|Aftek Infosys Limited
+0017B4|Remote Security Systems, LLC
+0017B5|Peerless Systems Corporation
+0017B6|Aquantia
+0017B7|Tonze Technology Co.
+0017B8|NOVATRON CO., LTD.
+0017B9|Gambro Lundia AB
+0017BA|SEDO CO., LTD.
+0017BB|Syrinx Industrial Electronics
+0017BC|Touchtunes Music Corporation
+0017BD|Tibetsystem
+0017BE|Tratec Telecom B.V.
+0017BF|Coherent Research Limited
+0017C0|PureTech Systems, Inc.
+0017C1|CM Precision Technology LTD.
+0017C2|ADB Broadband Italia
+0017C3|KTF Technologies Inc.
+0017C4|Quanta Microsystems, INC.
+0017C5|SonicWALL
+0017C6|Cross Match Technologies Inc
+0017C7|MARA Systems Consulting AB
+0017C8|KYOCERA Document Solutions Inc.
+0017C9|Samsung
+0017CA|Qisda Corporation
+0017CB|Juniper Networks
+0017CC|Alcatel-Lucent
+0017CD|CEC Wireless R&D Ltd.
+0017CE|Screen Service Spa
+0017CF|iMCA-GmbH
+0017D0|Opticom Communications, LLC
+0017D1|Nortel
+0017D2|THINLINX PTY LTD
+0017D3|Etymotic Research, Inc.
+0017D4|Monsoon Multimedia, Inc
+0017D5|Samsung
+0017D6|Bluechips Microhouse Co.,Ltd.
+0017D7|ION Geophysical Corporation Inc.
+0017D8|Magnum Semiconductor, Inc.
+0017D9|AAI Corporation
+0017DA|Spans Logic
+0017DB|CANKO TECHNOLOGIES INC.
+0017DC|DAEMYUNG ZERO1
+0017DD|Clipsal Australia
+0017DE|Advantage Six Ltd
+0017DF|Cisco
+0017E0|Cisco
+0017E1|DACOS Technologies Co., Ltd.
+0017E2|ARRIS Group, Inc.
+0017E3|Texas Instruments
+0017E4|Texas Instruments
+0017E5|Texas Instruments
+0017E6|Texas Instruments
+0017E7|Texas Instruments
+0017E8|Texas Instruments
+0017E9|Texas Instruments
+0017EA|Texas Instruments
+0017EB|Texas Instruments
+0017EC|Texas Instruments
+0017ED|WooJooIT Ltd.
+0017EE|ARRIS Group, Inc.
+0017EF|IBM Corp
+0017F0|SZCOM Broadband Network Technology Co.,Ltd
+0017F1|Renu Electronics Pvt Ltd
+0017F2|Apple
+0017F3|Harris Corparation
+0017F4|ZERON ALLIANCE
+0017F5|LIG NEOPTEK
+0017F6|Pyramid Meriden Inc.
+0017F7|CEM Solutions Pvt Ltd
+0017F8|Motech Industries Inc.
+0017F9|Forcom Sp. z o.o.
+0017FA|Microsoft
+0017FB|FA
+0017FC|Suprema Inc.
+0017FD|Amulet Hotkey
+0017FE|TALOS SYSTEM INC.
+0017FF|PLAYLINE Co.,Ltd.
+001800|UNIGRAND LTD
+001801|Actiontec Electronics, Inc
+001802|Alpha Networks Inc.
+001803|ArcSoft Shanghai Co. LTD
+001804|E-TEK DIGITAL TECHNOLOGY LIMITED
+001805|Beijing InHand Networking Technology Co.,Ltd.
+001806|Hokkei Industries Co., Ltd.
+001807|Fanstel Corp.
+001808|SightLogix, Inc.
+001809|CRESYN
+00180A|Meraki, Inc.
+00180B|Brilliant Telecommunications
+00180C|Optelian Access Networks
+00180D|Terabytes Server Storage Tech Corp
+00180E|Avega Systems
+00180F|Nokia Danmark A/S
+001810|IPTrade S.A.
+001811|Neuros Technology International, LLC.
+001812|Beijing Xinwei Telecom Technology Co., Ltd.
+001813|Sony Ericsson Mobile Communications
+001814|Mitutoyo Corporation
+001815|GZ Technologies, Inc.
+001816|Ubixon Co., Ltd.
+001817|D. E. Shaw Research, LLC
+001818|Cisco
+001819|Cisco
+00181A|AVerMedia Information Inc.
+00181B|TaiJin Metal Co., Ltd.
+00181C|Exterity Limited
+00181D|ASIA ELECTRONICS CO.,LTD
+00181E|GDX Technologies Ltd.
+00181F|Palmmicro Communications
+001820|w5networks
+001821|SINDORICOH
+001822|CEC TELECOM CO.,LTD.
+001823|Delta Electronics, Inc.
+001824|Kimaldi Electronics, S.L.
+001825|Wavion LTD 
+001826|Cale Access AB
+001827|NEC UNIFIED SOLUTIONS NEDERLAND B.V.
+001828|e2v technologies (UK) ltd.
+001829|Gatsometer
+00182A|Taiwan Video & Monitor
+00182B|Softier
+00182C|Ascend Networks, Inc.
+00182D|Artec Design
+00182E|XStreamHD, LLC
+00182F|Texas Instruments
+001830|Texas Instruments
+001831|Texas Instruments
+001832|Texas Instruments
+001833|Texas Instruments
+001834|Texas Instruments
+001835|Thoratec / ITC
+001836|Reliance Electric Limited
+001837|Universal ABIT Co., Ltd.
+001838|PanAccess Communications,Inc.
+001839|Cisco
+00183A|Westell Technologies
+00183B|CENITS Co., Ltd.
+00183C|Encore Software Limited
+00183D|Vertex Link Corporation
+00183E|Digilent, Inc
+00183F|2Wire, Inc
+001840|3 Phoenix, Inc.
+001841|High Tech Computer Corp
+001842|Nokia Danmark A/S
+001843|Dawevision Ltd
+001844|Heads Up Technologies, Inc.
+001845|Pulsar-Telecom LLC.
+001846|Crypto S.A.
+001847|AceNet Technology Inc.
+001848|Vecima Networks Inc.
+001849|Pigeon Point Systems LLC
+00184A|Catcher, Inc.
+00184B|Las Vegas Gaming, Inc.
+00184C|Bogen Communications
+00184D|Netgear
+00184E|Lianhe Technologies, Inc.
+00184F|8 Ways Technology Corp.
+001850|Secfone Kft
+001851|SWsoft
+001852|StorLink Semiconductors, Inc.
+001853|Atera Networks LTD.
+001854|Argard Co., Ltd
+001855|Aeromaritime Systembau GmbH
+001856|EyeFi, Inc
+001857|Unilever R&D
+001858|TagMaster AB
+001859|Strawberry Linux Co.,Ltd.
+00185A|uControl, Inc.
+00185B|Network Chemistry, Inc
+00185C|EDS Lab Pte Ltd
+00185D|TAIGUEN TECHNOLOGY (SHEN-ZHEN) CO., LTD.
+00185E|Nexterm Inc.
+00185F|TAC Inc.
+001860|SIM Technology Group Shanghai Simcom Ltd.,
+001861|Ooma, Inc.
+001862|Seagate Technology
+001863|Veritech Electronics Limited
+001864|Eaton Corporation
+001865|Siemens Healthcare Diagnostics Manufacturing Ltd
+001866|Leutron Vision
+001867|Datalogic ADC
+001868|Scientific Atlanta, A Cisco Company
+001869|KINGJIM
+00186A|Global Link Digital Technology Co,.LTD
+00186B|Sambu Communics CO., LTD.
+00186C|Neonode AB
+00186D|Zhenjiang Sapphire Electronic Industry CO.
+00186E|3Com Ltd
+00186F|Setha Industria Eletronica LTDA
+001870|E28 Shanghai Limited
+001871|Hewlett-Packard Company
+001872|Expertise Engineering
+001873|Cisco
+001874|Cisco
+001875|AnaCise Testnology Pte Ltd
+001876|WowWee Ltd.
+001877|Amplex A/S
+001878|Mackware GmbH
+001879|dSys
+00187A|Wiremold
+00187B|4NSYS Co. Ltd.
+00187C|INTERCROSS, LLC
+00187D|Armorlink shanghai Co. Ltd
+00187E|RGB Spectrum
+00187F|ZODIANET
+001880|Maxim Integrated Products
+001881|Buyang Electronics Industrial Co., Ltd
+001882|Huawei Technologies Co., Ltd.
+001883|FORMOSA21 INC.
+001884|Fon Technology S.L.
+001885|Avigilon Corporation
+001886|EL-TECH, INC.
+001887|Metasystem SpA
+001888|GOTIVE a.s.
+001889|WinNet Solutions Limited
+00188A|Infinova LLC
+00188B|Dell Inc
+00188C|Mobile Action Technology Inc.
+00188D|Nokia Danmark A/S
+00188E|Ekahau, Inc.
+00188F|Montgomery Technology, Inc.
+001890|RadioCOM, s.r.o.
+001891|Zhongshan General K-mate Electronics Co., Ltd
+001892|ads-tec GmbH
+001893|SHENZHEN PHOTON BROADBAND TECHNOLOGY CO.,LTD
+001894|NPCore, Inc.
+001895|Hansun Technologies Inc.
+001896|Great Well Electronic LTD
+001897|JESS-LINK PRODUCTS Co., LTD
+001898|KINGSTATE ELECTRONICS CORPORATION
+001899|ShenZhen jieshun Science&Technology Industry CO,LTD.
+00189A|HANA Micron Inc.
+00189B|Thomson Inc.
+00189C|Weldex Corporation
+00189D|Navcast Inc.
+00189E|OMNIKEY GmbH.
+00189F|Lenntek Corporation
+0018A0|Cierma Ascenseurs
+0018A1|Tiqit Computers, Inc.
+0018A2|XIP Technology AB
+0018A3|ZIPPY TECHNOLOGY CORP.
+0018A4|ARRIS Group, Inc.
+0018A5|ADigit Technologies Corp.
+0018A6|Persistent Systems, LLC
+0018A7|Yoggie Security Systems LTD.
+0018A8|AnNeal Technology Inc.
+0018A9|Ethernet Direct Corporation
+0018AA|Protec Fire Detection plc
+0018AB|BEIJING LHWT MICROELECTRONICS INC.
+0018AC|Shanghai Jiao Da HISYS Technology Co. Ltd.
+0018AD|NIDEC SANKYO CORPORATION
+0018AE|TVT CO.,LTD
+0018AF|Samsung
+0018B0|Nortel
+0018B1|IBM Corp
+0018B2|ADEUNIS RF
+0018B3|TEC WizHome Co., Ltd.
+0018B4|Dawon Media Inc.
+0018B5|Magna Carta
+0018B6|S3C, Inc.
+0018B7|D3 LED, LLC
+0018B8|New Voice International AG
+0018B9|Cisco
+0018BA|Cisco
+0018BB|Eliwell Controls srl
+0018BC|ZAO NVP Bolid
+0018BD|SHENZHEN DVBWORLD TECHNOLOGY CO., LTD.
+0018BE|ANSA Corporation
+0018BF|Essence Technology Solution, Inc.
+0018C0|ARRIS Group, Inc.
+0018C1|Almitec Informatica e Comercio
+0018C2|Firetide, Inc
+0018C3|CS Corporation
+0018C4|Raba Technologies LLC
+0018C5|Nokia Danmark A/S
+0018C6|OPW Fuel Management Systems
+0018C7|Real Time Automation
+0018C8|ISONAS Inc.
+0018C9|EOps Technology Limited
+0018CA|Viprinet GmbH
+0018CB|Tecobest Technology Limited
+0018CC|AXIOHM SAS
+0018CD|Erae Electronics Industry Co., Ltd
+0018CE|Dreamtech Co., Ltd
+0018CF|Baldor Electric Company
+0018D0|AtRoad,  A Trimble Company
+0018D1|Siemens Home & Office Comm. Devices
+0018D2|High-Gain Antennas LLC
+0018D3|TEAMCAST
+0018D4|Unified Display Interface SIG
+0018D5|REIGNCOM
+0018D6|Swirlnet A/S
+0018D7|Javad Navigation Systems Inc.
+0018D8|ARCH METER Corporation
+0018D9|Santosha Internatonal, Inc
+0018DA|AMBER wireless GmbH
+0018DB|EPL Technology Ltd
+0018DC|Prostar Co., Ltd.
+0018DD|Silicondust Engineering Ltd
+0018DE|Intel Corporate
+0018DF|The Morey Corporation
+0018E0|ANAVEO
+0018E1|Verkerk Service Systemen
+0018E2|Topdata Sistemas de Automacao Ltda
+0018E3|Visualgate Systems, Inc.
+0018E4|YIGUANG
+0018E5|Adhoco AG
+0018E6|Computer Hardware Design SIA
+0018E7|Cameo Communications, INC.
+0018E8|Hacetron Corporation
+0018E9|Numata Corporation
+0018EA|Alltec GmbH
+0018EB|BroVis Wireless Networks
+0018EC|Welding Technology Corporation
+0018ED|Accutech Ultrasystems Co., Ltd.
+0018EE|Videology Imaging Solutions, Inc.
+0018EF|Escape Communications, Inc.
+0018F0|JOYTOTO Co., Ltd.
+0018F1|Chunichi Denshi Co.,LTD.
+0018F2|Beijing Tianyu Communication Equipment Co., Ltd
+0018F3|ASUSTek COMPUTER INC.
+0018F4|EO TECHNICS Co., Ltd.
+0018F5|Shenzhen Streaming Video Technology Company Limited
+0018F6|Thomson Telecom Belgium
+0018F7|Kameleon Technologies
+0018F8|Cisco
+0018F9|VVOND, Inc.
+0018FA|Yushin Precision Equipment Co.,Ltd.
+0018FB|Compro Technology
+0018FC|Altec Electronic AG
+0018FD|Optimal Technologies International Inc.
+0018FE|Hewlett-Packard Company
+0018FF|PowerQuattro Co.
+001900|Intelliverese - DBA Voicecom
+001901|F1MEDIA
+001902|Cambridge Consultants Ltd
+001903|Bigfoot Networks Inc
+001904|WB Electronics Sp. z o.o.
+001905|SCHRACK Seconet AG
+001906|Cisco
+001907|Cisco
+001908|Duaxes Corporation
+001909|DEVI - Danfoss A/S
+00190A|HASWARE INC.
+00190B|Southern Vision Systems, Inc.
+00190C|Encore Electronics, Inc.
+00190D|IEEE 1394c
+00190E|Atech Technology Co., Ltd.
+00190F|Advansus Corp.
+001910|Knick Elektronische Messgeraete GmbH & Co. KG
+001911|Just In Mobile Information Technologies (Shanghai) Co., Ltd.
+001912|Welcat Inc
+001913|Chuang-Yi Network Equipment Co.Ltd.
+001914|Winix Co., Ltd
+001915|TECOM Co., Ltd.
+001916|PayTec AG
+001917|Posiflex Inc.
+001918|Interactive Wear AG
+001919|ASTEL Inc.
+00191A|IRLINK
+00191B|Sputnik Engineering AG
+00191C|Sensicast Systems
+00191D|Nintendo Co., Ltd.
+00191E|Beyondwiz Co., Ltd.
+00191F|Microlink communications Inc.
+001920|KUME electric Co.,Ltd.
+001921|Elitegroup Computer System Co.
+001922|CM Comandos Lineares
+001923|Phonex Korea Co., LTD.
+001924|LBNL  Engineering
+001925|Intelicis Corporation
+001926|BitsGen Co., Ltd.
+001927|ImCoSys Ltd
+001928|Siemens AG, Transportation Systems
+001929|2M2B Montadora de Maquinas Bahia Brasil LTDA
+00192A|Antiope Associates
+00192B|Aclara RF Systems Inc.
+00192C|ARRIS Group, Inc.
+00192D|Nokia Corporation
+00192E|Spectral Instruments, Inc.
+00192F|Cisco
+001930|Cisco
+001931|Balluff GmbH
+001932|Gude Analog- und Digialsysteme GmbH
+001933|Strix Systems, Inc.
+001934|TRENDON TOUCH TECHNOLOGY CORP.
+001935|DUERR DENTAL AG
+001936|STERLITE OPTICAL TECHNOLOGIES LIMITED
+001937|CommerceGuard AB
+001938|UMB Communications Co., Ltd.
+001939|Gigamips
+00193A|OESOLUTIONS
+00193B|Wilibox Deliberant Group LLC
+00193C|HighPoint Technologies Incorporated
+00193D|GMC Guardian Mobility Corp.
+00193E|ADB Broadband Italia
+00193F|RDI technology(Shenzhen) Co.,LTD
+001940|Rackable Systems
+001941|Pitney Bowes, Inc
+001942|ON SOFTWARE INTERNATIONAL LIMITED
+001943|Belden
+001944|Fossil Partners, L.P.
+001945|RF COncepts, LLC
+001946|Cianet Industria e Comercio S/A
+001947|Scientific Atlanta, A Cisco Company
+001948|AireSpider Networks
+001949|TENTEL  COMTECH CO., LTD.
+00194A|TESTO AG
+00194B|SAGEM COMMUNICATION
+00194C|Fujian Stelcom information & Technology CO.,Ltd
+00194D|Avago Technologies Sdn Bhd
+00194E|Ultra Electronics - TCS (Tactical Communication Systems)
+00194F|Nokia Danmark A/S
+001950|Harman Multimedia
+001951|NETCONS, s.r.o.
+001952|ACOGITO Co., Ltd
+001953|Chainleader Communications Corp.
+001954|Leaf Corporation.
+001955|Cisco
+001956|Cisco
+001957|Saafnet Canada Inc.
+001958|Bluetooth SIG, Inc.
+001959|Staccato Communications Inc.
+00195A|Jenaer Antriebstechnik GmbH
+00195B|D-Link Corporation
+00195C|Innotech Corporation
+00195D|ShenZhen XinHuaTong Opto Electronics Co.,Ltd
+00195E|ARRIS Group, Inc.
+00195F|Valemount Networks Corporation
+001960|DoCoMo Systems, Inc.
+001961|Blaupunkt  Embedded Systems GmbH
+001962|Commerciant, LP
+001963|Sony Ericsson Mobile Communications AB
+001964|Doorking Inc.
+001965|YuHua TelTech (ShangHai) Co., Ltd.
+001966|Asiarock Technology Limited
+001967|TELDAT Sp.J.
+001968|Digital Video Networks(Shanghai) CO. LTD.
+001969|Nortel
+00196A|MikroM GmbH
+00196B|Danpex Corporation
+00196C|ETROVISION TECHNOLOGY
+00196D|Raybit Systems Korea, Inc
+00196E|Metacom (Pty) Ltd.
+00196F|SensoPart GmbH
+001970|Z-Com, Inc.
+001971|Guangzhou Unicomp Technology Co.,Ltd
+001972|Plexus (Xiamen) Co.,ltd
+001973|Zeugma Systems
+001974|AboCom Systems, Inc.
+001975|Beijing Huisen networks technology Inc
+001976|Xipher Technologies, LLC
+001977|Aerohive Networks, Inc.
+001978|Datum Systems, Inc.
+001979|Nokia Danmark A/S
+00197A|MAZeT GmbH
+00197B|Picotest Corp.
+00197C|Riedel Communications GmbH
+00197D|Hon Hai Precision Ind. Co., Ltd
+00197E|Hon Hai Precision Ind. Co., Ltd
+00197F|PLANTRONICS, INC.
+001980|Gridpoint Systems
+001981|Vivox Inc
+001982|SmarDTV
+001983|CCT R&D Limited
+001984|ESTIC Corporation
+001985|IT Watchdogs, Inc
+001986|Cheng Hongjian
+001987|Panasonic Mobile Communications Co., Ltd.
+001988|Wi2Wi, Inc
+001989|Sonitrol Corporation
+00198A|Northrop Grumman Systems Corp.
+00198B|Novera Optics Korea, Inc.
+00198C|iXSea
+00198D|Ocean Optics, Inc.
+00198E|Oticon A/S
+00198F|Alcatel Bell N.V.
+001990|ELM DATA Co., Ltd.
+001991|avinfo
+001992|ADTRAN INC.
+001993|Changshu Switchgear MFG. Co.,Ltd. (Former Changshu Switchgea
+001994|Jorjin Technologies Inc.
+001995|Jurong Hi-Tech (Suzhou)Co.ltd
+001996|TurboChef Technologies Inc.
+001997|Soft Device Sdn Bhd
+001998|SATO CORPORATION
+001999|Fujitsu Technology Solutions
+00199A|EDO-EVI
+00199B|Diversified Technical Systems, Inc.
+00199C|CTRING
+00199D|VIZIO, Inc.
+00199E|Nifty
+00199F|DKT A/S
+0019A0|NIHON DATA SYSTENS, INC.
+0019A1|LG INFORMATION & COMM.
+0019A2|ORDYN TECHNOLOGIES
+0019A3|asteel electronique atlantique
+0019A4|Austar Technology (hang zhou) Co.,Ltd
+0019A5|RadarFind Corporation
+0019A6|ARRIS Group, Inc.
+0019A7|ITU-T
+0019A8|WiQuest Communications
+0019A9|Cisco
+0019AA|Cisco
+0019AB|Raycom CO ., LTD
+0019AC|GSP SYSTEMS Inc.
+0019AD|BOBST SA
+0019AE|Hopling Technologies b.v.
+0019AF|Rigol Technologies, Inc.
+0019B0|HanYang System
+0019B1|Arrow7 Corporation
+0019B2|XYnetsoft Co.,Ltd
+0019B3|Stanford Research Systems
+0019B4|Intellio Ltd
+0019B5|Famar Fueguina S.A.
+0019B6|Euro Emme s.r.l.
+0019B7|Nokia Danmark A/S
+0019B8|Boundary Devices
+0019B9|Dell Inc.
+0019BA|Paradox Security Systems Ltd
+0019BB|Hewlett-Packard Company
+0019BC|ELECTRO CHANCE SRL
+0019BD|New Media Life
+0019BE|Altai Technologies Limited
+0019BF|Citiway technology Co.,ltd
+0019C0|ARRIS Group, Inc.
+0019C1|Alps Electric Co., Ltd
+0019C2|Equustek Solutions, Inc.
+0019C3|Qualitrol
+0019C4|Infocrypt Inc.
+0019C5|SONY Computer Entertainment inc,
+0019C6|ZTE Corporation
+0019C7|Cambridge Industries(Group) Co.,Ltd.
+0019C8|AnyDATA Corporation
+0019C9|S&C ELECTRIC COMPANY
+0019CA|Broadata Communications, Inc
+0019CB|ZyXEL Communications Corporation
+0019CC|RCG (HK) Ltd
+0019CD|Chengdu ethercom information technology Ltd.
+0019CE|Progressive Gaming International
+0019CF|SALICRU, S.A.
+0019D0|Cathexis
+0019D1|Intel Corporate
+0019D2|Intel Corporate
+0019D3|TRAK Microwave
+0019D4|ICX Technologies
+0019D5|IP Innovations, Inc.
+0019D6|LS Cable and System Ltd.
+0019D7|FORTUNETEK CO., LTD
+0019D8|MAXFOR
+0019D9|Zeutschel GmbH
+0019DA|Welltrans O&E Technology Co. , Ltd.
+0019DB|MICRO-STAR INTERNATIONAL CO., LTD.
+0019DC|ENENSYS Technologies
+0019DD|FEI-Zyfer, Inc.
+0019DE|MOBITEK
+0019DF|Thomson Inc.
+0019E0|TP-LINK Technologies Co., Ltd.
+0019E1|Nortel
+0019E2|Juniper Networks
+0019E3|Apple
+0019E4|2Wire, Inc
+0019E5|Lynx Studio Technology, Inc.
+0019E6|TOYO MEDIC CO.,LTD.
+0019E7|Cisco
+0019E8|Cisco
+0019E9|S-Information Technolgy, Co., Ltd.
+0019EA|TeraMage Technologies Co., Ltd.
+0019EB|Pyronix Ltd
+0019EC|Sagamore Systems, Inc.
+0019ED|Axesstel Inc.
+0019EE|CARLO GAVAZZI CONTROLS SPA-Controls Division
+0019EF|SHENZHEN LINNKING ELECTRONICS CO.,LTD
+0019F0|UNIONMAN TECHNOLOGY CO.,LTD
+0019F1|Star Communication Network Technology Co.,Ltd
+0019F2|Teradyne K.K.
+0019F3|Cetis, Inc
+0019F4|Convergens Oy Ltd
+0019F5|Imagination Technologies Ltd
+0019F6|Acconet (PTE) Ltd
+0019F7|Onset Computer Corporation
+0019F8|Embedded Systems Design, Inc.
+0019F9|TDK-Lambda
+0019FA|Cable Vision Electronics CO., LTD.
+0019FB|BSkyB Ltd
+0019FC|PT. Ufoakses Sukses Luarbiasa
+0019FD|Nintendo Co., Ltd.
+0019FE|SHENZHEN SEECOMM TECHNOLOGY CO.,LTD.
+0019FF|Finnzymes
+001A00|MATRIX INC.
+001A01|Smiths Medical
+001A02|SECURE CARE PRODUCTS, INC
+001A03|Angel Electronics Co., Ltd.
+001A04|Interay Solutions BV
+001A05|OPTIBASE LTD
+001A06|OpVista, Inc.
+001A07|Arecont Vision
+001A08|Simoco Ltd.
+001A09|Wayfarer Transit Systems Ltd
+001A0A|Adaptive Micro-Ware Inc.
+001A0B|BONA TECHNOLOGY INC.
+001A0C|Swe-Dish Satellite Systems AB
+001A0D|HandHeld entertainment, Inc.
+001A0E|Cheng Uei Precision Industry Co.,Ltd
+001A0F|Sistemas Avanzados de Control, S.A.
+001A10|LUCENT TRANS ELECTRONICS CO.,LTD
+001A11|Google
+001A12|Essilor
+001A13|Wanlida Group Co., LTD
+001A14|Xin Hua Control Engineering Co.,Ltd.
+001A15|gemalto e-Payment
+001A16|Nokia Danmark A/S
+001A17|Teak Technologies, Inc.
+001A18|Advanced Simulation Technology inc.
+001A19|Computer Engineering Limited
+001A1A|Gentex Corporation/Electro-Acoustic Products
+001A1B|ARRIS Group, Inc.
+001A1C|GT&T Engineering Pte Ltd
+001A1D|PChome Online Inc.
+001A1E|Aruba Networks
+001A1F|Coastal Environmental Systems
+001A20|CMOTECH Co. Ltd.
+001A21|Indac B.V.
+001A22|eQ-3 Entwicklung GmbH
+001A23|Ice Qube, Inc
+001A24|Galaxy Telecom Technologies Ltd
+001A25|DELTA DORE
+001A26|Deltanode Solutions AB
+001A27|Ubistar
+001A28|ASWT Co., LTD. Taiwan Branch H.K.
+001A29|Johnson Outdoors Marine Electronics, Inc
+001A2A|Arcadyan Technology Corporation
+001A2B|Ayecom Technology Co., Ltd.
+001A2C|SATEC Co.,LTD
+001A2D|The Navvo Group
+001A2E|Ziova Coporation
+001A2F|Cisco
+001A30|Cisco
+001A31|SCAN COIN Industries AB
+001A32|ACTIVA MULTIMEDIA
+001A33|ASI Communications, Inc.
+001A34|Konka Group Co., Ltd.
+001A35|BARTEC GmbH
+001A36|Aipermon GmbH & Co. KG
+001A37|Lear Corporation
+001A38|Sanmina-SCI
+001A39|Merten GmbH&CoKG
+001A3A|Dongahelecomm
+001A3B|Doah Elecom Inc.
+001A3C|Technowave Ltd.
+001A3D|Ajin Vision Co.,Ltd
+001A3E|Faster Technology LLC
+001A3F|intelbras
+001A40|A-FOUR TECH CO., LTD.
+001A41|INOCOVA Co.,Ltd
+001A42|Techcity Technology co., Ltd.
+001A43|Logical Link Communications
+001A44|JWTrading Co., Ltd
+001A45|GN Netcom as
+001A46|Digital Multimedia Technology Co., Ltd
+001A47|Agami Systems, Inc.
+001A48|Takacom Corporation
+001A49|Micro Vision Co.,LTD
+001A4A|Qumranet Inc.
+001A4B|Hewlett-Packard Company
+001A4C|Crossbow Technology, Inc
+001A4D|GIGA-BYTE TECHNOLOGY CO.,LTD.
+001A4E|NTI AG / LinMot
+001A4F|AVM GmbH
+001A50|PheeNet Technology Corp.
+001A51|Alfred Mann Foundation
+001A52|Meshlinx Wireless Inc.
+001A53|Zylaya
+001A54|Hip Shing Electronics Ltd.
+001A55|ACA-Digital Corporation
+001A56|ViewTel Co,. Ltd.
+001A57|Matrix Design Group, LLC
+001A58|CCV Deutschland GmbH - Celectronic eHealth Div.
+001A59|Ircona
+001A5A|Korea Electric Power Data Network  (KDN) Co., Ltd
+001A5B|NetCare Service Co., Ltd.
+001A5C|Euchner GmbH+Co. KG
+001A5D|Mobinnova Corp.
+001A5E|Thincom Technology Co.,Ltd
+001A5F|KitWorks.fi Ltd.
+001A60|Wave Electronics Co.,Ltd.
+001A61|PacStar Corp.
+001A62|Data Robotics, Incorporated
+001A63|Elster Solutions, LLC,
+001A64|IBM Corp
+001A65|Seluxit
+001A66|ARRIS Group, Inc.
+001A67|Infinite QL Sdn Bhd
+001A68|Weltec Enterprise Co., Ltd.
+001A69|Wuhan Yangtze Optical Technology CO.,Ltd.
+001A6A|Tranzas, Inc.
+001A6B|Universal Global Scientific Industrial Co., Ltd.
+001A6C|Cisco
+001A6D|Cisco
+001A6E|Impro Technologies
+001A6F|MI.TEL s.r.l.
+001A70|Cisco
+001A71|Diostech Co., Ltd.
+001A72|Mosart Semiconductor Corp.
+001A73|Gemtek Technology Co., Ltd.
+001A74|Procare International Co
+001A75|Sony Ericsson Mobile Communications
+001A76|SDT information Technology Co.,LTD.
+001A77|ARRIS Group, Inc.
+001A78|ubtos
+001A79|TELECOMUNICATION TECHNOLOGIES LTD.
+001A7A|Lismore Instruments Limited
+001A7B|Teleco, Inc.
+001A7C|Hirschmann Multimedia B.V.
+001A7D|cyber-blue(HK)Ltd
+001A7E|LN Srithai Comm Ltd.
+001A7F|GCI Science&Technology Co.,Ltd.
+001A80|Sony Corporation
+001A81|Zelax
+001A82|PROBA Building Automation Co.,LTD
+001A83|Pegasus Technologies Inc.
+001A84|V One Multimedia Pte Ltd
+001A85|NV Michel Van de Wiele
+001A86|AdvancedIO Systems Inc
+001A87|Canhold International Limited
+001A88|Venergy,Co,Ltd
+001A89|Nokia Danmark A/S
+001A8A|Samsung
+001A8B|CHUNIL ELECTRIC IND., CO.
+001A8C|Sophos Ltd
+001A8D|AVECS Bergen GmbH
+001A8E|3Way Networks Ltd
+001A8F|Nortel
+001A90|Tropico Sistemas e Telecomunicacoes da Amazonia LTDA.
+001A91|FusionDynamic Ltd.
+001A92|ASUSTek COMPUTER INC.
+001A93|ERCO Leuchten GmbH
+001A94|Votronic GmbH
+001A95|Hisense Mobile Communications Technoligy Co.,Ltd.
+001A96|ECLER S.A.
+001A97|fitivision technology Inc.
+001A98|Asotel Communication Limited Taiwan Branch
+001A99|Smarty (HZ) Information Electronics Co., Ltd
+001A9A|Skyworth Digital technology(shenzhen)co.ltd.
+001A9B|ADEC & Parter AG
+001A9C|RightHand Technologies, Inc.
+001A9D|Skipper Wireless, Inc.
+001A9E|ICON Digital International Limited
+001A9F|A-Link Ltd
+001AA0|Dell Inc
+001AA1|Cisco
+001AA2|Cisco
+001AA3|DELORME
+001AA4|Future University-Hakodate
+001AA5|BRN Phoenix
+001AA6|Telefunken Radio Communication Systems GmbH &CO.KG
+001AA7|Torian Wireless
+001AA8|Mamiya Digital Imaging Co., Ltd.
+001AA9|FUJIAN STAR-NET COMMUNICATION CO.,LTD
+001AAA|Analogic Corp.
+001AAB|eWings s.r.l.
+001AAC|Corelatus AB
+001AAD|ARRIS Group, Inc.
+001AAE|Savant Systems LLC
+001AAF|BLUSENS TECHNOLOGY
+001AB0|Signal Networks Pvt. Ltd.,
+001AB1|Asia Pacific Satellite Industries Co., Ltd.
+001AB2|Cyber Solutions Inc.
+001AB3|VISIONITE INC.
+001AB4|FFEI Ltd.
+001AB5|Home Network System
+001AB6|Texas Instruments
+001AB7|Ethos Networks LTD.
+001AB8|Anseri Corporation
+001AB9|PMC
+001ABA|Caton Overseas Limited
+001ABB|Fontal Technology Incorporation
+001ABC|U4EA Technologies Ltd
+001ABD|Impatica Inc.
+001ABE|COMPUTER HI-TECH INC.
+001ABF|TRUMPF Laser Marking Systems AG
+001AC0|JOYBIEN TECHNOLOGIES CO., LTD.
+001AC1|3Com Ltd
+001AC2|YEC Co.,Ltd.
+001AC3|Scientific-Atlanta, Inc
+001AC4|2Wire, Inc
+001AC5|BreakingPoint Systems, Inc.
+001AC6|Micro Control Designs
+001AC7|UNIPOINT
+001AC8|ISL (Instrumentation Scientifique de Laboratoire)
+001AC9|SUZUKEN CO.,LTD
+001ACA|Tilera Corporation
+001ACB|Autocom Products Ltd
+001ACC|Celestial Semiconductor, Ltd
+001ACD|Tidel Engineering LP
+001ACE|YUPITERU CORPORATION
+001ACF|C.T. ELETTRONICA
+001AD0|Albis Technologies AG
+001AD1|FARGO CO., LTD.
+001AD2|Eletronica Nitron Ltda
+001AD3|Vamp Ltd.
+001AD4|iPOX Technology Co., Ltd.
+001AD5|KMC CHAIN INDUSTRIAL CO., LTD.
+001AD6|JIAGNSU AETNA ELECTRIC CO.,LTD
+001AD7|Christie Digital Systems, Inc.
+001AD8|AlsterAero GmbH
+001AD9|International Broadband Electric Communications, Inc.
+001ADA|Biz-2-Me Inc.
+001ADB|ARRIS Group, Inc.
+001ADC|Nokia Danmark A/S
+001ADD|PePWave Ltd
+001ADE|ARRIS Group, Inc.
+001ADF|Interactivetv Pty Limited
+001AE0|Mythology Tech Express Inc.
+001AE1|EDGE ACCESS INC
+001AE2|Cisco
+001AE3|Cisco
+001AE4|Medicis Technologies Corporation
+001AE5|Mvox Technologies Inc.
+001AE6|Atlanta Advanced Communications Holdings Limited
+001AE7|Aztek Networks, Inc.
+001AE8|Unify GmbH and Co KG
+001AE9|Nintendo Co., Ltd.
+001AEA|Radio Terminal Systems Pty Ltd
+001AEB|Allied Telesis K.K.
+001AEC|Keumbee Electronics Co.,Ltd.
+001AED|INCOTEC GmbH
+001AEE|Shenztech Ltd
+001AEF|Loopcomm Technology, Inc.
+001AF0|Alcatel - IPD
+001AF1|Embedded Artists AB
+001AF2|Dynavisions Schweiz AG
+001AF3|Samyoung Electronics
+001AF4|Handreamnet
+001AF5|PENTAONE. CO., LTD.
+001AF6|Woven Systems, Inc.
+001AF7|dataschalt e+a GmbH
+001AF8|Copley Controls Corporation
+001AF9|AeroVIronment (AV Inc)
+001AFA|Welch Allyn, Inc.
+001AFB|Joby Inc.
+001AFC|ModusLink Corporation
+001AFD|EVOLIS
+001AFE|SOFACREAL
+001AFF|Wizyoung Tech.
+001B00|Neopost Technologies
+001B01|Applied Radio Technologies
+001B02|ED Co.Ltd
+001B03|Action Technology (SZ) Co., Ltd
+001B04|Affinity International S.p.a
+001B05|YMC AG
+001B06|Ateliers R. LAUMONIER
+001B07|Mendocino Software
+001B08|Danfoss Drives A/S
+001B09|Matrix Telecom Pvt. Ltd.
+001B0A|Intelligent Distributed Controls Ltd
+001B0B|Phidgets Inc.
+001B0C|Cisco
+001B0D|Cisco
+001B0E|InoTec GmbH Organisationssysteme
+001B0F|Petratec
+001B10|ShenZhen Kang Hui Technology Co.,ltd
+001B11|D-Link Corporation
+001B12|Apprion
+001B13|Icron Technologies Corporation
+001B14|Carex Lighting Equipment Factory
+001B15|Voxtel, Inc.
+001B16|Celtro Ltd.
+001B17|Palo Alto Networks
+001B18|Tsuken Electric Ind. Co.,Ltd
+001B19|IEEE I&M Society TC9
+001B1A|e-trees Japan, Inc.
+001B1B|Siemens AG,
+001B1C|Coherent
+001B1D|Phoenix International Co., Ltd
+001B1E|HART Communication Foundation
+001B1F|DELTA - Danish Electronics, Light & Acoustics
+001B20|TPine Technology
+001B21|Intel Corporate
+001B22|Palit Microsystems ( H.K.) Ltd.
+001B23|SimpleComTools
+001B24|Quanta Computer Inc.
+001B25|Nortel
+001B26|RON-Telecom ZAO
+001B27|Merlin CSI
+001B28|POLYGON, JSC
+001B29|Avantis.Co.,Ltd
+001B2A|Cisco
+001B2B|Cisco
+001B2C|ATRON electronic GmbH
+001B2D|Med-Eng Systems Inc.
+001B2E|Sinkyo Electron Inc
+001B2F|Netgear
+001B30|Solitech Inc.
+001B31|Neural Image. Co. Ltd.
+001B32|QLogic Corporation
+001B33|Nokia Danmark A/S
+001B34|Focus System Inc.
+001B35|ChongQing JINOU Science & Technology Development CO.,Ltd
+001B36|Tsubata Engineering Co.,Ltd. (Head Office)
+001B37|Computec Oy
+001B38|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+001B39|Proxicast
+001B3A|SIMS Corp.
+001B3B|Yi-Qing CO., LTD
+001B3C|Software Technologies Group,Inc.
+001B3D|EuroTel Spa
+001B3E|Curtis, Inc.
+001B3F|ProCurve Networking by HP
+001B40|Network Automation mxc AB
+001B41|General Infinity Co.,Ltd.
+001B42|Wise & Blue
+001B43|Beijing DG Telecommunications equipment Co.,Ltd
+001B44|SanDisk Corporation
+001B45|ABB AS, Division Automation Products
+001B46|Blueone Technology Co.,Ltd
+001B47|Futarque A/S
+001B48|Shenzhen Lantech Electronics Co., Ltd.
+001B49|Roberts Radio limited
+001B4A|W&W Communications, Inc.
+001B4B|SANION Co., Ltd.
+001B4C|Signtech
+001B4D|Areca Technology Corporation
+001B4E|Navman New Zealand
+001B4F|Avaya Inc.
+001B50|Nizhny Novgorod Factory named after M.Frunze, FSUE (NZiF)
+001B51|Vector Technology Corp.
+001B52|ARRIS Group, Inc.
+001B53|Cisco
+001B54|Cisco
+001B55|Hurco Automation Ltd.
+001B56|Tehuti Networks Ltd.
+001B57|SEMINDIA SYSTEMS PRIVATE LIMITED
+001B58|ACE CAD Enterprise Co., Ltd.
+001B59|Sony Ericsson Mobile Communications AB
+001B5A|Apollo Imaging Technologies, Inc.
+001B5B|2Wire, Inc.
+001B5C|Azuretec Co., Ltd.
+001B5D|Vololink Pty Ltd
+001B5E|BPL Limited
+001B5F|Alien Technology
+001B60|NAVIGON AG
+001B61|Digital Acoustics, LLC
+001B62|JHT Optoelectronics Co.,Ltd.
+001B63|Apple
+001B64|IsaacLandKorea Co., Ltd,
+001B65|China Gridcom Co., Ltd
+001B66|Sennheiser electronic GmbH & Co. KG
+001B67|Cisco
+001B68|Modnnet Co., Ltd
+001B69|Equaline Corporation
+001B6A|Powerwave Technologies Sweden AB
+001B6B|Swyx Solutions AG
+001B6C|LookX Digital Media BV
+001B6D|Midtronics, Inc.
+001B6E|Anue Systems, Inc.
+001B6F|Teletrak Ltd
+001B70|IRI Ubiteq, INC.
+001B71|Telular Corp.
+001B72|Sicep s.p.a.
+001B73|DTL Broadcast Ltd
+001B74|MiraLink Corporation
+001B75|Hypermedia Systems
+001B76|Ripcode, Inc.
+001B77|Intel Corporate
+001B78|Hewlett-Packard Company
+001B79|FAIVELEY TRANSPORT
+001B7A|Nintendo Co., Ltd.
+001B7B|The Tintometer Ltd
+001B7C|A & R Cambridge
+001B7D|CXR Anderson Jacobson
+001B7E|Beckmann GmbH
+001B7F|TMN Technologies Telecomunicacoes Ltda
+001B80|LORD Corporation
+001B81|DATAQ Instruments, Inc.
+001B82|Taiwan Semiconductor Co., Ltd.
+001B83|Finsoft Ltd
+001B84|Scan Engineering Telecom
+001B85|MAN Diesel SE
+001B86|Bosch Access Systems GmbH
+001B87|Deepsound Tech. Co., Ltd
+001B88|Divinet Access Technologies Ltd
+001B89|EMZA Visual Sense Ltd.
+001B8A|2M Electronic A/S
+001B8B|NEC Platforms, Ltd.
+001B8C|JMicron Technology Corp.
+001B8D|Electronic Computer Systems, Inc.
+001B8E|Hulu Sweden AB
+001B8F|Cisco
+001B90|Cisco
+001B91|EFKON AG
+001B92|l-acoustics
+001B93|JC Decaux SA DNT
+001B94|T.E.M.A. S.p.A.
+001B95|VIDEO SYSTEMS SRL
+001B96|General Sensing
+001B97|Violin Technologies
+001B98|Samsung
+001B99|KS System GmbH
+001B9A|Apollo Fire Detectors Ltd
+001B9B|Hose-McCann Communications
+001B9C|SATEL sp. z o.o.
+001B9D|Novus Security Sp. z o.o.
+001B9E|ASKEY  COMPUTER  CORP
+001B9F|Calyptech Pty Ltd
+001BA0|Awox
+001BA1|Amic AB
+001BA2|IDS Imaging Development Systems GmbH
+001BA3|Flexit Group GmbH
+001BA4|S.A.E Afikim
+001BA5|MyungMin Systems, Inc.
+001BA6|intotech inc.
+001BA7|Lorica Solutions
+001BA8|UBI&MOBI,.Inc
+001BA9|BROTHER INDUSTRIES, LTD.
+001BAA|XenICs nv
+001BAB|Telchemy, Incorporated
+001BAC|Curtiss Wright Controls Embedded Computing
+001BAD|iControl Incorporated
+001BAE|Micro Control Systems, Inc
+001BAF|Nokia Danmark A/S
+001BB0|BHARAT ELECTRONICS
+001BB1|Wistron Neweb Corp.
+001BB2|Intellect International NV
+001BB3|Condalo GmbH
+001BB4|Airvod Limited
+001BB5|ZF Electronics GmbH
+001BB6|Bird Electronic Corp.
+001BB7|Alta Heights Technology Corp.
+001BB8|BLUEWAY ELECTRONIC CO;LTD
+001BB9|Elitegroup Computer System Co.
+001BBA|Nortel
+001BBB|RFTech Co.,Ltd
+001BBC|Silver Peak Systems, Inc.
+001BBD|FMC Kongsberg Subsea AS
+001BBE|ICOP Digital
+001BBF|SAGEM COMMUNICATION
+001BC0|Juniper Networks
+001BC1|HOLUX Technology, Inc.
+001BC2|Integrated Control Technology Limitied
+001BC3|Mobisolution Co.,Ltd
+001BC4|Ultratec, Inc.
+001BC5|IEEE REGISTRATION AUTHORITY  - Please see OUI36/MA-S public listing for more information.
+001BC6|Strato Rechenzentrum AG
+001BC7|StarVedia Technology Inc.
+001BC8|MIURA CO.,LTD
+001BC9|FSN DISPLAY INC
+001BCA|Beijing Run Technology LTD. Company
+001BCB|PEMPEK SYSTEMS PTY LTD
+001BCC|KINGTEK CCTV ALLIANCE CO., LTD.
+001BCD|DAVISCOMMS (S) PTE LTD
+001BCE|Measurement Devices Ltd
+001BCF|Dataupia Corporation
+001BD0|IDENTEC SOLUTIONS
+001BD1|SOGESTMATIC
+001BD2|ULTRA-X ASIA PACIFIC Inc.
+001BD3|Panasonic Corp. AVC Company
+001BD4|Cisco
+001BD5|Cisco
+001BD6|Kelvin Hughes Ltd
+001BD7|Scientific Atlanta, A Cisco Company
+001BD8|DVTel LTD
+001BD9|Edgewater Computer Systems
+001BDA|UTStarcom Inc
+001BDB|Valeo VECS
+001BDC|Vencer Co., Ltd.
+001BDD|ARRIS Group, Inc.
+001BDE|Renkus-Heinz, Inc.
+001BDF|Iskra Sistemi d.d.
+001BE0|TELENOT ELECTRONIC GmbH
+001BE1|ViaLogy
+001BE2|AhnLab,Inc.
+001BE3|Health Hero Network, Inc.
+001BE4|TOWNET SRL
+001BE5|802automation Limited
+001BE6|VR AG
+001BE7|Postek Electronics Co., Ltd.
+001BE8|Ultratronik GmbH
+001BE9|Broadcom Corporation
+001BEA|Nintendo Co., Ltd.
+001BEB|DMP Electronics INC.
+001BEC|Netio Technologies Co., Ltd
+001BED|Brocade Communications Systems, Inc
+001BEE|Nokia Danmark A/S
+001BEF|Blossoms Digital Technology Co.,Ltd.
+001BF0|Value Platforms Limited
+001BF1|Nanjing SilverNet Software Co., Ltd.
+001BF2|KWORLD COMPUTER CO., LTD
+001BF3|TRANSRADIO SenderSysteme Berlin AG
+001BF4|KENWIN INDUSTRIAL(HK) LTD.
+001BF5|Tellink Sistemas de Telecomunicacion S.L.
+001BF6|CONWISE Technology Corporation Ltd.
+001BF7|Lund IP Products AB
+001BF8|Digitrax Inc.
+001BF9|Intellitect Water Ltd
+001BFA|G.i.N. mbH
+001BFB|Alps Electric Co., Ltd
+001BFC|ASUSTek COMPUTER INC.
+001BFD|Dignsys Inc.
+001BFE|Zavio Inc.
+001BFF|Millennia Media inc.
+001C00|Entry Point, LLC
+001C01|ABB Oy Drives
+001C02|Pano Logic
+001C03|Betty TV Technology AG
+001C04|Airgain, Inc.
+001C05|Nonin Medical Inc.
+001C06|Siemens Numerical Control Ltd., Nanjing
+001C07|Cwlinux Limited
+001C08|Echo360, Inc.
+001C09|SAE Electronic Co.,Ltd.
+001C0A|Shenzhen AEE Technology Co.,Ltd.
+001C0B|SmartAnt Telecom
+001C0C|TANITA Corporation
+001C0D|G-Technology, Inc.
+001C0E|Cisco
+001C0F|Cisco
+001C10|Cisco
+001C11|ARRIS Group, Inc.
+001C12|ARRIS Group, Inc.
+001C13|OPTSYS TECHNOLOGY CO., LTD.
+001C14|VMware, Inc
+001C15|iPhotonix LLC
+001C16|ThyssenKrupp Elevator
+001C17|Nortel
+001C18|Sicert S.r.L.
+001C19|secunet Security Networks AG
+001C1A|Thomas Instrumentation, Inc
+001C1B|Hyperstone GmbH
+001C1C|Center Communication Systems GmbH
+001C1D|CHENZHOU GOSPELL DIGITAL TECHNOLOGY CO.,LTD
+001C1E|emtrion GmbH
+001C1F|Quest Retail Technology Pty Ltd
+001C20|CLB Benelux
+001C21|Nucsafe Inc.
+001C22|Aeris Elettronica s.r.l.
+001C23|Dell Inc
+001C24|Formosa Wireless Systems Corp.
+001C25|Hon Hai Precision Ind. Co.,Ltd.
+001C26|Hon Hai Precision Ind. Co.,Ltd.
+001C27|Sunell Electronics Co.
+001C28|Sphairon Technologies GmbH
+001C29|CORE DIGITAL ELECTRONICS CO., LTD
+001C2A|Envisacor Technologies Inc.
+001C2B|Alertme.com Limited
+001C2C|Synapse
+001C2D|FlexRadio Systems
+001C2E|HPN Supply Chain
+001C2F|Pfister GmbH
+001C30|Mode Lighting (UK ) Ltd.
+001C31|Mobile XP Technology Co., LTD
+001C32|Telian Corporation
+001C33|Sutron
+001C34|HUEY CHIAO INTERNATIONAL CO., LTD.
+001C35|Nokia Danmark A/S
+001C36|iNEWiT NV
+001C37|Callpod, Inc.
+001C38|Bio-Rad Laboratories, Inc.
+001C39|S Netsystems Inc.
+001C3A|Element Labs, Inc.
+001C3B|AmRoad Technology Inc.
+001C3C|Seon Design Inc.
+001C3D|WaveStorm
+001C3E|ECKey Corporation
+001C3F|International Police Technologies, Inc.
+001C40|VDG-Security bv
+001C41|scemtec Transponder Technology GmbH
+001C42|Parallels, Inc.
+001C43|Samsung
+001C44|Bosch Security Systems BV
+001C45|Chenbro Micom Co., Ltd.
+001C46|QTUM
+001C47|Hangzhou Hollysys Automation Co., Ltd
+001C48|WiDeFi, Inc.
+001C49|Zoltan Technology Inc.
+001C4A|AVM GmbH
+001C4B|Gener8, Inc.
+001C4C|Petrotest Instruments
+001C4D|Aplix IP Holdings Corporation
+001C4E|TASA International Limited
+001C4F|MACAB AB
+001C50|TCL Technoly Electronics(Huizhou)Co.,Ltd
+001C51|Celeno Communications
+001C52|VISIONEE SRL
+001C53|Synergy Lighting Controls
+001C54|Hillstone Networks Inc
+001C55|Shenzhen Kaifa Technology Co.
+001C56|Pado Systems, Inc.
+001C57|Cisco
+001C58|Cisco
+001C59|DEVON IT
+001C5A|Advanced Relay Corporation
+001C5B|Chubb Electronic Security Systems Ltd
+001C5C|Integrated Medical Systems, Inc.
+001C5D|Leica Microsystems
+001C5E|ASTON France
+001C5F|Winland Electronics, Inc.
+001C60|CSP Frontier Technologies,Inc.
+001C61|Galaxy  Microsystems LImited
+001C62|LG Electronics
+001C63|TRUEN
+001C64|Landis+Gyr
+001C65|JoeScan, Inc.
+001C66|UCAMP CO.,LTD
+001C67|Pumpkin Networks, Inc.
+001C68|Anhui Sun Create Electronics Co., Ltd
+001C69|Packet Vision Ltd
+001C6A|Weiss Engineering Ltd.
+001C6B|COVAX  Co. Ltd
+001C6C|Jabil Circuit (Guangzhou) Limited
+001C6D|KYOHRITSU ELECTRONIC INDUSTRY CO., LTD.
+001C6E|Newbury Networks, Inc.
+001C6F|Emfit Ltd
+001C70|NOVACOMM LTDA
+001C71|Emergent Electronics
+001C72|Mayer & Cie GmbH & Co KG
+001C73|Arista Networks, Inc.
+001C74|Syswan Technologies Inc.
+001C75|Segnet Ltd.
+001C76|The Wandsworth Group Ltd
+001C77|Prodys
+001C78|WYPLAY SAS
+001C79|Cohesive Financial Technologies LLC
+001C7A|Perfectone Netware Company Ltd
+001C7B|Castlenet Technology Inc.
+001C7C|PERQ SYSTEMS CORPORATION
+001C7D|Excelpoint Manufacturing Pte Ltd
+001C7E|Toshiba
+001C7F|Check Point Software Technologies
+001C80|New Business Division/Rhea-Information CO., LTD.
+001C81|NextGen Venturi LTD
+001C82|Genew Technologies
+001C83|New Level Telecom Co., Ltd.
+001C84|STL Solution Co.,Ltd.
+001C85|Eunicorn
+001C86|Cranite Systems, Inc.
+001C87|Uriver Inc.
+001C88|TRANSYSTEM INC.
+001C89|Force Communications, Inc.
+001C8A|Cirrascale Corporation
+001C8B|MJ Innovations Ltd.
+001C8C|DIAL TECHNOLOGY LTD.
+001C8D|Mesa Imaging
+001C8E|Alcatel-Lucent IPD
+001C8F|Advanced Electronic Design, Inc.
+001C90|Empacket Corporation
+001C91|Gefen Inc.
+001C92|Tervela
+001C93|ExaDigm Inc
+001C94|LI-COR Biosciences
+001C95|Opticomm Corporation
+001C96|Linkwise Technology Pte Ltd
+001C97|Enzytek Technology Inc.,
+001C98|LUCKY TECHNOLOGY (HK) COMPANY LIMITED
+001C99|Shunra Software Ltd.
+001C9A|Nokia Danmark A/S
+001C9B|FEIG ELECTRONIC GmbH
+001C9C|Nortel
+001C9D|Liecthi AG
+001C9E|Dualtech IT AB
+001C9F|Razorstream, LLC
+001CA0|Production Resource Group, LLC
+001CA1|AKAMAI TECHNOLOGIES, INC.
+001CA2|ADB Broadband Italia
+001CA3|Terra
+001CA4|Sony Ericsson Mobile Communications
+001CA5|Zygo Corporation
+001CA6|Win4NET
+001CA7|International Quartz Limited
+001CA8|AirTies Wireless Networks
+001CA9|Audiomatica Srl
+001CAA|Bellon Pty Ltd
+001CAB|Meyer Sound Laboratories, Inc.
+001CAC|Qniq Technology Corp.
+001CAD|Wuhan Telecommunication Devices Co.,Ltd
+001CAE|WiChorus, Inc.
+001CAF|Plato Networks Inc.
+001CB0|Cisco
+001CB1|Cisco
+001CB2|BPT SPA
+001CB3|Apple
+001CB4|Iridium Satellite LLC
+001CB5|Neihua Network Technology Co.,LTD.(NHN)
+001CB6|Duzon CNT Co., Ltd.
+001CB7|USC DigiArk Corporation
+001CB8|CBC Co., Ltd
+001CB9|KWANG SUNG ELECTRONICS CO., LTD.
+001CBA|VerScient, Inc.
+001CBB|MusicianLink
+001CBC|CastGrabber, LLC
+001CBD|Ezze Mobile Tech., Inc.
+001CBE|Nintendo Co., Ltd.
+001CBF|Intel Corporate
+001CC0|Intel Corporate
+001CC1|ARRIS Group, Inc.
+001CC2|Part II Research, Inc.
+001CC3|Pace plc
+001CC4|Hewlett-Packard Company
+001CC5|3COM LTD
+001CC6|ProStor Systems
+001CC7|Rembrandt Technologies, LLC d/b/a REMSTREAM
+001CC8|INDUSTRONIC Industrie-Electronic GmbH & Co. KG
+001CC9|Kaise Electronic Technology Co., Ltd.
+001CCA|Shanghai Gaozhi Science & Technology Development Co.
+001CCB|Forth Corporation Public Company Limited
+001CCC|Research In Motion Limited
+001CCD|Alektrona Corporation
+001CCE|By Techdesign
+001CCF|LIMETEK
+001CD0|Circleone Co.,Ltd.
+001CD1|Waves Audio LTD
+001CD2|King Champion (Hong Kong) Limited
+001CD3|ZP Engineering SEL
+001CD4|Nokia Danmark A/S
+001CD5|ZeeVee, Inc.
+001CD6|Nokia Danmark A/S
+001CD7|Harman/Becker Automotive Systems GmbH
+001CD8|BlueAnt Wireless
+001CD9|GlobalTop Technology Inc.
+001CDA|Exegin Technologies Limited
+001CDB|CARPOINT CO.,LTD
+001CDC|Custom Computer Services, Inc.
+001CDD|COWBELL ENGINEERING CO., LTD.
+001CDE|Interactive Multimedia eXchange Inc.
+001CDF|Belkin International Inc.
+001CE0|DASAN TPS
+001CE1|INDRA SISTEMAS, S.A.
+001CE2|Attero Tech, LLC.
+001CE3|Optimedical Systems
+001CE4|EleSy JSC
+001CE5|MBS Electronic Systems GmbH
+001CE6|INNES
+001CE7|Rocon PLC Research Centre
+001CE8|Cummins Inc
+001CE9|Galaxy Technology Limited
+001CEA|Scientific-Atlanta, Inc
+001CEB|Nortel
+001CEC|Mobilesoft (Aust.) Pty Ltd
+001CED|ENVIRONNEMENT SA
+001CEE|SHARP Corporation
+001CEF|Primax Electronics LTD
+001CF0|D-Link Corporation
+001CF1|SUPoX Technology Co. , LTD.
+001CF2|Tenlon Technology Co.,Ltd.
+001CF3|EVS BROADCAST EQUIPMENT
+001CF4|Media Technology Systems Inc
+001CF5|Wiseblue Technology Limited
+001CF6|Cisco
+001CF7|AudioScience
+001CF8|Parade Technologies, Ltd.
+001CF9|Cisco
+001CFA|Alarm.com
+001CFB|ARRIS Group, Inc.
+001CFC|Suminet Communication Technologies (Shanghai) Co., Ltd.
+001CFD|Universal Electronics
+001CFE|Quartics Inc
+001CFF|Napera Networks Inc
+001D00|Brivo Systems, LLC
+001D01|Neptune Digital
+001D02|Cybertech Telecom Development
+001D03|Design Solutions Inc.
+001D04|Zipit Wireless, Inc.
+001D05|Eaton Corporation
+001D06|HM Electronics, Inc.
+001D07|Shenzhen Sang Fei Consumer Communications Co.,Ltd
+001D08|JIANGSU YINHE ELECTRONICS CO., LTD
+001D09|Dell Inc
+001D0A|Davis Instruments, Inc.
+001D0B|Power Standards Lab
+001D0C|MobileCompia
+001D0D|Sony Computer Entertainment inc.
+001D0E|Agapha Technology co., Ltd.
+001D0F|TP-LINK Technologies Co., Ltd.
+001D10|LightHaus Logic, Inc.
+001D11|Analogue & Micro Ltd
+001D12|ROHM CO., LTD.
+001D13|NextGTV
+001D14|SPERADTONE INFORMATION TECHNOLOGY LIMITED
+001D15|Shenzhen Dolphin Electronic Co., Ltd
+001D16|SFR
+001D17|Digital Sky Corporation
+001D18|Power Innovation GmbH
+001D19|Arcadyan Technology Corporation
+001D1A|OvisLink S.A.
+001D1B|Sangean Electronics Inc.
+001D1C|Gennet s.a.
+001D1D|Inter-M Corporation
+001D1E|KYUSHU TEN CO.,LTD
+001D1F|Siauliu Tauro Televizoriai, JSC
+001D20|COMTREND CO.
+001D21|Alcad SL
+001D22|Foss Analytical A/S
+001D23|SENSUS
+001D24|Aclara Power-Line Systems Inc.
+001D25|Samsung
+001D26|Rockridgesound Technology Co.
+001D27|NAC-INTERCOM
+001D28|Sony Ericsson Mobile Communications AB
+001D29|Doro AB
+001D2A|SHENZHEN BUL-TECH CO.,LTD.
+001D2B|Wuhan Pont Technology CO. , LTD
+001D2C|Wavetrend Technologies (Pty) Limited
+001D2D|Pylone, Inc.
+001D2E|Ruckus Wireless
+001D2F|QuantumVision Corporation
+001D30|YX Wireless S.A.
+001D31|HIGHPRO INTERNATIONAL R&D CO,.LTD.
+001D32|Longkay Communication & Technology (Shanghai) Co. Ltd
+001D33|Maverick Systems Inc.
+001D34|SYRIS Technology Corp
+001D35|Viconics Electronics Inc.
+001D36|ELECTRONICS CORPORATION OF INDIA LIMITED
+001D37|Thales-Panda Transportation System
+001D38|Seagate Technology
+001D39|MOOHADIGITAL CO., LTD
+001D3A|mh acoustics LLC
+001D3B|Nokia Danmark A/S
+001D3C|Muscle Corporation
+001D3D|Avidyne Corporation
+001D3E|SAKA TECHNO SCIENCE CO.,LTD
+001D3F|Mitron Pty Ltd
+001D40|Intel GE Care Innovations LLC
+001D41|Hardy Instruments
+001D42|Nortel
+001D43|Shenzhen G-link Digital Technology Co., Ltd.
+001D44|KROHNE Messtechnik GmbH
+001D45|Cisco
+001D46|Cisco
+001D47|Covote GmbH & Co KG
+001D48|Sensor-Technik Wiedemann GmbH
+001D49|Innovation Wireless Inc.
+001D4A|Carestream Health, Inc.
+001D4B|Grid Connect Inc.
+001D4C|Alcatel-Lucent
+001D4D|Adaptive Recognition Hungary, Inc
+001D4E|TCM Mobile LLC
+001D4F|Apple
+001D50|SPINETIX SA
+001D51|Babcock & Wilcox Power Generation Group, Inc
+001D52|Defzone B.V.
+001D53|S&O Electronics (Malaysia) Sdn. Bhd.
+001D54|Sunnic Technology & Merchandise INC.
+001D55|ZANTAZ, Inc
+001D56|Kramer Electronics Ltd.
+001D57|CAETEC Messtechnik
+001D58|CQ Inc
+001D59|Mitra Energy & Infrastructure
+001D5A|2Wire Inc.
+001D5B|Tecvan Informatica Ltda
+001D5C|Tom Communication Industrial Co.,Ltd.
+001D5D|Control Dynamics Pty. Ltd.
+001D5E|COMING MEDIA CORP.
+001D5F|OverSpeed SARL
+001D60|ASUSTek COMPUTER INC.
+001D61|BIJ Corporation
+001D62|InPhase Technologies
+001D63|Miele & Cie. KG
+001D64|Adam Communications Systems Int Ltd
+001D65|Microwave Radio Communications
+001D66|Hyundai Telecom
+001D67|AMEC
+001D68|Thomson Telecom Belgium
+001D69|Knorr-Bremse IT-Services GmbH
+001D6A|Alpha Networks Inc.
+001D6B|ARRIS Group, Inc.
+001D6C|ClariPhy Communications, Inc.
+001D6D|Confidant International LLC
+001D6E|Nokia Danmark A/S
+001D6F|Chainzone Technology Co., Ltd
+001D70|Cisco
+001D71|Cisco
+001D72|Wistron Corporation
+001D73|Buffalo Inc.
+001D74|Tianjin China-Silicon Microelectronics Co., Ltd.
+001D75|Radioscape PLC
+001D76|Eyeheight Ltd.
+001D77|NSGate
+001D78|Invengo Information Technology Co.,Ltd
+001D79|SIGNAMAX LLC
+001D7A|Wideband Semiconductor, Inc.
+001D7B|Ice Energy, Inc.
+001D7C|ABE Elettronica S.p.A.
+001D7D|GIGA-BYTE TECHNOLOGY CO.,LTD.
+001D7E|Cisco
+001D7F|Tekron International Ltd
+001D80|Beijing Huahuan Eletronics Co.,Ltd
+001D81|GUANGZHOU GATEWAY ELECTRONICS CO., LTD
+001D82|GN A/S (GN Netcom A/S)
+001D83|Emitech Corporation
+001D84|Gateway, Inc.
+001D85|Call Direct Cellular Solutions
+001D86|Shinwa Industries(China) Ltd.
+001D87|VigTech Labs Sdn Bhd
+001D88|Clearwire
+001D89|VaultStor Corporation
+001D8A|TechTrex Inc
+001D8B|ADB Broadband Italia
+001D8C|La Crosse Technology LTD
+001D8D|Raytek GmbH
+001D8E|Alereon, Inc.
+001D8F|PureWave Networks
+001D90|EMCO Flow Systems
+001D91|Digitize, Inc
+001D92|MICRO-STAR INT'L CO.,LTD.
+001D93|Modacom
+001D94|Climax Technology Co., Ltd
+001D95|Flash, Inc.
+001D96|WatchGuard Video
+001D97|Alertus Technologies LLC
+001D98|Nokia Danmark A/S
+001D99|Cyan Optic, Inc.
+001D9A|GODEX INTERNATIONAL CO., LTD
+001D9B|Hokuyo Automatic Co., Ltd.
+001D9C|Rockwell Automation
+001D9D|ARTJOY INTERNATIONAL LIMITED
+001D9E|AXION TECHNOLOGIES
+001D9F|MATT   R.P.Traczynscy Sp.J.
+001DA0|Heng Yu Electronic Manufacturing Company Limited
+001DA1|Cisco
+001DA2|Cisco
+001DA3|SabiOso
+001DA4|Hangzhou System Technology CO., LTD
+001DA5|WB Electronics
+001DA6|Media Numerics Limited
+001DA7|Seamless Internet
+001DA8|Takahata Electronics Co.,Ltd
+001DA9|Castles Technology, Co., LTD
+001DAA|DrayTek Corp.
+001DAB|SwissQual License AG
+001DAC|Gigamon Systems LLC
+001DAD|Sinotech Engineering Consultants, Inc.  Geotechnical Enginee
+001DAE|CHANG TSENG TECHNOLOGY CO., LTD
+001DAF|Nortel
+001DB0|FuJian HengTong Information Technology Co.,Ltd
+001DB1|Crescendo Networks
+001DB2|HOKKAIDO ELECTRIC ENGINEERING CO.,LTD.
+001DB3|HPN Supply Chain
+001DB4|KUMHO ENG CO.,LTD
+001DB5|Juniper networks
+001DB6|BestComm Networks, Inc.
+001DB7|Tendril Networks, Inc.
+001DB8|Intoto Inc.
+001DB9|Wellspring Wireless
+001DBA|Sony Corporation
+001DBB|Dynamic System Electronics Corp.
+001DBC|Nintendo Co., Ltd.
+001DBD|Versamed Inc.
+001DBE|ARRIS Group, Inc.
+001DBF|Radiient Technologies, Inc.
+001DC0|Enphase Energy
+001DC1|Audinate Pty L
+001DC2|XORTEC OY
+001DC3|RIKOR TV, Ltd
+001DC4|AIOI Systems Co., Ltd.
+001DC5|Beijing Jiaxun Feihong Electricial Co., Ltd.
+001DC6|SNR Inc.
+001DC7|L-3 Communications Geneva Aerospace
+001DC8|Navionics Research Inc., dba SCADAmetrics
+001DC9|GainSpan Corp.
+001DCA|PAV Electronics Limited
+001DCB|Exens Development Oy
+001DCC|Hetra Secure Solutions
+001DCD|ARRIS Group, Inc.
+001DCE|ARRIS Group, Inc.
+001DCF|ARRIS Group, Inc.
+001DD0|ARRIS Group, Inc.
+001DD1|ARRIS Group, Inc.
+001DD2|ARRIS Group, Inc.
+001DD3|ARRIS Group, Inc.
+001DD4|ARRIS Group, Inc.
+001DD5|ARRIS Group, Inc.
+001DD6|ARRIS Group, Inc.
+001DD7|Algolith
+001DD8|Microsoft
+001DD9|Hon Hai Precision Ind.Co.,Ltd.
+001DDA|Mikroelektronika spol. s r. o.
+001DDB|C-BEL Corporation
+001DDC|HangZhou DeChangLong Tech&Info Co.,Ltd
+001DDD|DAT H.K. LIMITED
+001DDE|Zhejiang Broadcast&Television Technology Co.,Ltd.
+001DDF|Sunitec Enterprise Co., Ltd.
+001DE0|Intel Corporate
+001DE1|Intel Corporate
+001DE2|Radionor Communications
+001DE3|Intuicom
+001DE4|Visioneered Image Systems
+001DE5|Cisco
+001DE6|Cisco
+001DE7|Marine Sonic Technology, Ltd.
+001DE8|Nikko Denki Tsushin Corporation(NDTC)
+001DE9|Nokia Danmark A/S
+001DEA|Commtest Instruments Ltd
+001DEB|DINEC International
+001DEC|Marusys
+001DED|Grid Net, Inc.
+001DEE|NEXTVISION SISTEMAS DIGITAIS DE TELEVISAO LTDA.
+001DEF|TRIMM, INC.
+001DF0|Vidient Systems, Inc.
+001DF1|Intego Systems, Inc.
+001DF2|Netflix, Inc.
+001DF3|SBS Science & Technology Co., Ltd
+001DF4|Magellan Technology Pty Limited
+001DF5|Sunshine Co,LTD
+001DF6|Samsung
+001DF7|R. STAHL Schaltgerate GmbH
+001DF8|Webpro Vision Technology Corporation
+001DF9|Cybiotronics (Far East) Limited
+001DFA|Fujian LANDI Commercial Equipment Co.,Ltd
+001DFB|NETCLEUS Systems Corporation
+001DFC|KSIC
+001DFD|Nokia Danmark A/S
+001DFE|Palm, Inc
+001DFF|Network Critical Solutions Ltd
+001E00|Shantou Institute of Ultrasonic Instruments
+001E01|Renesas Technology Sales Co., Ltd.
+001E02|Sougou Keikaku Kougyou Co.,Ltd.
+001E03|LiComm Co., Ltd.
+001E04|Hanson Research Corporation
+001E05|Xseed Technologies & Computing
+001E06|WIBRAIN
+001E07|Winy Technology Co., Ltd.
+001E08|Centec Networks Inc
+001E09|ZEFATEK Co.,LTD
+001E0A|Syba Tech Limited
+001E0B|Hewlett-Packard Company
+001E0C|Sherwood Information Partners, Inc.
+001E0D|Micran Ltd.
+001E0E|MAXI VIEW HOLDINGS LIMITED
+001E0F|Briot International
+001E10|ShenZhen Huawei Communication Technologies Co.,Ltd.
+001E11|ELELUX INTERNATIONAL LTD
+001E12|Ecolab
+001E13|Cisco
+001E14|Cisco
+001E15|Beech Hill Electronics
+001E16|Keytronix
+001E17|STN BV
+001E18|Radio Activity srl
+001E19|GTRI
+001E1A|Best Source Taiwan Inc.
+001E1B|Digital Stream Technology, Inc.
+001E1C|SWS Australia Pty Limited
+001E1D|East Coast Datacom, Inc.
+001E1E|Honeywell Life Safety
+001E1F|Nortel
+001E20|Intertain Inc.
+001E21|Qisda Co.
+001E22|ARVOO Imaging Products BV
+001E23|Electronic Educational Devices, Inc
+001E24|Zhejiang Bell Technology Co.,ltd
+001E25|Intek Digital Inc
+001E26|Digifriends Co. Ltd
+001E27|SBN TECH Co.,Ltd.
+001E28|Lumexis Corporation
+001E29|Hypertherm Inc
+001E2A|Netgear
+001E2B|Radio Systems Design, Inc.
+001E2C|CyVerse Corporation
+001E2D|STIM
+001E2E|SIRTI S.p.A.
+001E2F|DiMoto Pty Ltd
+001E30|Shireen Inc
+001E31|INFOMARK CO.,LTD.
+001E32|Zensys
+001E33|Inventec Corporation
+001E34|CryptoMetrics
+001E35|Nintendo Co., Ltd.
+001E36|IPTE
+001E37|Universal Global Scientific Industrial Co., Ltd.
+001E38|Bluecard Software Technology Co., Ltd.
+001E39|Comsys Communication Ltd.
+001E3A|Nokia Danmark A/S
+001E3B|Nokia Danmark A/S
+001E3C|Lyngbox Media AB
+001E3D|Alps Electric Co., Ltd
+001E3E|KMW Inc.
+001E3F|TrellisWare Technologies, Inc.
+001E40|Shanghai DareGlobal Technologies  Co.,Ltd.
+001E41|Microwave Communication & Component, Inc.
+001E42|Teltonika
+001E43|AISIN AW CO.,LTD.
+001E44|SANTEC
+001E45|Sony Ericsson Mobile Communications AB
+001E46|ARRIS Group, Inc.
+001E47|PT. Hariff Daya Tunggal Engineering
+001E48|Wi-Links
+001E49|Cisco
+001E4A|Cisco
+001E4B|City Theatrical
+001E4C|Hon Hai Precision Ind.Co., Ltd.
+001E4D|Welkin Sciences, LLC
+001E4E|DAKO EDV-Ingenieur- und Systemhaus GmbH
+001E4F|Dell Inc.
+001E50|BATTISTONI RESEARCH
+001E51|Converter Industry Srl
+001E52|Apple
+001E53|Further Tech Co., LTD
+001E54|TOYO ELECTRIC Corporation
+001E55|COWON SYSTEMS,Inc.
+001E56|Bally Wulff Entertainment GmbH
+001E57|ALCOMA, spol. s r.o.
+001E58|D-Link Corporation
+001E59|Silicon Turnkey Express, LLC
+001E5A|ARRIS Group, Inc.
+001E5B|Unitron Company, Inc.
+001E5C|RB GeneralEkonomik
+001E5D|Holosys d.o.o.
+001E5E|COmputime Ltd.
+001E5F|KwikByte, LLC
+001E60|Digital Lighting Systems, Inc
+001E61|ITEC GmbH
+001E62|Siemon
+001E63|Vibro-Meter SA
+001E64|Intel Corporate
+001E65|Intel Corporate
+001E66|RESOL Elektronische Regelungen GmbH
+001E67|Intel Corporate
+001E68|Quanta Computer
+001E69|Thomson Inc.
+001E6A|Beijing Bluexon Technology Co.,Ltd
+001E6B|Cisco
+001E6C|Opaque Systems
+001E6D|IT R&D Center
+001E6E|Shenzhen First Mile Communications Ltd
+001E6F|Magna-Power Electronics, Inc.
+001E70|Cobham Defence Communications Ltd
+001E71|MIrcom Group of Companies
+001E72|PCS
+001E73|ZTE CORPORATION
+001E74|SAGEM COMMUNICATION
+001E75|LG Electronics
+001E76|Thermo Fisher Scientific
+001E77|Air2App
+001E78|Owitek Technology Ltd.,
+001E79|Cisco
+001E7A|Cisco
+001E7B|R.I.CO. S.r.l.
+001E7C|Taiwick Limited
+001E7D|Samsung
+001E7E|Nortel
+001E7F|CBM of America
+001E80|Last Mile Ltd.
+001E81|CNB Technology Inc.
+001E82|SanDisk Corporation
+001E83|LAN/MAN Standards Association (LMSC)
+001E84|Pika Technologies Inc.
+001E85|Lagotek Corporation
+001E86|MEL Co.,Ltd.
+001E87|Realease Limited
+001E88|ANDOR SYSTEM SUPPORT CO., LTD.
+001E89|CRFS Limited
+001E8A|eCopy, Inc
+001E8B|Infra Access Korea Co., Ltd.
+001E8C|ASUSTek COMPUTER INC.
+001E8D|ARRIS Group, Inc.
+001E8E|Hunkeler AG
+001E8F|CANON INC.
+001E90|Elitegroup Computer Systems Co
+001E91|KIMIN Electronic Co., Ltd.
+001E92|JEULIN S.A.
+001E93|CiriTech Systems Inc
+001E94|SUPERCOM TECHNOLOGY CORPORATION
+001E95|SIGMALINK
+001E96|Sepura Plc
+001E97|Medium Link System Technology CO., LTD,
+001E98|GreenLine Communications
+001E99|Vantanol Industrial Corporation
+001E9A|HAMILTON Bonaduz AG
+001E9B|San-Eisha, Ltd.
+001E9C|Fidustron INC
+001E9D|Recall Technologies, Inc.
+001E9E|ddm hopt + schuler Gmbh + Co. KG
+001E9F|Visioneering Systems, Inc.
+001EA0|XLN-t
+001EA1|Brunata a/s
+001EA2|Symx Systems, Inc.
+001EA3|Nokia Danmark A/S
+001EA4|Nokia Danmark A/S
+001EA5|ROBOTOUS, Inc.
+001EA6|Best IT World (India) Pvt. Ltd.
+001EA7|ActionTec Electronics, Inc
+001EA8|Datang Mobile Communications Equipment CO.,LTD
+001EA9|Nintendo Co., Ltd.
+001EAA|E-Senza Technologies GmbH
+001EAB|TeleWell Oy
+001EAC|Armadeus Systems
+001EAD|Wingtech Group Limited
+001EAE|Continental Automotive Systems
+001EAF|Ophir Optronics Ltd
+001EB0|ImesD Electronica S.L.
+001EB1|Cryptsoft Pty Ltd
+001EB2|LG innotek
+001EB3|Primex Wireless
+001EB4|UNIFAT TECHNOLOGY LTD.
+001EB5|Ever Sparkle Technologies Ltd
+001EB6|TAG Heuer SA
+001EB7|TBTech, Co., Ltd.
+001EB8|Fortis, Inc.
+001EB9|Sing Fai Technology Limited
+001EBA|High Density Devices AS
+001EBB|BLUELIGHT TECHNOLOGY INC.
+001EBC|WINTECH AUTOMATION CO.,LTD.
+001EBD|Cisco
+001EBE|Cisco
+001EBF|Haas Automation Inc.
+001EC0|Microchip Technology Inc.
+001EC1|3COM EUROPE LTD
+001EC2|Apple
+001EC3|Kozio, Inc.
+001EC4|Celio Corp
+001EC5|Middle Atlantic Products Inc
+001EC6|Obvius Holdings LLC
+001EC7|2Wire, Inc.
+001EC8|Rapid Mobile (Pty) Ltd
+001EC9|Dell Inc
+001ECA|Nortel
+001ECB|"RPC "Energoautomatika" Ltd
+001ECC|CDVI
+001ECD|KYLAND Technology Co. LTD
+001ECE|BISA Technologies (Hong Kong) Limited
+001ECF|PHILIPS ELECTRONICS UK LTD
+001ED0|Ingespace
+001ED1|Keyprocessor B.V.
+001ED2|Ray Shine Video Technology Inc
+001ED3|Dot Technology Int'l Co., Ltd.
+001ED4|Doble Engineering
+001ED5|Tekon-Automatics
+001ED6|Alentec & Orion AB
+001ED7|H-Stream Wireless, Inc.
+001ED8|Digital United Inc.
+001ED9|Mitsubishi Precision Co.,LTd.
+001EDA|Wesemann Elektrotechniek B.V.
+001EDB|Giken Trastem Co., Ltd.
+001EDC|Sony Ericsson Mobile Communications AB
+001EDD|WASKO S.A.
+001EDE|BYD COMPANY LIMITED
+001EDF|Master Industrialization Center Kista
+001EE0|Urmet Domus SpA
+001EE1|Samsung
+001EE2|Samsung
+001EE3|T&W Electronics (ShenZhen) Co.,Ltd
+001EE4|ACS Solutions France
+001EE5|Cisco
+001EE6|Shenzhen Advanced Video Info-Tech Co., Ltd.
+001EE7|Epic Systems Inc
+001EE8|Mytek
+001EE9|Stoneridge Electronics AB
+001EEA|Sensor Switch, Inc.
+001EEB|Talk-A-Phone Co.
+001EEC|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+001EED|Adventiq Ltd.
+001EEE|ETL Systems Ltd
+001EEF|Cantronic International Limited
+001EF0|Gigafin Networks
+001EF1|Servimat
+001EF2|Micro Motion Inc
+001EF3|From2
+001EF4|L-3 Communications Display Systems
+001EF5|Hitek Automated Inc.
+001EF6|Cisco
+001EF7|Cisco
+001EF8|Emfinity Inc.
+001EF9|Pascom Kommunikations systeme GmbH.
+001EFA|PROTEI Ltd.
+001EFB|Trio Motion Technology Ltd
+001EFC|JSC "MASSA-K"
+001EFD|Microbit 2.0 AB
+001EFE|LEVEL s.r.o.
+001EFF|Mueller-Elektronik GmbH & Co. KG
+001F00|Nokia Danmark A/S
+001F01|Nokia Danmark A/S
+001F02|Pixelmetrix Corporation Pte Ltd
+001F03|NUM AG
+001F04|Granch Ltd.
+001F05|iTAS Technology Corp.
+001F06|Integrated Dispatch Solutions
+001F07|AZTEQ Mobile
+001F08|RISCO LTD
+001F09|JASTEC CO., LTD.
+001F0A|Nortel
+001F0B|Federal State Unitary Enterprise Industrial Union"Electropribor"
+001F0C|Intelligent Digital Services GmbH
+001F0D|L3 Communications - Telemetry West
+001F0E|Japan Kyastem Co., Ltd
+001F0F|Select Engineered Systems
+001F10|TOLEDO DO BRASIL INDUSTRIA DE BALANCAS  LTDA
+001F11|OPENMOKO, INC.
+001F12|Juniper Networks
+001F13|S.& A.S. Ltd.
+001F14|NexG
+001F15|Bioscrypt Inc
+001F16|Wistron Corporation
+001F17|IDX Company, Ltd.
+001F18|Hakusan.Mfg.Co,.Ltd
+001F19|BEN-RI ELECTRONICA S.A.
+001F1A|Prominvest
+001F1B|RoyalTek Company Ltd.
+001F1C|KOBISHI ELECTRIC Co.,Ltd.
+001F1D|Atlas Material Testing Technology LLC
+001F1E|Astec Technology Co., Ltd
+001F1F|Edimax Technology Co. Ltd.
+001F20|Logitech Europe SA
+001F21|Inner Mongolia Yin An Science & Technology Development Co.,L
+001F22|Source Photonics, Inc.
+001F23|Interacoustics
+001F24|DIGITVIEW TECHNOLOGY CO., LTD.
+001F25|MBS GmbH
+001F26|Cisco
+001F27|Cisco
+001F28|HPN Supply Chain
+001F29|Hewlett-Packard Company
+001F2A|ACCM
+001F2B|Orange Logic
+001F2C|Starbridge Networks
+001F2D|Electro-Optical Imaging, Inc.
+001F2E|Triangle Research Int'l Pte Ltd
+001F2F|Berker GmbH & Co. KG
+001F30|Travelping
+001F31|Radiocomp
+001F32|Nintendo Co., Ltd.
+001F33|Netgear
+001F34|Lung Hwa Electronics Co., Ltd.
+001F35|AIR802 LLC
+001F36|Bellwin Information Co. Ltd.,
+001F37|Genesis I&C
+001F38|POSITRON
+001F39|Construcciones y Auxiliar de Ferrocarriles, S.A.
+001F3A|Hon Hai Precision Ind.Co., Ltd.
+001F3B|Intel Corporate
+001F3C|Intel Corporate
+001F3D|Qbit GmbH
+001F3E|RP-Technik e.K.
+001F3F|AVM GmbH
+001F40|Speakercraft Inc.
+001F41|Ruckus Wireless
+001F42|Etherstack plc
+001F43|ENTES ELEKTRONIK
+001F44|GE Transportation Systems
+001F45|Enterasys
+001F46|Nortel
+001F47|MCS Logic Inc.
+001F48|Mojix Inc.
+001F49|Manhattan Technology Limited
+001F4A|Albentia Systems S.A.
+001F4B|Lineage Power
+001F4C|Roseman Engineering Ltd
+001F4D|Segnetics LLC
+001F4E|ConMed Linvatec
+001F4F|Thinkware Co. Ltd.
+001F50|Swissdis AG
+001F51|HD Communications Corp
+001F52|UVT Unternehmensberatung fur Verkehr und Technik GmbH
+001F53|GEMAC Gesellschaft fur Mikroelektronikanwendung Chemnitz mbH
+001F54|Lorex Technology Inc.
+001F55|Honeywell Security (China) Co., Ltd.
+001F56|DIGITAL FORECAST
+001F57|Phonik Innovation Co.,LTD
+001F58|EMH Energiemesstechnik GmbH
+001F59|Kronback Tracers
+001F5A|Beckwith Electric Co.
+001F5B|Apple
+001F5C|Nokia Danmark A/S
+001F5D|Nokia Danmark A/S
+001F5E|Dyna Technology Co.,Ltd.
+001F5F|Blatand GmbH
+001F60|COMPASS SYSTEMS CORP.
+001F61|Talent Communication Networks Inc.
+001F62|JSC "Stilsoft"
+001F63|JSC Goodwin-Europa
+001F64|Beijing Autelan Technology Inc.
+001F65|KOREA ELECTRIC TERMINAL CO., LTD.
+001F66|PLANAR LLC
+001F67|Hitachi,Ltd.
+001F68|Martinsson Elektronik AB
+001F69|Pingood Technology Co., Ltd.
+001F6A|PacketFlux Technologies, Inc.
+001F6B|LG Electronics
+001F6C|Cisco
+001F6D|Cisco
+001F6E|Vtech Engineering Corporation
+001F6F|Fujian Sunnada Communication Co.,Ltd.
+001F70|Botik Technologies LTD
+001F71|xG Technology, Inc.
+001F72|QingDao Hiphone Technology Co,.Ltd
+001F73|Teraview Technology Co., Ltd.
+001F74|Eigen Development
+001F75|GiBahn Media
+001F76|AirLogic Systems Inc.
+001F77|HEOL DESIGN
+001F78|Blue Fox Porini Textile
+001F79|Lodam Electronics A/S
+001F7A|WiWide Inc.
+001F7B|TechNexion Ltd.
+001F7C|Witelcom AS
+001F7D|embedded wireless GmbH
+001F7E|ARRIS Group, Inc.
+001F7F|Phabrix Limited
+001F80|Lucas Holding bv
+001F81|Accel Semiconductor Corp
+001F82|Cal-Comp Electronics & Communications Co., Ltd
+001F83|Teleplan Technology Services Sdn Bhd
+001F84|Gigle Semiconductor
+001F85|Apriva ISS, LLC
+001F86|digEcor
+001F87|Skydigital Inc.
+001F88|FMS Force Measuring Systems AG
+001F89|Signalion GmbH
+001F8A|Ellion Digital Inc.
+001F8B|Cache IQ
+001F8C|CCS Inc.
+001F8D|Ingenieurbuero Stark GmbH und Ko. KG
+001F8E|Metris USA Inc.
+001F8F|Shanghai Bellmann Digital Source Co.,Ltd.
+001F90|Actiontec Electronics, Inc
+001F91|DBS Lodging Technologies, LLC
+001F92|VideoIQ, Inc.
+001F93|Xiotech Corporation
+001F94|Lascar Electronics Ltd
+001F95|SAGEM COMMUNICATION
+001F96|APROTECH CO.LTD
+001F97|BERTANA SRL
+001F98|DAIICHI-DENTSU LTD.
+001F99|SERONICS co.ltd
+001F9A|Nortel Networks
+001F9B|POSBRO
+001F9C|LEDCO
+001F9D|Cisco
+001F9E|Cisco
+001F9F|Thomson Telecom Belgium
+001FA0|A10 Networks
+001FA1|Gtran Inc
+001FA2|Datron World Communications, Inc.
+001FA3|T&W Electronics(Shenzhen)Co.,Ltd.
+001FA4|ShenZhen Gongjin Electronics Co.,Ltd
+001FA5|Blue-White Industries
+001FA6|Stilo srl
+001FA7|Sony Computer Entertainment Inc.
+001FA8|Smart Energy Instruments Inc.
+001FA9|Atlanta DTH, Inc.
+001FAA|Taseon, Inc.
+001FAB|I.S HIGH TECH.INC
+001FAC|Goodmill Systems Ltd
+001FAD|Brown Innovations, Inc
+001FAE|Blick South Africa (Pty) Ltd
+001FAF|NextIO, Inc.
+001FB0|TimeIPS, Inc.
+001FB1|Cybertech Inc.
+001FB2|Sontheim Industrie Elektronik GmbH
+001FB3|2Wire
+001FB4|SmartShare Systems
+001FB5|I/O Interconnect Inc.
+001FB6|Chi Lin Technology Co., Ltd.
+001FB7|WiMate Technologies Corp.
+001FB8|Universal Remote Control, Inc.
+001FB9|Paltronics
+001FBA|BoYoung Tech. & Marketing, Inc.
+001FBB|Xenatech Co.,LTD
+001FBC|EVGA Corporation
+001FBD|Kyocera Wireless Corp.
+001FBE|Shenzhen Mopnet Industrial Co.,Ltd
+001FBF|Fulhua Microelectronics Corp. Taiwan Branch
+001FC0|Control Express Finland Oy
+001FC1|Hanlong Technology Co.,LTD
+001FC2|Jow Tong Technology Co Ltd
+001FC3|SmartSynch, Inc
+001FC4|ARRIS Group, Inc.
+001FC5|Nintendo Co., Ltd.
+001FC6|ASUSTek COMPUTER INC.
+001FC7|Casio Hitachi Mobile Comunications Co., Ltd.
+001FC8|Up-Today Industrial Co., Ltd.
+001FC9|Cisco
+001FCA|Cisco
+001FCB|NIW Solutions
+001FCC|Samsung
+001FCD|Samsung
+001FCE|QTECH LLC
+001FCF|MSI Technology GmbH
+001FD0|GIGA-BYTE TECHNOLOGY CO.,LTD.
+001FD1|OPTEX CO.,LTD.
+001FD2|COMMTECH TECHNOLOGY MACAO COMMERCIAL OFFSHORE LTD.
+001FD3|RIVA Networks Inc.
+001FD4|4IPNET, INC.
+001FD5|MICRORISC s.r.o.
+001FD6|Shenzhen Allywll
+001FD7|TELERAD SA
+001FD8|A-TRUST COMPUTER CORPORATION
+001FD9|RSD Communications Ltd
+001FDA|Nortel Networks
+001FDB|Network Supply Corp.,
+001FDC|Mobile Safe Track Ltd
+001FDD|GDI LLC
+001FDE|Nokia Danmark A/S
+001FDF|Nokia Danmark A/S
+001FE0|EdgeVelocity Corp
+001FE1|Hon Hai Precision Ind. Co., Ltd.
+001FE2|Hon Hai Precision Ind. Co., Ltd.
+001FE3|LG Electronics
+001FE4|Sony Ericsson Mobile Communications
+001FE5|In-Circuit GmbH
+001FE6|Alphion Corporation
+001FE7|Simet
+001FE8|KURUSUGAWA Electronics Industry Inc,.
+001FE9|Printrex, Inc.
+001FEA|Applied Media Technologies Corporation
+001FEB|Trio Datacom Pty Ltd
+001FEC|Synapse Electronique
+001FED|Tecan Systems Inc.
+001FEE|ubisys technologies GmbH
+001FEF|SHINSEI INDUSTRIES CO.,LTD
+001FF0|Audio Partnership
+001FF1|Paradox Hellas S.A.
+001FF2|VIA Technologies, Inc.
+001FF3|Apple
+001FF4|Power Monitors, Inc.
+001FF5|Kongsberg Defence & Aerospace
+001FF6|PS Audio International
+001FF7|Nakajima All Precision Co., Ltd.
+001FF8|Siemens AG, Sector Industry, Drive Technologies, Motion Control Systems
+001FF9|Advanced Knowledge Associates
+001FFA|Coretree, Co, Ltd
+001FFB|Green Packet Bhd
+001FFC|Riccius+Sohn GmbH
+001FFD|Indigo Mobile Technologies Corp.
+001FFE|HPN Supply Chain
+001FFF|Respironics, Inc.
+002000|LEXMARK INTERNATIONAL, INC.
+002001|DSP SOLUTIONS, INC.
+002002|SERITECH ENTERPRISE CO., LTD.
+002003|PIXEL POWER LTD.
+002004|YAMATAKE-HONEYWELL CO., LTD.
+002005|SIMPLE TECHNOLOGY
+002006|GARRETT COMMUNICATIONS, INC.
+002007|SFA, INC.
+002008|CABLE & COMPUTER TECHNOLOGY
+002009|PACKARD BELL ELEC., INC.
+00200A|SOURCE-COMM CORP.
+00200B|OCTAGON SYSTEMS CORP.
+00200C|ADASTRA SYSTEMS CORP.
+00200D|CARL ZEISS
+00200E|SATELLITE TECHNOLOGY MGMT, INC
+00200F|TANBAC CO., LTD.
+002010|JEOL SYSTEM TECHNOLOGY CO. LTD
+002011|CANOPUS CO., LTD.
+002012|CAMTRONICS MEDICAL SYSTEMS
+002013|DIVERSIFIED TECHNOLOGY, INC.
+002014|GLOBAL VIEW CO., LTD.
+002015|ACTIS COMPUTER SA
+002016|SHOWA ELECTRIC WIRE & CABLE CO
+002017|ORBOTECH
+002018|CIS TECHNOLOGY INC.
+002019|OHLER GmbH
+00201A|MRV Communications, Inc.
+00201B|NORTHERN TELECOM/NETWORK
+00201C|EXCEL, INC.
+00201D|KATANA PRODUCTS
+00201E|NETQUEST CORPORATION
+00201F|BEST POWER TECHNOLOGY, INC.
+002020|MEGATRON COMPUTER INDUSTRIES PTY, LTD.
+002021|ALGORITHMS SOFTWARE PVT. LTD.
+002022|NMS Communications
+002023|T.C. TECHNOLOGIES PTY. LTD
+002024|PACIFIC COMMUNICATION SCIENCES
+002025|CONTROL TECHNOLOGY, INC.
+002026|AMKLY SYSTEMS, INC.
+002027|MING FORTUNE INDUSTRY CO., LTD
+002028|WEST EGG SYSTEMS, INC.
+002029|TELEPROCESSING PRODUCTS, INC.
+00202A|N.V. DZINE
+00202B|ADVANCED TELECOMMUNICATIONS MODULES, LTD.
+00202C|WELLTRONIX CO., LTD.
+00202D|TAIYO CORPORATION
+00202E|DAYSTAR DIGITAL
+00202F|ZETA COMMUNICATIONS, LTD.
+002030|ANALOG & DIGITAL SYSTEMS
+002031|Tattile SRL
+002032|ALCATEL TAISEL
+002033|SYNAPSE TECHNOLOGIES, INC.
+002034|ROTEC INDUSTRIEAUTOMATION GMBH
+002035|IBM Corp
+002036|BMC SOFTWARE
+002037|SEAGATE TECHNOLOGY
+002038|VME MICROSYSTEMS INTERNATIONAL CORPORATION
+002039|SCINETS
+00203A|DIGITAL BI0METRICS INC.
+00203B|WISDM LTD.
+00203C|EUROTIME AB
+00203D|Honeywell ECC
+00203E|LogiCan Technologies, Inc.
+00203F|JUKI CORPORATION
+002040|ARRIS Group, Inc.
+002041|DATA NET
+002042|DATAMETRICS CORP.
+002043|NEURON COMPANY LIMITED
+002044|GENITECH PTY LTD
+002045|ION Networks, Inc.
+002046|CIPRICO, INC.
+002047|STEINBRECHER CORP.
+002048|Marconi Communications
+002049|COMTRON, INC.
+00204A|PRONET GMBH
+00204B|AUTOCOMPUTER CO., LTD.
+00204C|MITRON COMPUTER PTE LTD.
+00204D|INOVIS GMBH
+00204E|NETWORK SECURITY SYSTEMS, INC.
+00204F|DEUTSCHE AEROSPACE AG
+002050|KOREA COMPUTER INC.
+002051|Verilink Corporation
+002052|RAGULA SYSTEMS
+002053|HUNTSVILLE MICROSYSTEMS, INC.
+002054|Sycamore Networks
+002055|ALTECH CO., LTD.
+002056|NEOPRODUCTS
+002057|TITZE DATENTECHNIK GmbH
+002058|ALLIED SIGNAL INC.
+002059|MIRO COMPUTER PRODUCTS AG
+00205A|COMPUTER IDENTICS
+00205B|Kentrox, LLC
+00205C|InterNet Systems of Florida, Inc.
+00205D|NANOMATIC OY
+00205E|CASTLE ROCK, INC.
+00205F|GAMMADATA COMPUTER GMBH
+002060|ALCATEL ITALIA S.p.A.
+002061|GarrettCom, Inc.
+002062|SCORPION LOGIC, LTD.
+002063|WIPRO INFOTECH LTD.
+002064|PROTEC MICROSYSTEMS, INC.
+002065|SUPERNET NETWORKING INC.
+002066|GENERAL MAGIC, INC.
+002067|IEEE OUI Administation (was: Node Runner Inc) 
+002068|ISDYNE
+002069|ISDN SYSTEMS CORPORATION
+00206A|OSAKA COMPUTER CORP.
+00206B|KONICA MINOLTA HOLDINGS, INC.
+00206C|EVERGREEN TECHNOLOGY CORP.
+00206D|DATA RACE, INC.
+00206E|XACT, INC.
+00206F|FLOWPOINT CORPORATION
+002070|HYNET, LTD.
+002071|IBR GMBH
+002072|WORKLINK INNOVATIONS
+002073|FUSION SYSTEMS CORPORATION
+002074|SUNGWOON SYSTEMS
+002075|Motorola
+002076|REUDO CORPORATION
+002077|KARDIOS SYSTEMS CORP.
+002078|RUNTOP, INC.
+002079|MIKRON GMBH
+00207A|WiSE Communications, Inc.
+00207B|Intel Corporate
+00207C|AUTEC GmbH
+00207D|ADVANCED COMPUTER APPLICATIONS
+00207E|FINECOM Co., Ltd.
+00207F|KYOEI SANGYO CO., LTD.
+002080|SYNERGY (UK) LTD.
+002081|TITAN ELECTRONICS
+002082|ONEAC CORPORATION
+002083|PRESTICOM INCORPORATED
+002084|OCE PRINTING SYSTEMS, GMBH
+002085|Eaton Corporation
+002086|MICROTECH ELECTRONICS LIMITED
+002087|MEMOTEC, INC.
+002088|GLOBAL VILLAGE COMMUNICATION
+002089|T3PLUS NETWORKING, INC.
+00208A|SONIX COMMUNICATIONS, LTD.
+00208B|LAPIS TECHNOLOGIES, INC.
+00208C|GALAXY NETWORKS, INC.
+00208D|CMD TECHNOLOGY
+00208E|CHEVIN SOFTWARE ENG. LTD.
+00208F|ECI TELECOM LTD.
+002090|ADVANCED COMPRESSION TECHNOLOGY, INC.
+002091|J125, NATIONAL SECURITY AGENCY
+002092|CHESS ENGINEERING B.V.
+002093|LANDINGS TECHNOLOGY CORP.
+002094|CUBIX CORPORATION
+002095|RIVA ELECTRONICS
+002096|Invensys
+002097|APPLIED SIGNAL TECHNOLOGY
+002098|HECTRONIC AB
+002099|BON ELECTRIC CO., LTD.
+00209A|THE 3DO COMPANY
+00209B|ERSAT ELECTRONIC GMBH
+00209C|PRIMARY ACCESS CORP.
+00209D|LIPPERT AUTOMATIONSTECHNIK
+00209E|BROWN'S OPERATING SYSTEM SERVICES, LTD.
+00209F|MERCURY COMPUTER SYSTEMS, INC.
+0020A0|OA LABORATORY CO., LTD.
+0020A1|DOVATRON
+0020A2|GALCOM NETWORKING LTD.
+0020A3|Harmonic, Inc
+0020A4|MULTIPOINT NETWORKS
+0020A5|API ENGINEERING
+0020A6|Proxim Wireless
+0020A7|PAIRGAIN TECHNOLOGIES, INC.
+0020A8|SAST TECHNOLOGY CORP.
+0020A9|WHITE HORSE INDUSTRIAL
+0020AA|Ericsson Television Limited
+0020AB|MICRO INDUSTRIES CORP.
+0020AC|INTERFLEX DATENSYSTEME GMBH
+0020AD|LINQ SYSTEMS
+0020AE|ORNET DATA COMMUNICATION TECH.
+0020AF|3COM CORPORATION
+0020B0|GATEWAY DEVICES, INC.
+0020B1|COMTECH RESEARCH INC.
+0020B2|GKD Gesellschaft Fur Kommunikation Und Datentechnik
+0020B3|Tattile SRL
+0020B4|TERMA ELEKTRONIK AS
+0020B5|YASKAWA ELECTRIC CORPORATION
+0020B6|AGILE NETWORKS, INC.
+0020B7|NAMAQUA COMPUTERWARE
+0020B8|PRIME OPTION, INC.
+0020B9|METRICOM, INC.
+0020BA|CENTER FOR HIGH PERFORMANCE
+0020BB|ZAX CORPORATION
+0020BC|Long Reach Networks Pty Ltd
+0020BD|NIOBRARA R & D CORPORATION
+0020BE|LAN ACCESS CORP.
+0020BF|AEHR TEST SYSTEMS
+0020C0|PULSE ELECTRONICS, INC.
+0020C1|SAXA, Inc.
+0020C2|TEXAS MEMORY SYSTEMS, INC.
+0020C3|COUNTER SOLUTIONS LTD.
+0020C4|INET,INC.
+0020C5|EAGLE TECHNOLOGY
+0020C6|NECTEC
+0020C7|AKAI Professional M.I. Corp.
+0020C8|LARSCOM INCORPORATED
+0020C9|VICTRON BV
+0020CA|DIGITAL OCEAN
+0020CB|PRETEC ELECTRONICS CORP.
+0020CC|DIGITAL SERVICES, LTD.
+0020CD|HYBRID NETWORKS, INC.
+0020CE|LOGICAL DESIGN GROUP, INC.
+0020CF|TEST & MEASUREMENT SYSTEMS INC
+0020D0|VERSALYNX CORPORATION
+0020D1|MICROCOMPUTER SYSTEMS (M) SDN.
+0020D2|RAD DATA COMMUNICATIONS, LTD.
+0020D3|OST (OUEST STANDARD TELEMATIQU
+0020D4|CABLETRON - ZEITTNET INC.
+0020D5|VIPA GMBH
+0020D6|BREEZECOM
+0020D7|JAPAN MINICOMPUTER SYSTEMS CO., Ltd.
+0020D8|Nortel Networks
+0020D9|PANASONIC TECHNOLOGIES, INC./MIECO-US
+0020DA|Alcatel North America ESD
+0020DB|XNET TECHNOLOGY, INC.
+0020DC|DENSITRON TAIWAN LTD.
+0020DD|Cybertec Pty Ltd
+0020DE|JAPAN DIGITAL LABORAT'Y CO.LTD
+0020DF|KYOSAN ELECTRIC MFG. CO., LTD.
+0020E0|Actiontec Electronics, Inc.
+0020E1|ALAMAR ELECTRONICS
+0020E2|INFORMATION RESOURCE ENGINEERING
+0020E3|MCD KENCOM CORPORATION
+0020E4|HSING TECH ENTERPRISE CO., LTD
+0020E5|APEX DATA, INC.
+0020E6|LIDKOPING MACHINE TOOLS AB
+0020E7|B&W NUCLEAR SERVICE COMPANY
+0020E8|DATATREK CORPORATION
+0020E9|DANTEL
+0020EA|EFFICIENT NETWORKS, INC.
+0020EB|CINCINNATI MICROWAVE, INC.
+0020EC|TECHWARE SYSTEMS CORP.
+0020ED|GIGA-BYTE TECHNOLOGY CO., LTD.
+0020EE|GTECH CORPORATION
+0020EF|USC CORPORATION
+0020F0|UNIVERSAL MICROELECTRONICS CO.
+0020F1|ALTOS INDIA LIMITED
+0020F2|Oracle Corporation
+0020F3|RAYNET CORPORATION
+0020F4|SPECTRIX CORPORATION
+0020F5|PANDATEL AG
+0020F6|NET TEK  AND KARLNET, INC.
+0020F7|CYBERDATA CORPORATION
+0020F8|CARRERA COMPUTERS, INC.
+0020F9|PARALINK NETWORKS, INC.
+0020FA|GDE SYSTEMS, INC.
+0020FB|OCTEL COMMUNICATIONS CORP.
+0020FC|MATROX
+0020FD|ITV TECHNOLOGIES, INC.
+0020FE|TOPWARE INC. / GRAND COMPUTER
+0020FF|SYMMETRICAL TECHNOLOGIES
+002100|GemTek Technology Co., Ltd.
+002101|Aplicaciones Electronicas Quasar (AEQ)
+002102|UpdateLogic Inc.
+002103|GHI Electronics, LLC
+002104|Gigaset Communications GmbH
+002105|Alcatel-Lucent
+002106|RIM Testing Services
+002107|Seowonintech Co Ltd.
+002108|Nokia Danmark A/S
+002109|Nokia Danmark A/S
+00210A|byd:sign Corporation
+00210B|GEMINI TRAZE RFID PVT. LTD.
+00210C|Cymtec Systems, Inc.
+00210D|SAMSIN INNOTEC
+00210E|Orpak Systems L.T.D.
+00210F|Cernium Corp
+002110|Clearbox Systems
+002111|Uniphone Inc.
+002112|WISCOM SYSTEM CO.,LTD
+002113|Padtec S/A
+002114|Hylab Technology Inc.
+002115|PHYWE Systeme GmbH & Co. KG
+002116|Transcon Electronic Systems, spol. s r. o.
+002117|Tellord
+002118|Athena Tech, Inc.
+002119|Samsung
+00211A|LInTech Corporation
+00211B|Cisco
+00211C|Cisco
+00211D|Dataline AB
+00211E|ARRIS Group, Inc.
+00211F|SHINSUNG DELTATECH CO.,LTD.
+002120|Sequel Technologies
+002121|VRmagic GmbH
+002122|Chip-pro Ltd.
+002123|Aerosat Avionics
+002124|Optos Plc
+002125|KUK JE TONG SHIN Co.,LTD
+002126|Shenzhen Torch Equipment Co., Ltd.
+002127|TP-LINK Technology Co., Ltd.
+002128|Oracle Corporation
+002129|Cisco
+00212A|Audiovox Corporation
+00212B|MSA Auer
+00212C|SemIndia System Private Limited
+00212D|SCIMOLEX CORPORATION
+00212E|dresden-elektronik
+00212F|Phoebe Micro Inc.
+002130|Keico Hightech Inc.
+002131|Blynke Inc.
+002132|Masterclock, Inc.
+002133|Building B, Inc
+002134|Brandywine Communications
+002135|ALCATEL-LUCENT
+002136|ARRIS Group, Inc.
+002137|Bay Controls, LLC
+002138|Cepheid
+002139|Escherlogic Inc.
+00213A|Winchester Systems Inc.
+00213B|Berkshire Products, Inc
+00213C|AliphCom
+00213D|Cermetek Microelectronics, Inc.
+00213E|TomTom
+00213F|A-Team Technology Ltd.
+002140|EN Technologies Inc.
+002141|RADLIVE
+002142|Advanced Control Systems doo
+002143|ARRIS Group, Inc.
+002144|SS Telecoms
+002145|Semptian Technologies Ltd.
+002146|Sanmina-SCI
+002147|Nintendo Co., Ltd.
+002148|Kaco Solar Korea
+002149|China Daheng Group ,Inc.
+00214A|Pixel Velocity, Inc
+00214B|Shenzhen HAMP Science & Technology Co.,Ltd
+00214C|Samsung
+00214D|Guangzhou Skytone Transmission Technology Com. Ltd.
+00214E|GS Yuasa Power Supply Ltd.
+00214F|ALPS Electric Co., Ltd
+002150|EYEVIEW ELECTRONICS
+002151|Millinet Co., Ltd.
+002152|General Satellite Research & Development Limited
+002153|SeaMicro Inc.
+002154|D-TACQ Solutions Ltd
+002155|Cisco
+002156|Cisco
+002157|National Datacast, Inc.
+002158|Style Flying Technology Co.
+002159|Juniper Networks
+00215A|Hewlett-Packard Company
+00215B|Inotive
+00215C|Intel Corporate
+00215D|Intel Corporate
+00215E|IBM Corp
+00215F|IHSE GmbH
+002160|Hidea Solutions Co. Ltd.
+002161|Yournet Inc.
+002162|Nortel
+002163|ASKEY COMPUTER CORP
+002164|Special Design Bureau for Seismic Instrumentation
+002165|Presstek Inc.
+002166|NovAtel Inc.
+002167|HWA JIN T&I Corp.
+002168|iVeia, LLC
+002169|Prologix, LLC.
+00216A|Intel Corporate
+00216B|Intel Corporate
+00216C|ODVA
+00216D|Soltech Co., Ltd.
+00216E|Function ATI (Huizhou) Telecommunications Co., Ltd.
+00216F|SymCom, Inc.
+002170|Dell Inc
+002171|Wesung TNC Co., Ltd.
+002172|Seoultek Valley
+002173|Ion Torrent Systems, Inc.
+002174|AvaLAN Wireless
+002175|Pacific Satellite International Ltd.
+002176|YMax Telecom Ltd.
+002177|W. L. Gore & Associates
+002178|Matuschek Messtechnik GmbH
+002179|IOGEAR, Inc.
+00217A|Sejin Electron, Inc.
+00217B|Bastec AB
+00217C|2Wire
+00217D|PYXIS S.R.L.
+00217E|Telit Communication s.p.a
+00217F|Intraco Technology Pte Ltd
+002180|ARRIS Group, Inc.
+002181|Si2 Microsystems Limited
+002182|SandLinks Systems, Ltd.
+002183|VATECH HYDRO
+002184|POWERSOFT SRL
+002185|MICRO-STAR INT'L CO.,LTD.
+002186|Universal Global Scientific Industrial Co., Ltd
+002187|Imacs GmbH
+002188|EMC Corporation
+002189|AppTech, Inc.
+00218A|Electronic Design and Manufacturing Company
+00218B|Wescon Technology, Inc.
+00218C|TopControl GMBH
+00218D|AP Router Ind. Eletronica LTDA
+00218E|MEKICS CO., LTD.
+00218F|Avantgarde Acoustic Lautsprechersysteme GmbH
+002190|Goliath Solutions
+002191|D-Link Corporation
+002192|Baoding Galaxy Electronic Technology  Co.,Ltd
+002193|Videofon MV
+002194|Ping Communication
+002195|GWD Media Limited
+002196|Telsey  S.p.A.
+002197|ELITEGROUP COMPUTER SYSTEM
+002198|Thai Radio Co, LTD
+002199|Vacon Plc
+00219A|Cambridge Visual Networks Ltd
+00219B|Dell Inc
+00219C|Honeywld Technology Corp.
+00219D|Adesys BV
+00219E|Sony Ericsson Mobile Communications
+00219F|SATEL OY
+0021A0|Cisco
+0021A1|Cisco
+0021A2|EKE-Electronics Ltd.
+0021A3|Micromint
+0021A4|Dbii Networks
+0021A5|ERLPhase Power Technologies Ltd.
+0021A6|Videotec Spa
+0021A7|Hantle System Co., Ltd.
+0021A8|Telephonics Corporation
+0021A9|Mobilink Telecom Co.,Ltd
+0021AA|Nokia Danmark A/S
+0021AB|Nokia Danmark A/S
+0021AC|Infrared Integrated Systems Ltd
+0021AD|Nordic ID Oy
+0021AE|ALCATEL-LUCENT FRANCE - WTD
+0021AF|Radio Frequency Systems
+0021B0|Tyco Telecommunications
+0021B1|DIGITAL SOLUTIONS LTD
+0021B2|Fiberblaze A/S
+0021B3|Ross Controls
+0021B4|APRO MEDIA CO., LTD
+0021B5|Galvanic Ltd
+0021B6|Triacta Power Technologies Inc.
+0021B7|Lexmark International Inc.
+0021B8|Inphi Corporation
+0021B9|Universal Devices Inc.
+0021BA|Texas Instruments
+0021BB|Riken Keiki Co., Ltd.
+0021BC|ZALA COMPUTER
+0021BD|Nintendo Co., Ltd.
+0021BE|Cisco
+0021BF|Hitachi High-Tech Control Systems Corporation
+0021C0|Mobile Appliance, Inc.
+0021C1|ABB Oy / Medium Voltage Products
+0021C2|GL Communications Inc
+0021C3|CORNELL Communications, Inc.
+0021C4|Consilium AB
+0021C5|3DSP Corp
+0021C6|CSJ Global, Inc.
+0021C7|Russound
+0021C8|LOHUIS Networks
+0021C9|Wavecom Asia Pacific Limited
+0021CA|ART System Co., Ltd.
+0021CB|SMS TECNOLOGIA ELETRONICA LTDA
+0021CC|Flextronics International
+0021CD|LiveTV
+0021CE|NTC-Metrotek
+0021CF|The Crypto Group
+0021D0|Global Display Solutions Spa
+0021D1|Samsung
+0021D2|Samsung
+0021D3|BOCOM SECURITY(ASIA PACIFIC) LIMITED
+0021D4|Vollmer Werke GmbH
+0021D5|X2E GmbH
+0021D6|LXI Consortium
+0021D7|Cisco
+0021D8|Cisco
+0021D9|SEKONIC CORPORATION
+0021DA|Automation Products Group Inc.
+0021DB|Santachi Video Technology (Shenzhen) Co., Ltd.
+0021DC|TECNOALARM S.r.l.
+0021DD|Northstar Systems Corp
+0021DE|Firepro Wireless
+0021DF|Martin Christ GmbH
+0021E0|CommAgility Ltd
+0021E1|Nortel Networks
+0021E2|Creative Electronic GmbH
+0021E3|SerialTek LLC
+0021E4|I-WIN
+0021E5|Display Solution AG
+0021E6|Starlight Video Limited
+0021E7|Informatics Services Corporation
+0021E8|Murata Manufacturing Co., Ltd.
+0021E9|Apple
+0021EA|Bystronic Laser AG
+0021EB|ESP SYSTEMS, LLC
+0021EC|Solutronic GmbH
+0021ED|Telegesis
+0021EE|Full Spectrum Inc.
+0021EF|Kapsys
+0021F0|EW3 Technologies LLC
+0021F1|Tutus Data AB
+0021F2|EASY3CALL Technology Limited
+0021F3|Si14 SpA
+0021F4|INRange Systems, Inc
+0021F5|Western Engravers Supply, Inc.
+0021F6|Oracle Corporation
+0021F7|HPN Supply Chain
+0021F8|Enseo, Inc.
+0021F9|WIRECOM Technologies
+0021FA|A4SP Technologies Ltd.
+0021FB|LG Electronics
+0021FC|Nokia Danmark A/S
+0021FD|DSTA S.L.
+0021FE|Nokia Danmark A/S
+0021FF|Cyfrowy Polsat SA
+002200|IBM Corp
+002201|Aksys Networks Inc
+002202|Excito Elektronik i Skane AB
+002203|Glensound Electronics Ltd
+002204|KORATEK
+002205|WeLink Solutions, Inc.
+002206|Cyberdyne Inc.
+002207|Inteno Broadband Technology AB
+002208|Certicom Corp
+002209|Omron Healthcare Co., Ltd
+00220A|OnLive, Inc
+00220B|National Source Coding Center
+00220C|Cisco
+00220D|Cisco
+00220E|Indigo Security Co., Ltd.
+00220F|MoCA (Multimedia over Coax Alliance)
+002210|ARRIS Group, Inc.
+002211|Rohati Systems
+002212|CAI Networks, Inc.
+002213|PCI CORPORATION
+002214|RINNAI KOREA
+002215|ASUSTek COMPUTER INC.
+002216|SHIBAURA VENDING MACHINE CORPORATION
+002217|Neat Electronics
+002218|Verivue Inc.
+002219|Dell Inc
+00221A|Audio Precision
+00221B|Morega Systems
+00221C|ASSIGNED - PRIVATE REGISTRATION 
+00221D|Freegene Technology LTD
+00221E|Media Devices Co., Ltd.
+00221F|eSang Technologies Co., Ltd.
+002220|Mitac Technology Corp
+002221|ITOH DENKI CO,LTD.
+002222|Schaffner Deutschland GmbH
+002223|TimeKeeping Systems, Inc.
+002224|Good Will Instrument Co., Ltd.
+002225|Thales Avionics Ltd
+002226|Avaak, Inc.
+002227|uv-electronic GmbH
+002228|Breeze Innovations Ltd.
+002229|Compumedics Ltd
+00222A|SoundEar A/S
+00222B|Nucomm, Inc.
+00222C|Ceton Corp
+00222D|SMC Networks Inc.
+00222E|maintech GmbH
+00222F|Open Grid Computing, Inc.
+002230|FutureLogic Inc.
+002231|SMT&C Co., Ltd.
+002232|Design Design Technology Ltd
+002233|ADB Broadband Italia
+002234|Corventis Inc.
+002235|Strukton Systems bv
+002236|VECTOR SP. Z O.O.
+002237|Shinhint Group
+002238|LOGIPLUS
+002239|Indiana Life Sciences Incorporated
+00223A|Scientific Atlanta, Cisco SPVT Group
+00223B|Communication Networks, LLC
+00223C|RATIO Entwicklungen GmbH
+00223D|JumpGen Systems, LLC
+00223E|IRTrans GmbH
+00223F|Netgear
+002240|Universal Telecom S/A
+002241|Apple
+002242|Alacron Inc.
+002243|AzureWave Technologies, Inc.
+002244|Chengdu Linkon Communications Device Co., Ltd
+002245|Leine & Linde AB
+002246|Evoc Intelligent Technology Co.,Ltd.
+002247|DAC ENGINEERING CO., LTD.
+002248|Microsoft
+002249|HOME MULTIENERGY SL
+00224A|RAYLASE AG
+00224B|AIRTECH TECHNOLOGIES, INC.
+00224C|Nintendo Co., Ltd.
+00224D|MITAC INTERNATIONAL CORP.
+00224E|SEEnergy Corp.
+00224F|Byzoro Networks Ltd.
+002250|Point Six Wireless, LLC
+002251|Lumasense Technologies
+002252|ZOLL Lifecor Corporation
+002253|Entorian Technologies
+002254|Bigelow Aerospace
+002255|Cisco
+002256|Cisco
+002257|3Com Europe Ltd
+002258|Taiyo Yuden Co., Ltd.
+002259|Guangzhou New Postcom Equipment Co.,Ltd.
+00225A|Garde Security AB
+00225B|Teradici Corporation
+00225C|Multimedia & Communication Technology
+00225D|Digicable Network India Pvt. Ltd.
+00225E|Uwin Technologies Co.,LTD
+00225F|Liteon Technology Corporation
+002260|AFREEY Inc.
+002261|Frontier Silicon Ltd
+002262|BEP Marine
+002263|Koos Technical Services, Inc.
+002264|Hewlett-Packard Company
+002265|Nokia Danmark A/S
+002266|Nokia Danmark A/S
+002267|Nortel Networks
+002268|Hon Hai Precision Ind. Co., Ltd.
+002269|Hon Hai Precision Ind. Co., Ltd.
+00226A|Honeywell
+00226B|Cisco
+00226C|LinkSprite Technologies, Inc.
+00226D|Shenzhen GIEC Electronics Co., Ltd.
+00226E|Gowell Electronic Limited
+00226F|3onedata Technology Co. Ltd.
+002270|ABK North America, LLC
+002271|Jager Computergesteuerte MeBtechnik GmbH.
+002272|American Micro-Fuel Device Corp.
+002273|Techway
+002274|FamilyPhone AB
+002275|Belkin International Inc.
+002276|Triple EYE B.V.
+002277|NEC Australia Pty Ltd
+002278|Shenzhen  Tongfang Multimedia  Technology Co.,Ltd.
+002279|Nippon Conlux Co., Ltd.
+00227A|Telecom Design
+00227B|Apogee Labs, Inc.
+00227C|Woori SMT Co.,ltd
+00227D|YE DATA INC.
+00227E|Chengdu 30Kaitian Communication Industry Co.Ltd
+00227F|Ruckus Wireless
+002280|A2B Electronics AB
+002281|Daintree Networks Pty
+002282|8086 Consultancy
+002283|Juniper Networks
+002284|DESAY A&V SCIENCE AND TECHNOLOGY CO.,LTD
+002285|NOMUS COMM SYSTEMS
+002286|ASTRON
+002287|Titan Wireless LLC
+002288|Sagrad, Inc.
+002289|Optosecurity Inc.
+00228A|Teratronik elektronische systeme gmbh
+00228B|Kensington Computer Products Group
+00228C|Photon Europe GmbH
+00228D|GBS Laboratories LLC
+00228E|TV-NUMERIC
+00228F|CNRS
+002290|Cisco
+002291|Cisco
+002292|Cinetal
+002293|ZTE Corporation
+002294|Kyocera Corporation
+002295|SGM Technology for lighting spa
+002296|LinoWave Corporation
+002297|XMOS Semiconductor
+002298|Sony Ericsson Mobile Communications
+002299|SeaMicro Inc.
+00229A|Lastar, Inc.
+00229B|AverLogic Technologies, Inc.
+00229C|Verismo Networks Inc
+00229D|PYUNG-HWA IND.CO.,LTD
+00229E|Social Aid Research Co., Ltd.
+00229F|Sensys Traffic AB
+0022A0|Delphi Corporation
+0022A1|Huawei Symantec Technologies Co.,Ltd.
+0022A2|Xtramus Technologies
+0022A3|California Eastern Laboratories
+0022A4|2Wire
+0022A5|Texas Instruments
+0022A6|Sony Computer Entertainment America
+0022A7|Tyco Electronics AMP GmbH
+0022A8|Ouman Oy
+0022A9|LG Electronics
+0022AA|Nintendo Co., Ltd.
+0022AB|Shenzhen Turbosight Technology Ltd
+0022AC|Hangzhou Siyuan Tech. Co., Ltd
+0022AD|TELESIS TECHNOLOGIES, INC.
+0022AE|Mattel Inc.
+0022AF|Safety Vision
+0022B0|D-Link Corporation
+0022B1|Elbit Systems
+0022B2|4RF Communications Ltd
+0022B3|Sei S.p.A.
+0022B4|ARRIS Group, Inc.
+0022B5|NOVITA
+0022B6|Superflow Technologies Group
+0022B7|GSS Grundig SAT-Systems GmbH
+0022B8|Norcott
+0022B9|Analogix Seminconductor, Inc
+0022BA|HUTH Elektronik Systeme GmbH
+0022BB|beyerdynamic GmbH & Co. KG
+0022BC|JDSU France SAS
+0022BD|Cisco
+0022BE|Cisco
+0022BF|SieAmp Group of Companies
+0022C0|Shenzhen Forcelink Electronic Co, Ltd
+0022C1|Active Storage Inc.
+0022C2|Proview Eletronica do Brasil LTDA
+0022C3|Zeeport Technology Inc.
+0022C4|epro GmbH
+0022C5|INFORSON Co,Ltd.
+0022C6|Sutus Inc
+0022C7|SEGGER Microcontroller GmbH & Co. KG
+0022C8|Applied Instruments B.V.
+0022C9|Lenord, Bauer & Co GmbH
+0022CA|Anviz Biometric Tech. Co., Ltd.
+0022CB|IONODES Inc.
+0022CC|SciLog, Inc.
+0022CD|Ared Technology Co., Ltd.
+0022CE|Cisco
+0022CF|PLANEX Communications INC
+0022D0|Polar Electro Oy
+0022D1|Albrecht Jung GmbH & Co. KG
+0022D2|All Earth Comercio de Eletronicos LTDA.
+0022D3|Hub-Tech
+0022D4|ComWorth Co., Ltd.
+0022D5|Eaton Corp. Electrical Group Data Center Solutions - Pulizzi
+0022D6|Cypak AB
+0022D7|Nintendo Co., Ltd.
+0022D8|Shenzhen GST Security and Safety Technology Limited
+0022D9|Fortex Industrial Ltd.
+0022DA|ANATEK, LLC
+0022DB|Translogic Corporation
+0022DC|Vigil Health Solutions Inc.
+0022DD|Protecta Electronics Ltd
+0022DE|OPPO Digital, Inc.
+0022DF|TAMUZ Monitors
+0022E0|Atlantic Software Technologies S.r.L.
+0022E1|ZORT Labs, LLC.
+0022E2|WABTEC Transit Division
+0022E3|Amerigon
+0022E4|APASS TECHNOLOGY CO., LTD.
+0022E5|Fisher-Rosemount Systems Inc.
+0022E6|Intelligent Data
+0022E7|WPS Parking Systems
+0022E8|Applition Co., Ltd.
+0022E9|ProVision Communications
+0022EA|Rustelcom Inc.
+0022EB|Data Respons A/S
+0022EC|IDEALBT TECHNOLOGY CORPORATION
+0022ED|TSI Power Corporation
+0022EE|Algo Communication Products Ltd
+0022EF|iWDL Technologies
+0022F0|3 Greens Aviation Limited
+0022F1|ASSIGNED - PRIVATE REGISTRATION 
+0022F2|SunPower Corp
+0022F3|SHARP Corporation
+0022F4|AMPAK Technology, Inc.
+0022F5|Advanced Realtime Tracking GmbH
+0022F6|Syracuse Research Corporation
+0022F7|Conceptronic
+0022F8|PIMA Electronic Systems Ltd.
+0022F9|Pollin Electronic GmbH
+0022FA|Intel Corporate
+0022FB|Intel Corporate
+0022FC|Nokia Danmark A/S
+0022FD|Nokia Danmark A/S
+0022FE|Advanced Illumination
+0022FF|iWDL Technologies
+002300|Cayee Computer Ltd.
+002301|Witron Technology Limited
+002302|Cobalt Digital, Inc.
+002303|LITE-ON IT Corporation
+002304|Cisco
+002305|Cisco
+002306|ALPS Electric Co., Ltd
+002307|FUTURE INNOVATION TECH CO.,LTD
+002308|Arcadyan Technology Corporation
+002309|Janam Technologies LLC
+00230A|ARBURG GmbH & Co KG
+00230B|ARRIS Group, Inc.
+00230C|CLOVER ELECTRONICS CO.,LTD.
+00230D|Nortel Networks
+00230E|Gorba AG
+00230F|Hirsch Electronics Corporation
+002310|LNC Technology Co., Ltd.
+002311|Gloscom Co., Ltd.
+002312|Apple
+002313|Qool Technologies Ltd.
+002314|Intel Corporate
+002315|Intel Corporate
+002316|KISAN ELECTRONICS CO
+002317|Lasercraft Inc
+002318|Toshiba
+002319|Sielox LLC
+00231A|ITF Co., Ltd.
+00231B|Danaher Motion - Kollmorgen
+00231C|Fourier Systems Ltd.
+00231D|Deltacom Electronics Ltd
+00231E|Cezzer Multimedia Technologies
+00231F|Guangda Electronic & Telecommunication Technology Development Co., Ltd.
+002320|Nicira Networks
+002321|Avitech International Corp
+002322|KISS Teknical Solutions, Inc.
+002323|Zylin AS
+002324|G-PRO COMPUTER
+002325|IOLAN Holding
+002326|Fujitsu Limited
+002327|Shouyo Electronics CO., LTD
+002328|ALCON TELECOMMUNICATIONS CO., LTD.
+002329|DDRdrive LLC
+00232A|eonas IT-Beratung und -Entwicklung GmbH
+00232B|IRD A/S
+00232C|Senticare
+00232D|SandForce
+00232E|Kedah Electronics Engineering, LLC
+00232F|Advanced Card Systems Ltd.
+002330|DIZIPIA, INC.
+002331|Nintendo Co., Ltd.
+002332|Apple
+002333|Cisco
+002334|Cisco
+002335|Linkflex Co.,Ltd
+002336|METEL s.r.o.
+002337|Global Star Solutions ULC
+002338|OJ-Electronics A/S
+002339|Samsung
+00233A|Samsung
+00233B|C-Matic Systems Ltd
+00233C|Alflex
+00233D|Novero holding B.V.
+00233E|Alcatel-Lucent-IPD
+00233F|Purechoice Inc
+002340|MiX Telematics
+002341|Siemens AB, Infrastructure & Cities, Building Technologies Division, IC BT SSP SP BA PR
+002342|Coffee Equipment Company
+002343|TEM AG
+002344|Objective Interface Systems, Inc.
+002345|Sony Ericsson Mobile Communications
+002346|Vestac
+002347|ProCurve Networking by HP
+002348|SAGEM COMMUNICATION
+002349|Helmholtz Centre Berlin for Material and Energy
+00234A|ASSIGNED - PRIVATE REGISTRATION 
+00234B|Inyuan Technology Inc.
+00234C|KTC AB
+00234D|Hon Hai Precision Ind. Co., Ltd.
+00234E|Hon Hai Precision Ind. Co., Ltd.
+00234F|Luminous Power Technologies Pvt. Ltd.
+002350|LynTec
+002351|2Wire
+002352|DATASENSOR S.p.A.
+002353|F E T Elettronica snc
+002354|ASUSTek COMPUTER INC.
+002355|Kinco Automation(Shanghai) Ltd.
+002356|Packet Forensics LLC
+002357|Pitronot Technologies and Engineering P.T.E. Ltd.
+002358|SYSTEL SA
+002359|Benchmark Electronics ( Thailand ) Public Company Limited
+00235A|COMPAL INFORMATION (KUNSHAN) CO., Ltd.
+00235B|Gulfstream
+00235C|Aprius, Inc.
+00235D|Cisco
+00235E|Cisco
+00235F|Silicon Micro Sensors GmbH
+002360|Lookit Technology Co., Ltd
+002361|Unigen Corporation
+002362|Goldline Controls
+002363|Zhuhai RaySharp Technology Co., Ltd.
+002364|Power Instruments Pte Ltd
+002365|ELKA-Elektronik GmbH
+002366|Beijing Siasun Electronic System Co.,Ltd.
+002367|UniControls a.s.
+002368|Zebra Technologies Inc
+002369|Cisco
+00236A|SmartRG Inc
+00236B|Xembedded, Inc.
+00236C|Apple
+00236D|ResMed Ltd
+00236E|Burster GmbH & Co KG
+00236F|DAQ System
+002370|Snell
+002371|SOAM Systel
+002372|MORE STAR INDUSTRIAL GROUP LIMITED
+002373|GridIron Systems, Inc.
+002374|ARRIS Group, Inc.
+002375|ARRIS Group, Inc.
+002376|HTC Corporation
+002377|Isotek Electronics Ltd
+002378|GN Netcom A/S
+002379|Union Business Machines Co. Ltd.
+00237A|RIM
+00237B|WHDI LLC
+00237C|NEOTION
+00237D|Hewlett-Packard Company
+00237E|ELSTER GMBH
+00237F|PLANTRONICS, INC.
+002380|Nanoteq
+002381|Lengda Technology(Xiamen) Co.,Ltd.
+002382|Lih Rong Electronic Enterprise Co., Ltd.
+002383|InMage Systems Inc
+002384|GGH Engineering s.r.l.
+002385|ANTIPODE
+002386|Tour & Andersson AB
+002387|ThinkFlood, Inc.
+002388|V.T. Telematica S.p.a.
+002389|HANGZHOU H3C Technologies Co., Ltd.
+00238A|Ciena Corporation
+00238B|Quanta Computer Inc.
+00238C|ASSIGNED - PRIVATE REGISTRATION 
+00238D|Techno Design Co., Ltd.
+00238E|Pirelli Tyre S.p.A.
+00238F|NIDEC COPAL CORPORATION
+002390|Algolware Corporation
+002391|Maxian
+002392|Proteus Industries Inc.
+002393|AJINEXTEK
+002394|Samjeon
+002395|ARRIS Group, Inc.
+002396|ANDES TECHNOLOGY CORPORATION
+002397|Westell Technologies Inc.
+002398|Sky Control
+002399|VD Division, Samsung Electronics Co.
+00239A|EasyData Hardware GmbH
+00239B|Elster Solutions, LLC
+00239C|Juniper Networks
+00239D|Mapower Electronics Co., Ltd
+00239E|Jiangsu Lemote Technology Corporation Limited
+00239F|Institut fur Pruftechnik
+0023A0|Hana CNS Co., LTD.
+0023A1|Trend Electronics Ltd
+0023A2|ARRIS Group, Inc.
+0023A3|ARRIS Group, Inc.
+0023A4|New Concepts Development Corp.
+0023A5|SageTV, LLC
+0023A6|E-Mon
+0023A7|Redpine Signals, Inc.
+0023A8|Marshall Electronics
+0023A9|Beijing Detianquan Electromechanical Equipment Co., Ltd
+0023AA|HFR, Inc.
+0023AB|Cisco
+0023AC|Cisco
+0023AD|Xmark Corporation
+0023AE|Dell Inc.
+0023AF|ARRIS Group, Inc.
+0023B0|COMXION Technology Inc.
+0023B1|Longcheer Technology (Singapore) Pte Ltd
+0023B2|Intelligent Mechatronic Systems Inc
+0023B3|Lyyn AB
+0023B4|Nokia Danmark A/S
+0023B5|ORTANA LTD
+0023B6|SECURITE COMMUNICATIONS / HONEYWELL
+0023B7|Q-Light Co., Ltd.
+0023B8|Sichuan Jiuzhou Electronic Technology Co.,Ltd
+0023B9|EADS Deutschland GmbH
+0023BA|Chroma
+0023BB|Schmitt Industries
+0023BC|EQ-SYS GmbH
+0023BD|Digital Ally, Inc.
+0023BE|Cisco
+0023BF|Mainpine, Inc.
+0023C0|Broadway Networks
+0023C1|Securitas Direct AB
+0023C2|Samsung
+0023C3|LogMeIn, Inc.
+0023C4|Lux Lumen
+0023C5|Radiation Safety and Control Services Inc
+0023C6|SMC Corporation
+0023C7|AVSystem
+0023C8|TEAM-R
+0023C9|Sichuan Tianyi Information Science & Technology Stock CO.,LTD
+0023CA|Behind The Set, LLC
+0023CB|Shenzhen Full-join Technology Co.,Ltd
+0023CC|Nintendo Co., Ltd.
+0023CD|TP-LINK TECHNOLOGIES CO., LTD.
+0023CE|KITA DENSHI CORPORATION
+0023CF|CUMMINS-ALLISON CORP.
+0023D0|Uniloc USA Inc.
+0023D1|TRG
+0023D2|Inhand Electronics, Inc.
+0023D3|AirLink WiFi Networking Corp.
+0023D4|Texas Instruments
+0023D5|WAREMA electronic GmbH
+0023D6|Samsung
+0023D7|Samsung
+0023D8|Ball-It Oy
+0023D9|Banner Engineering
+0023DA|Industrial Computer Source (Deutschland)GmbH
+0023DB|saxnet gmbh
+0023DC|Benein, Inc
+0023DD|ELGIN S.A.
+0023DE|Ansync Inc.
+0023DF|Apple
+0023E0|INO Therapeutics LLC
+0023E1|Cavena Image Products AB
+0023E2|SEA Signalisation
+0023E3|Microtronic AG
+0023E4|IPnect co. ltd.
+0023E5|IPaXiom Networks
+0023E6|Pirkus, Inc.
+0023E7|Hinke A/S
+0023E8|Demco Corp.
+0023E9|F5 Networks, Inc.
+0023EA|Cisco
+0023EB|Cisco
+0023EC|Algorithmix GmbH
+0023ED|ARRIS Group, Inc.
+0023EE|ARRIS Group, Inc.
+0023EF|Zuend Systemtechnik AG
+0023F0|Shanghai Jinghan Weighing Apparatus Co. Ltd.
+0023F1|Sony Ericsson Mobile Communications
+0023F2|TVLogic
+0023F3|Glocom, Inc.
+0023F4|Masternaut
+0023F5|WILO SE
+0023F6|Softwell Technology Co., Ltd.
+0023F7|ASSIGNED - PRIVATE REGISTRATION 
+0023F8|ZyXEL Communications Corporation
+0023F9|Double-Take Software, INC.
+0023FA|RG Nets, Inc.
+0023FB|IP Datatel, LLC.
+0023FC|Ultra Stereo Labs, Inc
+0023FD|AFT Atlas Fahrzeugtechnik GmbH
+0023FE|Biodevices, SA
+0023FF|Beijing HTTC Technology Ltd.
+002400|Nortel Networks
+002401|D-Link Corporation
+002402|Op-Tection GmbH
+002403|Nokia Danmark A/S
+002404|Nokia Danmark A/S
+002405|Dilog Nordic AB
+002406|Pointmobile
+002407|TELEM SAS
+002408|Pacific Biosciences
+002409|The Toro Company
+00240A|US Beverage Net
+00240B|Virtual Computer Inc.
+00240C|DELEC GmbH
+00240D|OnePath Networks LTD.
+00240E|Inventec Besta Co., Ltd.
+00240F|Ishii Tool & Engineering Corporation
+002410|NUETEQ Technology,Inc.
+002411|PharmaSmart LLC
+002412|Benign Technologies Co, Ltd.
+002413|Cisco
+002414|Cisco
+002415|Magnetic Autocontrol GmbH
+002416|Any Use
+002417|Thomson Telecom Belgium
+002418|Nextwave Semiconductor
+002419|ASSIGNED - PRIVATE REGISTRATION 
+00241A|Red Beetle Inc.
+00241B|iWOW Communications Pte Ltd
+00241C|FuGang Electronic (DG) Co.,Ltd
+00241D|GIGA-BYTE TECHNOLOGY CO.,LTD.
+00241E|Nintendo Co., Ltd.
+00241F|DCT-Delta GmbH
+002420|NetUP Inc.
+002421|MICRO-STAR INT'L CO., LTD.
+002422|Knapp Logistik Automation GmbH
+002423|AzureWave Technologies (Shanghai) Inc.
+002424|Axis Network Technology
+002425|Shenzhenshi chuangzhicheng Technology Co.,Ltd
+002426|NOHMI BOSAI LTD.
+002427|SSI COMPUTER CORP
+002428|EnergyICT
+002429|MK MASTER INC.
+00242A|Hittite Microwave Corporation
+00242B|Hon Hai Precision Ind.Co.,Ltd.
+00242C|Hon Hai Precision Ind. Co., Ltd.
+00242E|Datastrip Inc.
+00242F|Micron
+002430|Ruby Tech Corp.
+002431|Uni-v co.,ltd
+002432|Neostar Technology Co.,LTD
+002433|Alps Electric Co., Ltd
+002434|Lectrosonics, Inc.
+002435|WIDE CORPORATION
+002436|Apple
+002437|Motorola
+002438|Brocade Communications Systems, Inc
+002439|Digital Barriers Advanced Technologies
+00243A|Ludl Electronic Products
+00243B|CSSI (S) Pte Ltd
+00243C|S.A.A.A.
+00243D|Emerson Appliance Motors and Controls
+00243F|Storwize, Inc.
+002440|Halo Monitoring, Inc.
+002441|Wanzl Metallwarenfabrik GmbH
+002442|Axona Limited
+002443|Nortel Networks
+002444|Nintendo Co., Ltd.
+002445|CommScope Canada Inc.
+002446|MMB Research Inc.
+002447|Kaztek Systems
+002448|SpiderCloud Wireless, Inc
+002449|Shen Zhen Lite Star Electronics Technology Co., Ltd
+00244A|Voyant International
+00244B|PERCEPTRON INC
+00244C|Solartron Metrology Ltd
+00244D|Hokkaido Electronics Corporation
+00244E|RadChips, Inc.
+00244F|Asantron Technologies Ltd.
+002450|Cisco
+002451|Cisco
+002452|Silicon Software GmbH
+002453|Initra d.o.o.
+002454|Samsung
+002455|MuLogic BV
+002456|2Wire
+002458|PA Bastion CC
+002459|ABB STOTZ-KONTAKT GmbH
+00245A|Nanjing Panda Electronics Company Limited
+00245B|RAIDON TECHNOLOGY, INC.
+00245C|Design-Com Technologies Pty. Ltd.
+00245D|Terberg besturingstechniek B.V.
+00245E|Hivision Co.,ltd
+00245F|Vine Telecom CO.,Ltd.
+002460|Giaval Science Development Co. Ltd.
+002461|Shin Wang Tech.
+002462|Rayzone Corporation
+002463|Phybridge Inc
+002464|Bridge Technologies Co AS
+002465|Elentec
+002466|Unitron nv
+002467|AOC International (Europe) GmbH
+002468|Sumavision Technologies Co.,Ltd
+002469|Smart Doorphones
+00246A|Solid Year Co., Ltd.
+00246B|Covia, Inc.
+00246C|ARUBA NETWORKS, INC.
+00246D|Weinzierl Engineering GmbH
+00246E|Phihong USA Corp.
+00246F|Onda Communication spa
+002470|AUROTECH ultrasound AS.
+002471|Fusion MultiSystems dba Fusion-io
+002472|ReDriven Power Inc.
+002473|3Com Europe Ltd
+002474|Autronica Fire And Securirty
+002475|Compass System(Embedded Dept.)
+002476|TAP.tv
+002477|Tibbo Technology
+002478|Mag Tech Electronics Co Limited
+002479|Optec Displays, Inc.
+00247A|FU YI CHENG Technology Co., Ltd.
+00247B|Actiontec Electronics, Inc
+00247C|Nokia Danmark A/S
+00247D|Nokia Danmark A/S
+00247E|Universal Global Scientific Industrial Co., Ltd
+00247F|Nortel Networks
+002480|Meteocontrol GmbH
+002481|Hewlett-Packard Company
+002482|Ruckus Wireless
+002483|LG Electronics
+002484|Bang and Olufsen Medicom a/s
+002485|ConteXtream Ltd
+002486|DesignArt Networks
+002487|Blackboard Inc.
+002488|Centre For Development Of Telematics
+002489|Vodafone Omnitel N.V.
+00248A|Kaga Electronics Co., Ltd.
+00248B|HYBUS CO., LTD.
+00248C|ASUSTek COMPUTER INC.
+00248D|Sony Computer Entertainment Inc.
+00248E|Infoware ZRt.
+00248F|DO-MONIX
+002490|Samsung
+002491|Samsung
+002492|Motorola
+002493|ARRIS Group, Inc.
+002494|Shenzhen Baoxin Tech CO., Ltd.
+002495|ARRIS Group, Inc.
+002496|Ginzinger electronic systems
+002497|Cisco
+002498|Cisco
+002499|Aquila Technologies
+00249A|Beijing Zhongchuang Telecommunication Test Co., Ltd.
+00249B|Action Star Enterprise Co., Ltd.
+00249C|Bimeng Comunication System Co. Ltd
+00249D|NES Technology Inc.
+00249E|ADC-Elektronik GmbH
+00249F|RIM Testing Services
+0024A0|ARRIS Group, Inc.
+0024A1|ARRIS Group, Inc.
+0024A2|Hong Kong Middleware Technology Limited
+0024A3|Sonim Technologies Inc
+0024A4|Siklu Communication
+0024A5|Buffalo Inc.
+0024A6|TELESTAR DIGITAL GmbH
+0024A7|Advanced Video Communications Inc.
+0024A8|ProCurve Networking by HP
+0024A9|Ag Leader Technology
+0024AA|Dycor Technologies Ltd.
+0024AB|A7 Engineering, Inc.
+0024AC|Hangzhou DPtech Technologies Co., Ltd.
+0024AD|Adolf Thies Gmbh & Co. KG
+0024AE|Morpho
+0024AF|EchoStar Technologies
+0024B0|ESAB AB
+0024B1|Coulomb Technologies
+0024B2|Netgear
+0024B3|Graf-Syteco GmbH & Co. KG
+0024B4|ESCATRONIC GmbH
+0024B5|Nortel Networks
+0024B6|Seagate Technology
+0024B7|GridPoint, Inc.
+0024B8|free alliance sdn bhd
+0024B9|Wuhan Higheasy Electronic Technology Development Co.Ltd
+0024BA|Texas Instruments
+0024BB|CENTRAL Corporation
+0024BC|HuRob Co.,Ltd
+0024BD|Hainzl Industriesysteme GmbH
+0024BE|Sony Corporation
+0024BF|CIAT
+0024C0|NTI COMODO INC
+0024C1|ARRIS Group, Inc.
+0024C2|Asumo Co.,Ltd.
+0024C3|Cisco
+0024C4|Cisco
+0024C5|Meridian Audio Limited
+0024C6|Hager Electro SAS
+0024C7|Mobilarm Ltd
+0024C8|Broadband Solutions Group
+0024C9|Broadband Solutions Group
+0024CA|Tobii Technology AB
+0024CB|Autonet Mobile
+0024CC|Fascinations Toys and Gifts, Inc.
+0024CD|Willow Garage, Inc.
+0024CE|Exeltech Inc
+0024CF|Inscape Data Corporation
+0024D0|Shenzhen SOGOOD Industry CO.,LTD.
+0024D1|Thomson Inc.
+0024D2|Askey Computer
+0024D3|QUALICA Inc.
+0024D4|FREEBOX SA
+0024D5|Winward Industrial Limited
+0024D6|Intel Corporate
+0024D7|Intel Corporate
+0024D8|IlSung Precision
+0024D9|BICOM, Inc.
+0024DA|Innovar Systems Limited
+0024DB|Alcohol Monitoring Systems
+0024DC|Juniper Networks
+0024DD|Centrak, Inc.
+0024DE|GLOBAL Technology Inc.
+0024DF|Digitalbox Europe GmbH
+0024E0|DS Tech, LLC
+0024E1|Convey Computer Corp.
+0024E2|HASEGAWA ELECTRIC CO.,LTD.
+0024E3|CAO Group
+0024E4|Withings
+0024E5|Seer Technology, Inc
+0024E6|In Motion Technology Inc.
+0024E7|Plaster Networks
+0024E8|Dell Inc.
+0024E9|Samsung
+0024EA|iris-GmbH infrared & intelligent sensors
+0024EB|ClearPath Networks, Inc.
+0024EC|United Information Technology Co.,Ltd.
+0024ED|YT Elec. Co,.Ltd.
+0024EE|Wynmax Inc.
+0024EF|Sony Ericsson Mobile Communications
+0024F0|Seanodes
+0024F1|Shenzhen Fanhai Sanjiang Electronics Co., Ltd.
+0024F2|Uniphone Telecommunication Co., Ltd.
+0024F3|Nintendo Co., Ltd.
+0024F4|Kaminario Technologies Ltd.
+0024F5|NDS Surgical Imaging
+0024F6|MIYOSHI ELECTRONICS CORPORATION
+0024F7|Cisco
+0024F8|Technical Solutions Company Ltd.
+0024F9|Cisco
+0024FA|Hilger u. Kern GMBH
+0024FB|ASSIGNED - PRIVATE REGISTRATION 
+0024FC|QuoPin Co., Ltd.
+0024FD|Accedian Networks Inc
+0024FE|AVM GmbH
+0024FF|QLogic Corporation
+002500|Apple
+002501|JSC "Supertel"
+002502|NaturalPoint
+002503|IBM Corp
+002504|Valiant Communications Limited
+002505|eks Engel GmbH & Co. KG
+002506|A.I. ANTITACCHEGGIO ITALIA SRL
+002507|ASTAK Inc.
+002508|Maquet Cardiopulmonary AG
+002509|SHARETRONIC Group LTD
+00250A|Security Expert Co. Ltd
+00250B|CENTROFACTOR  INC
+00250C|Enertrac
+00250D|GZT Telkom-Telmor sp. z o.o.
+00250E|gt german telematics gmbh
+00250F|On-Ramp Wireless, Inc.
+002510|Pico-Tesla Magnetic Therapies
+002511|ELITEGROUP COMPUTER SYSTEM CO., LTD.
+002512|ZTE Corporation
+002513|CXP DIGITAL BV
+002514|PC Worth Int'l Co., Ltd.
+002515|SFR
+002516|Integrated Design Tools, Inc.
+002517|Venntis, LLC
+002518|Power PLUS Communications AG
+002519|Viaas Inc
+00251A|Psiber Data Systems Inc.
+00251B|Philips CareServant
+00251C|EDT
+00251D|DSA Encore, LLC
+00251E|ROTEL TECHNOLOGIES
+00251F|ZYNUS VISION INC.
+002520|SMA Railway Technology GmbH
+002521|Logitek Electronic Systems, Inc.
+002522|ASRock Incorporation
+002523|OCP Inc.
+002524|Lightcomm Technology Co., Ltd
+002525|CTERA Networks Ltd.
+002526|Genuine Technologies Co., Ltd.
+002527|Bitrode Corp.
+002528|Daido Signal Co., Ltd.
+002529|COMELIT GROUP S.P.A
+00252A|Chengdu GeeYa Technology Co.,LTD
+00252B|Stirling Energy Systems
+00252C|Entourage Systems, Inc.
+00252D|Kiryung Electronics
+00252E|Cisco
+00252F|Energy, Inc.
+002530|Aetas Systems Inc.
+002531|Cloud Engines, Inc.
+002532|Digital Recorders
+002533|WITTENSTEIN AG
+002535|Minimax GmbH & Co KG
+002536|Oki Electric Industry Co., Ltd.
+002537|Runcom Technologies Ltd.
+002538|Samsung
+002539|IfTA GmbH
+00253A|CEVA, Ltd.
+00253B|din Dietmar Nocker Facilitymanagement GmbH
+00253C|2Wire
+00253D|DRS Consolidated Controls
+00253E|Sensus Metering Systems
+002540|Quasar Technologies, Inc.
+002541|Maquet Critical Care AB
+002542|Pittasoft
+002543|MONEYTECH
+002544|LoJack Corporation
+002545|Cisco
+002546|Cisco
+002547|Nokia Danmark A/S
+002548|Nokia Danmark A/S
+002549|Jeorich Tech. Co.,Ltd.
+00254A|RingCube Technologies, Inc.
+00254B|Apple
+00254C|Videon Central, Inc.
+00254D|Singapore Technologies Electronics Limited
+00254E|Vertex Wireless Co., Ltd.
+00254F|ELETTROLAB Srl
+002550|Riverbed Technology
+002551|SE-Elektronic GmbH
+002552|VXI CORPORATION
+002553|Pirelli Tyre S.p.A.
+002554|Pixel8 Networks
+002555|Visonic Technologies 1993 Ltd
+002556|Hon Hai Precision Ind. Co., Ltd.
+002557|Research In Motion
+002558|MPEDIA
+002559|Syphan Technologies Ltd
+00255A|Tantalus Systems Corp.
+00255B|CoachComm, LLC
+00255C|NEC Corporation
+00255D|Morningstar Corporation
+00255E|Shanghai Dare Technologies Co.,Ltd.
+00255F|SenTec AG
+002560|Ibridge Networks & Communications Ltd.
+002561|ProCurve Networking by HP
+002562|interbro Co. Ltd.
+002563|Luxtera Inc
+002564|Dell Inc.
+002565|Vizimax Inc.
+002566|Samsung
+002567|Samsung
+002568|Shenzhen Huawei Communication Technologies Co., Ltd
+002569|SAGEM COMMUNICATION
+00256A|inIT - Institut Industrial IT
+00256B|ATENIX E.E. s.r.l.
+00256C|"Azimut" Production Association JSC
+00256D|Broadband Forum
+00256E|Van Breda B.V.
+00256F|Dantherm Power
+002570|Eastern Communications Company Limited
+002571|Zhejiang Tianle Digital Electric Co.,Ltd
+002572|Nemo-Q International AB
+002573|ST Electronics (Info-Security) Pte Ltd
+002574|KUNIMI MEDIA DEVICE Co., Ltd.
+002575|FiberPlex Technologies, LLC
+002576|NELI TECHNOLOGIES
+002577|D-BOX Technologies
+002578|JSC "Concern "Sozvezdie"
+002579|J & F Labs
+00257A|CAMCO Produktions- und Vertriebs-GmbH fur  Beschallungs- und Beleuchtungsanlagen
+00257B|STJ  ELECTRONICS  PVT  LTD
+00257C|Huachentel Technology Development Co., Ltd
+00257D|PointRed Telecom Private Ltd.
+00257E|NEW POS Technology Limited
+00257F|CallTechSolution Co.,Ltd
+002580|Equipson S.A.
+002581|x-star networks Inc.
+002582|Maksat Technologies (P) Ltd
+002583|Cisco
+002584|Cisco
+002585|KOKUYO S&T Co., Ltd.
+002586|TP-LINK Technologies Co., Ltd.
+002587|Vitality, Inc.
+002588|Genie Industries, Inc.
+002589|Hills Industries Limited
+00258A|Pole/Zero Corporation
+00258B|Mellanox Technologies Ltd
+00258C|ESUS ELEKTRONIK SAN. VE DIS. TIC. LTD. STI.
+00258D|Haier
+00258E|The Weather Channel
+00258F|Trident Microsystems, Inc.
+002590|Super Micro Computer, Inc.
+002591|NEXTEK, Inc.
+002592|Guangzhou Shirui Electronic Co., Ltd
+002593|DatNet Informatikai Kft.
+002594|Eurodesign BG LTD
+002595|Northwest Signal Supply, Inc
+002596|GIGAVISION srl
+002597|Kalki Communication Technologies
+002598|Zhong Shan City Litai Electronic Industrial Co. Ltd
+002599|Hedon e.d. B.V.
+00259A|CEStronics GmbH
+00259B|Beijing PKUNITY Microsystems Technology Co., Ltd
+00259C|Cisco
+00259D|ASSIGNED - PRIVATE REGISTRATION 
+00259E|Huawei Technologies Co., Ltd.
+00259F|TechnoDigital Technologies GmbH
+0025A0|Nintendo Co., Ltd.
+0025A1|Enalasys
+0025A2|Alta Definicion LINCEO S.L.
+0025A3|Trimax Wireless, Inc.
+0025A4|EuroDesign embedded technologies GmbH
+0025A5|Walnut Media Network
+0025A6|Central Network Solution Co., Ltd.
+0025A7|Comverge, Inc.
+0025A8|Kontron (BeiJing) Technology Co.,Ltd
+0025A9|Shanghai Embedway Information Technologies Co.,Ltd
+0025AA|Beijing Soul Technology Co.,Ltd.
+0025AB|AIO LCD PC BU / TPV
+0025AC|I-Tech corporation
+0025AD|Manufacturing Resources International
+0025AE|Microsoft
+0025AF|COMFILE Technology
+0025B0|Schmartz Inc
+0025B1|Maya-Creation Corporation
+0025B2|MBDA Deutschland GmbH
+0025B3|Hewlett-Packard Company
+0025B4|Cisco
+0025B5|Cisco
+0025B6|Telecom FM
+0025B7|Costar  electronics, inc.,
+0025B8|Agile Communications, Inc.
+0025B9|Cypress Solutions Inc
+0025BA|Alcatel-Lucent IPD
+0025BB|INNERINT Co., Ltd.
+0025BC|Apple
+0025BD|Italdata Ingegneria dell'Idea S.p.A.
+0025BE|Tektrap Systems Inc.
+0025BF|Wireless Cables Inc.
+0025C0|ZillionTV Corporation
+0025C1|Nawoo Korea Corp.
+0025C2|RingBell Co.,Ltd.
+0025C3|Nortel Networks
+0025C4|Ruckus Wireless
+0025C5|Star Link Communication Pvt. Ltd.
+0025C6|kasercorp, ltd
+0025C7|altek Corporation
+0025C8|S-Access GmbH
+0025C9|SHENZHEN HUAPU DIGITAL CO., LTD
+0025CA|LS Research, LLC
+0025CB|Reiner SCT
+0025CC|Mobile Communications Korea Incorporated
+0025CD|Skylane Optics
+0025CE|InnerSpace
+0025CF|Nokia Danmark A/S
+0025D0|Nokia Danmark A/S
+0025D1|Eastern Asia Technology Limited
+0025D2|InpegVision Co., Ltd
+0025D3|AzureWave Technologies, Inc
+0025D4|Fortress Technologies
+0025D5|Robonica (Pty) Ltd
+0025D6|The Kroger Co.
+0025D7|CEDO
+0025D8|KOREA MAINTENANCE
+0025D9|DataFab Systems Inc.
+0025DA|Secura Key
+0025DB|ATI Electronics(Shenzhen) Co., LTD
+0025DC|Sumitomo Electric Networks, Inc
+0025DD|SUNNYTEK INFORMATION CO., LTD.
+0025DE|Probits Co., LTD.
+0025DF|ASSIGNED - PRIVATE REGISTRATION 
+0025E0|CeedTec Sdn Bhd
+0025E1|SHANGHAI SEEYOO ELECTRONIC & TECHNOLOGY CO., LTD
+0025E2|Everspring Industry Co., Ltd.
+0025E3|Hanshinit Inc.
+0025E4|OMNI-WiFi, LLC
+0025E5|LG Electronics
+0025E6|Belgian Monitoring Systems bvba
+0025E7|Sony Ericsson Mobile Communications
+0025E8|Idaho Technology
+0025E9|i-mate Development, Inc.
+0025EA|Iphion BV
+0025EB|Reutech Radar Systems (PTY) Ltd
+0025EC|Humanware
+0025ED|NuVo Technologies LLC
+0025EE|Avtex Ltd
+0025EF|I-TEC Co., Ltd.
+0025F0|Suga Electronics Limited
+0025F1|ARRIS Group, Inc.
+0025F2|ARRIS Group, Inc.
+0025F3|Nordwestdeutsche Zahlerrevision
+0025F4|KoCo Connector AG
+0025F5|DVS Korea, Co., Ltd
+0025F6|netTALK.com, Inc.
+0025F7|Ansaldo STS USA
+0025F9|GMK electronic design GmbH
+0025FA|J&M Analytik AG
+0025FB|Tunstall Healthcare A/S
+0025FC|ENDA ENDUSTRIYEL ELEKTRONIK LTD. STI.
+0025FD|OBR Centrum Techniki Morskiej S.A.
+0025FE|Pilot Electronics Corporation
+0025FF|CreNova Multimedia Co., Ltd
+002600|TEAC Australia Pty Ltd.
+002601|Cutera Inc
+002602|SMART Temps LLC
+002603|Shenzhen Wistar Technology Co., Ltd
+002604|Audio Processing Technology Ltd
+002605|CC Systems AB
+002606|RAUMFELD GmbH
+002607|Enabling Technology Pty Ltd
+002608|Apple
+002609|Phyllis Co., Ltd.
+00260A|Cisco
+00260B|Cisco
+00260C|Dataram
+00260D|Mercury Systems, Inc.
+00260E|Ablaze Systems, LLC
+00260F|Linn Products Ltd
+002610|Apacewave Technologies
+002611|Licera AB
+002612|Space Exploration Technologies
+002613|Engel Axil S.L.
+002614|KTNF
+002615|Teracom Limited
+002616|Rosemount Inc.
+002617|OEM Worldwide
+002618|ASUSTek COMPUTER INC.
+002619|FRC
+00261A|Femtocomm System Technology Corp.
+00261B|LAUREL BANK MACHINES CO., LTD.
+00261C|NEOVIA INC.
+00261D|COP SECURITY SYSTEM CORP.
+00261E|QINGBANG ELEC(SZ) CO., LTD
+00261F|SAE Magnetics (H.K.) Ltd.
+002620|ISGUS GmbH
+002621|InteliCloud Technology Inc.
+002622|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+002623|JRD Communication Inc
+002624|Thomson Inc.
+002625|MediaSputnik
+002626|Geophysical Survey Systems, Inc.
+002627|Truesell
+002628|companytec automacao e controle ltda.
+002629|Juphoon System Software Inc.
+00262A|Proxense, LLC
+00262B|Wongs Electronics Co. Ltd.
+00262C|IKT Advanced Technologies s.r.o.
+00262D|Wistron Corporation
+00262E|Chengdu Jiuzhou Electronic Technology Inc
+00262F|HAMAMATSU TOA ELECTRONICS
+002630|ACOREL S.A.S
+002631|COMMTACT LTD
+002632|Instrumentation Technologies d.d.
+002633|MIR - Medical International Research
+002634|Infineta Systems, Inc
+002635|Bluetechnix GmbH
+002636|ARRIS Group, Inc.
+002637|Samsung
+002638|Xia Men Joyatech Co., Ltd.
+002639|T.M. Electronics, Inc.
+00263A|Digitec Systems
+00263B|Onbnetech
+00263C|Bachmann Technology GmbH & Co. KG
+00263D|MIA Corporation
+00263E|Trapeze Networks
+00263F|LIOS Technology GmbH
+002640|Baustem Broadband Technologies, Ltd.
+002641|ARRIS Group, Inc.
+002642|ARRIS Group, Inc.
+002643|Alps Electric Co., Ltd
+002644|Thomson Telecom Belgium
+002645|Circontrol S.A.
+002646|SHENYANG TONGFANG MULTIMEDIA TECHNOLOGY COMPANY LIMITED
+002647|WFE TECHNOLOGY CORP.
+002648|Emitech Corp.
+00264A|Apple
+00264C|Shanghai DigiVision Technology Co., Ltd.
+00264D|Arcadyan Technology Corporation
+00264E|Rail & Road Protec GmbH
+00264F|Kruger &Gothe GmbH
+002650|2Wire
+002651|Cisco
+002652|Cisco
+002653|DaySequerra Corporation
+002654|3Com Corporation
+002655|Hewlett-Packard Company
+002656|Sansonic Electronics USA
+002657|OOO NPP EKRA
+002658|T-Platforms (Cyprus) Limited
+002659|Nintendo Co., Ltd.
+00265A|D-Link Corporation
+00265B|Hitron Technologies. Inc
+00265C|Hon Hai Precision Ind. Co.,Ltd.
+00265D|Samsung
+00265E|Hon Hai Precision Ind. Co.,Ltd.
+00265F|Samsung
+002660|Logiways
+002661|Irumtek Co., Ltd.
+002662|Actiontec Electronics, Inc
+002663|Shenzhen Huitaiwei Tech. Ltd, co.
+002664|Core System Japan
+002665|ProtectedLogic Corporation
+002666|EFM Networks
+002667|CARECOM CO.,LTD.
+002668|Nokia Danmark A/S
+002669|Nokia Danmark A/S
+00266A|ESSENSIUM NV
+00266B|SHINE UNION ENTERPRISE LIMITED
+00266C|Inventec
+00266D|MobileAccess Networks
+00266E|Nissho-denki Co.,LTD.
+00266F|Coordiwise Technology Corp.
+002670|Cinch Connectors
+002671|AUTOVISION Co., Ltd
+002672|AAMP of America
+002673|RICOH COMPANY,LTD.
+002674|Electronic Solutions, Inc.
+002675|Aztech Electronics Pte Ltd
+002676|COMMidt AS
+002677|DEIF A/S
+002678|Logic Instrument SA
+002679|Euphonic Technologies, Inc.
+00267A|wuhan hongxin telecommunication technologies co.,ltd
+00267B|GSI Helmholtzzentrum fur Schwerionenforschung GmbH
+00267C|Metz-Werke GmbH & Co KG
+00267D|A-Max Technology Macao Commercial Offshore Company Limited
+00267E|Parrot SA
+00267F|Zenterio AB
+002680|Lockie Innovation Pty Ltd
+002681|Interspiro AB
+002682|Gemtek Technology Co., Ltd.
+002683|Ajoho Enterprise Co., Ltd.
+002684|KISAN SYSTEM
+002685|Digital Innovation
+002686|Quantenna Communcations, Inc.
+002687|Corega K.K
+002688|Juniper Networks
+002689|General Dynamics Robotic Systems
+00268A|Terrier SC Ltd
+00268B|Guangzhou Escene Computer Technology Limited
+00268C|StarLeaf Ltd.
+00268D|CellTel S.p.A.
+00268E|Alta Solutions, Inc.
+00268F|MTA SpA
+002690|I DO IT
+002691|SAGEM COMMUNICATION
+002692|Mitsubishi Electric Co.
+002693|QVidium Technologies, Inc.
+002694|Senscient Ltd
+002695|ZT Group Int'l Inc
+002696|NOOLIX Co., Ltd
+002697|Cheetah Technologies, L.P.
+002698|Cisco
+002699|Cisco
+00269A|Carina System Co., Ltd.
+00269B|SOKRAT Ltd.
+00269C|ITUS JAPAN CO. LTD
+00269D|M2Mnet Co., Ltd.
+00269E|Quanta Computer Inc
+00269F|ASSIGNED - PRIVATE REGISTRATION 
+0026A0|moblic
+0026A1|Megger
+0026A2|Instrumentation Technology Systems
+0026A3|FQ Ingenieria Electronica S.A.
+0026A4|Novus Produtos Eletronicos Ltda
+0026A5|MICROROBOT.CO.,LTD
+0026A6|TRIXELL
+0026A7|CONNECT SRL
+0026A8|DAEHAP HYPER-TECH
+0026A9|Strong Technologies Pty Ltd
+0026AA|Kenmec Mechanical Engineering Co., Ltd.
+0026AB|SEIKO EPSON CORPORATION
+0026AC|Shanghai LUSTER Teraband photonic Co., Ltd.
+0026AD|Arada Systems, Inc.
+0026AE|Wireless Measurement Ltd
+0026AF|Duelco A/S
+0026B0|Apple
+0026B1|Navis Auto Motive Systems, Inc.
+0026B2|Setrix GmbH
+0026B3|Thales Communications Inc
+0026B4|Ford Motor Company
+0026B5|ICOMM Tele Ltd
+0026B6|Askey Computer
+0026B7|Kingston Technology Company, Inc.
+0026B8|Actiontec Electronics, Inc
+0026B9|Dell Inc
+0026BA|ARRIS Group, Inc.
+0026BB|Apple
+0026BC|General Jack Technology Ltd.
+0026BD|JTEC Card & Communication Co., Ltd.
+0026BE|Schoonderbeek Elektronica Systemen B.V.
+0026BF|ShenZhen Temobi Science&Tech Development Co.,Ltd
+0026C0|EnergyHub
+0026C1|ARTRAY CO., LTD.
+0026C2|SCDI Co. LTD
+0026C3|Insightek Corp.
+0026C4|Cadmos microsystems S.r.l.
+0026C5|Guangdong Gosun Telecommunications Co.,Ltd
+0026C6|Intel Corporate
+0026C7|Intel Corporate
+0026C8|System Sensor
+0026C9|Proventix Systems, Inc.
+0026CA|Cisco
+0026CB|Cisco
+0026CC|Nokia Danmark A/S
+0026CD|PurpleComm, Inc.
+0026CE|Kozumi USA Corp.
+0026CF|DEKA R&D
+0026D0|Semihalf
+0026D1|S Squared Innovations Inc.
+0026D2|Pcube Systems, Inc.
+0026D3|Zeno Information System
+0026D4|IRCA SpA
+0026D5|Ory Solucoes em Comercio de Informatica Ltda.
+0026D6|Ningbo Andy Optoelectronic Co., Ltd.
+0026D7|KM Electornic Technology Co., Ltd.
+0026D8|Magic Point Inc.
+0026D9|Pace plc
+0026DA|Universal Media Corporation /Slovakia/ s.r.o.
+0026DB|Ionics EMS Inc.
+0026DC|Optical Systems Design
+0026DD|Fival Science & Technology Co.,Ltd.
+0026DE|FDI MATELEC
+0026DF|TaiDoc Technology Corp.
+0026E0|ASITEQ
+0026E1|Stanford University, OpenFlow Group
+0026E2|LG Electronics
+0026E3|DTI
+0026E4|CANAL OVERSEAS
+0026E5|AEG Power Solutions
+0026E6|Visionhitech Co., Ltd.
+0026E7|Shanghai ONLAN Communication Tech. Co., Ltd.
+0026E8|Murata Manufacturing Co., Ltd.
+0026E9|SP Corp
+0026EA|Cheerchip Electronic Technology (ShangHai) Co., Ltd.
+0026EB|Advanced Spectrum Technology Co., Ltd.
+0026EC|Legrand Home Systems, Inc
+0026ED|zte corporation
+0026EE|TKM GmbH
+0026EF|Technology Advancement Group, Inc.
+0026F0|cTrixs International GmbH.
+0026F1|ProCurve Networking by HP
+0026F2|Netgear
+0026F3|SMC Networks
+0026F4|Nesslab
+0026F5|XRPLUS Inc.
+0026F6|Military Communication Institute
+0026F7|Infosys Technologies Ltd.
+0026F8|Golden Highway Industry Development Co., Ltd.
+0026F9|S.E.M. srl
+0026FA|BandRich Inc.
+0026FB|AirDio Wireless, Inc.
+0026FC|AcSiP Technology Corp.
+0026FD|Interactive Intelligence
+0026FE|MKD Technology Inc.
+0026FF|Research In Motion
+002700|Shenzhen Siglent Technology Co., Ltd.
+002701|INCOstartec GmbH
+002702|SolarEdge Technologies
+002703|Testech Electronics Pte Ltd
+002704|Accelerated Concepts, Inc
+002705|Sectronic
+002706|YOISYS
+002707|Lift Complex DS, JSC
+002708|Nordiag ASA
+002709|Nintendo Co., Ltd.
+00270A|IEE S.A.
+00270B|Adura Technologies
+00270C|Cisco
+00270D|Cisco
+00270E|Intel Corporate
+00270F|Envisionnovation Inc
+002710|Intel Corporate
+002711|LanPro Inc
+002712|MaxVision LLC
+002713|Universal Global Scientific Industrial Co., Ltd.
+002714|Grainmustards, Co,ltd.
+002715|Rebound Telecom. Co., Ltd
+002716|Adachi-Syokai Co., Ltd.
+002717|CE Digital(Zhenjiang)Co.,Ltd
+002718|Suzhou NEW SEAUNION Video Technology Co.,Ltd
+002719|TP-LINK TECHNOLOGIES CO., LTD.
+00271A|Geenovo Technology Ltd.
+00271B|Alec Sicherheitssysteme GmbH
+00271C|MERCURY CORPORATION
+00271D|Comba Telecom Systems (China) Ltd.
+00271E|Xagyl Communications
+00271F|MIPRO Electronics Co., Ltd
+002720|NEW-SOL COM
+002721|Shenzhen Baoan Fenda Industrial Co., Ltd
+002722|Ubiquiti Networks
+0027F8|Brocade Communications Systems, Inc.
+002A6A|Cisco
+002AAF|LARsys-Automation GmbH
+002D76|TITECH GmbH
+003000|ALLWELL TECHNOLOGY CORP.
+003001|SMP
+003002|Expand Networks
+003003|Phasys Ltd.
+003004|LEADTEK RESEARCH INC.
+003005|Fujitsu Siemens Computers
+003006|SUPERPOWER COMPUTER
+003007|OPTI, INC.
+003008|AVIO DIGITAL, INC.
+003009|Tachion Networks, Inc.
+00300A|AZTECH Electronics Pte Ltd
+00300B|mPHASE Technologies, Inc.
+00300C|CONGRUENCY, LTD.
+00300D|MMC Technology, Inc.
+00300E|Klotz Digital AG
+00300F|IMT - Information Management T
+003010|VISIONETICS INTERNATIONAL
+003011|HMS Industrial Networks
+003012|DIGITAL ENGINEERING LTD.
+003013|NEC Corporation
+003014|DIVIO, INC.
+003015|CP CLARE CORP.
+003016|ISHIDA CO., LTD.
+003017|BlueArc UK Ltd
+003018|Jetway Information Co., Ltd.
+003019|Cisco
+00301A|SMARTBRIDGES PTE. LTD.
+00301B|SHUTTLE, INC.
+00301C|ALTVATER AIRDATA SYSTEMS
+00301D|SKYSTREAM, INC.
+00301E|3COM Europe Ltd.
+00301F|OPTICAL NETWORKS, INC.
+003020|TSI, Inc..
+003021|HSING TECH. ENTERPRISE CO.,LTD
+003022|Fong Kai Industrial Co., Ltd.
+003023|COGENT COMPUTER SYSTEMS, INC.
+003024|Cisco
+003025|CHECKOUT COMPUTER SYSTEMS, LTD
+003026|HeiTel Digital Video GmbH
+003027|KERBANGO, INC.
+003028|FASE Saldatura srl
+003029|OPICOM
+00302A|SOUTHERN INFORMATION
+00302B|INALP NETWORKS, INC.
+00302C|SYLANTRO SYSTEMS CORPORATION
+00302D|QUANTUM BRIDGE COMMUNICATIONS
+00302E|Hoft & Wessel AG
+00302F|GE Aviation System
+003030|HARMONIX CORPORATION
+003031|LIGHTWAVE COMMUNICATIONS, INC.
+003032|MagicRam, Inc.
+003033|ORIENT TELECOM CO., LTD.
+003034|SET ENGINEERING
+003035|Corning Incorporated
+003036|RMP ELEKTRONIKSYSTEME GMBH
+003037|Packard Bell Nec Services
+003038|XCP, INC.
+003039|SOFTBOOK PRESS
+00303A|MAATEL
+00303B|PowerCom Technology
+00303C|ONNTO CORP.
+00303D|IVA CORPORATION
+00303E|Radcom Ltd.
+00303F|TurboComm Tech Inc.
+003040|Cisco
+003041|SAEJIN T & M CO., LTD.
+003042|DeTeWe-Deutsche Telephonwerke
+003043|IDREAM TECHNOLOGIES, PTE. LTD.
+003044|CradlePoint, Inc
+003045|Village Networks, Inc. (VNI)
+003046|Controlled Electronic Manageme
+003047|NISSEI ELECTRIC CO., LTD.
+003048|Supermicro Computer, Inc.
+003049|BRYANT TECHNOLOGY, LTD.
+00304A|Fraunhofer IPMS
+00304B|ORBACOM SYSTEMS, INC.
+00304C|APPIAN COMMUNICATIONS, INC.
+00304D|ESI
+00304E|BUSTEC PRODUCTION LTD.
+00304F|PLANET Technology Corporation
+003050|Versa Technology
+003051|ORBIT AVIONIC & COMMUNICATION
+003052|ELASTIC NETWORKS
+003053|Basler AG
+003054|CASTLENET TECHNOLOGY, INC.
+003055|Renesas Technology America, Inc.
+003056|Beck IPC GmbH
+003057|QTelNet, Inc.
+003058|API MOTION
+003059|KONTRON COMPACT COMPUTERS AG
+00305A|TELGEN CORPORATION
+00305B|Toko Inc.
+00305C|SMAR Laboratories Corp.
+00305D|DIGITRA SYSTEMS, INC.
+00305E|Abelko Innovation
+00305F|Hasselblad
+003060|Powerfile, Inc.
+003061|MobyTEL
+003062|IP Video Networks Inc
+003063|SANTERA SYSTEMS, INC.
+003064|ADLINK TECHNOLOGY, INC.
+003065|Apple
+003066|RFM
+003067|BIOSTAR MICROTECH INT'L CORP.
+003068|CYBERNETICS TECH. CO., LTD.
+003069|IMPACCT TECHNOLOGY CORP.
+00306A|PENTA MEDIA CO., LTD.
+00306B|CMOS SYSTEMS, INC.
+00306C|Hitex Holding GmbH
+00306D|LUCENT TECHNOLOGIES
+00306E|HEWLETT PACKARD
+00306F|SEYEON TECH. CO., LTD.
+003070|1Net Corporation
+003071|Cisco
+003072|Intellibyte Inc.
+003073|International Microsystems, In
+003074|EQUIINET LTD.
+003075|ADTECH
+003076|Akamba Corporation
+003077|ONPREM NETWORKS
+003078|Cisco
+003079|CQOS, INC.
+00307A|Advanced Technology & Systems
+00307B|Cisco
+00307C|ADID SA
+00307D|GRE AMERICA, INC.
+00307E|Redflex Communication Systems
+00307F|IRLAN LTD.
+003080|Cisco
+003081|ALTOS C&C
+003082|TAIHAN ELECTRIC WIRE CO., LTD.
+003083|Ivron Systems
+003084|ALLIED TELESYN INTERNAIONAL
+003085|Cisco
+003086|Transistor Devices, Inc.
+003087|VEGA GRIESHABER KG
+003088|Ericsson
+003089|Spectrapoint Wireless, LLC
+00308A|NICOTRA SISTEMI S.P.A
+00308B|Brix Networks
+00308C|Quantum Corporation
+00308D|Pinnacle Systems, Inc.
+00308E|CROSS MATCH TECHNOLOGIES, INC.
+00308F|MICRILOR, Inc.
+003090|CYRA TECHNOLOGIES, INC.
+003091|TAIWAN FIRST LINE ELEC. CORP.
+003092|ModuNORM GmbH
+003093|Sonnet Technologies, Inc
+003094|Cisco
+003095|Procomp Informatics, Ltd.
+003096|Cisco
+003097|AB Regin
+003098|Global Converging Technologies
+003099|BOENIG UND KALLENBACH OHG
+00309A|ASTRO TERRA CORP.
+00309B|Smartware
+00309C|Timing Applications, Inc.
+00309D|Nimble Microsystems, Inc.
+00309E|WORKBIT CORPORATION.
+00309F|AMBER NETWORKS
+0030A0|TYCO SUBMARINE SYSTEMS, LTD.
+0030A1|WEBGATE Inc.
+0030A2|Lightner Engineering
+0030A3|Cisco
+0030A4|Woodwind Communications System
+0030A5|ACTIVE POWER
+0030A6|VIANET TECHNOLOGIES, LTD.
+0030A7|SCHWEITZER ENGINEERING
+0030A8|OL'E COMMUNICATIONS, INC.
+0030A9|Netiverse, Inc.
+0030AA|AXUS MICROSYSTEMS, INC.
+0030AB|DELTA NETWORKS, INC.
+0030AC|Systeme Lauer GmbH & Co., Ltd.
+0030AD|SHANGHAI COMMUNICATION
+0030AE|Times N System, Inc.
+0030AF|Honeywell GmbH
+0030B0|Convergenet Technologies
+0030B1|TrunkNet
+0030B2|L-3 Sonoma EO
+0030B3|San Valley Systems, Inc.
+0030B4|INTERSIL CORP.
+0030B5|Tadiran Microwave Networks
+0030B6|Cisco
+0030B7|Teletrol Systems, Inc.
+0030B8|RiverDelta Networks
+0030B9|ECTEL
+0030BA|AC&T SYSTEM CO., LTD.
+0030BB|CacheFlow, Inc.
+0030BC|Optronic AG
+0030BD|BELKIN COMPONENTS
+0030BE|City-Net Technology, Inc.
+0030BF|MULTIDATA GMBH
+0030C0|Lara Technology, Inc.
+0030C1|HEWLETT-PACKARD
+0030C2|COMONE
+0030C3|FLUECKIGER ELEKTRONIK AG
+0030C4|Canon Imaging Systems Inc.
+0030C5|CADENCE DESIGN SYSTEMS
+0030C6|CONTROL SOLUTIONS, INC.
+0030C7|Macromate Corp.
+0030C8|GAD LINE, LTD.
+0030C9|LuxN, N
+0030CA|Discovery Com
+0030CB|OMNI FLOW COMPUTERS, INC.
+0030CC|Tenor Networks, Inc.
+0030CD|CONEXANT SYSTEMS, INC.
+0030CE|Zaffire
+0030CF|TWO TECHNOLOGIES, INC.
+0030D0|Tellabs
+0030D1|INOVA CORPORATION
+0030D2|WIN TECHNOLOGIES, CO., LTD.
+0030D3|Agilent Technologies
+0030D4|AAE Systems, Inc.
+0030D5|DResearch GmbH
+0030D6|MSC VERTRIEBS GMBH
+0030D7|Innovative Systems, L.L.C.
+0030D8|SITEK
+0030D9|DATACORE SOFTWARE CORP.
+0030DA|COMTREND CO.
+0030DB|Mindready Solutions, Inc.
+0030DC|RIGHTECH CORPORATION
+0030DD|INDIGITA CORPORATION
+0030DE|WAGO Kontakttechnik GmbH
+0030DF|KB/TEL TELECOMUNICACIONES
+0030E0|OXFORD SEMICONDUCTOR LTD.
+0030E1|Network Equipment Technologies, Inc.
+0030E2|GARNET SYSTEMS CO., LTD.
+0030E3|SEDONA NETWORKS CORP.
+0030E4|CHIYODA SYSTEM RIKEN
+0030E5|Amper Datos S.A.
+0030E6|Draeger Medical Systems, Inc.
+0030E7|CNF MOBILE SOLUTIONS, INC.
+0030E8|ENSIM CORP.
+0030E9|GMA COMMUNICATION MANUFACT'G
+0030EA|TeraForce Technology Corporation
+0030EB|TURBONET COMMUNICATIONS, INC.
+0030EC|BORGARDT
+0030ED|Expert Magnetics Corp.
+0030EE|DSG Technology, Inc.
+0030EF|NEON TECHNOLOGY, INC.
+0030F0|Uniform Industrial Corp.
+0030F1|Accton Technology Corp.
+0030F2|Cisco
+0030F3|At Work Computers
+0030F4|STARDOT TECHNOLOGIES
+0030F5|Wild Lab. Ltd.
+0030F6|SECURELOGIX CORPORATION
+0030F7|RAMIX INC.
+0030F8|Dynapro Systems, Inc.
+0030F9|Sollae Systems Co., Ltd.
+0030FA|TELICA, INC.
+0030FB|AZS Technology AG
+0030FC|Terawave Communications, Inc.
+0030FD|INTEGRATED SYSTEMS DESIGN
+0030FE|DSA GmbH
+0030FF|DATAFAB SYSTEMS, INC.
+00323A|so-logic
+00336C|SynapSense Corporation
+0034F1|Radicom Research, Inc.
+003532|Electro-Metrics Corporation
+003560|Rosen Aviation
+0036F8|Conti Temic microelectronic GmbH
+0036FE|SuperVision
+00376D|Murata Manufacturing Co., Ltd.
+0037B7|SAGEMCOM
+003A98|Cisco
+003A99|Cisco
+003A9A|Cisco
+003A9B|Cisco
+003A9C|Cisco
+003A9D|NEC Platforms, Ltd.
+003AAF|BlueBit Ltd.
+003CC5|WONWOO Engineering Co., Ltd
+003D41|Hatteland Computer AS
+003EE1|Apple
+004000|PCI COMPONENTES DA AMZONIA LTD
+004001|Zero One Technology Co. Ltd.
+004002|PERLE SYSTEMS LIMITED
+004003|Emerson Process Management Power & Water Solutions, Inc.
+004004|ICM CO. LTD.
+004005|ANI COMMUNICATIONS INC.
+004006|SAMPO TECHNOLOGY CORPORATION
+004007|TELMAT INFORMATIQUE
+004008|A PLUS INFO CORPORATION
+004009|TACHIBANA TECTRON CO., LTD.
+00400A|PIVOTAL TECHNOLOGIES, INC.
+00400B|Cisco
+00400C|GENERAL MICRO SYSTEMS, INC.
+00400D|LANNET DATA COMMUNICATIONS,LTD
+00400E|MEMOTEC, INC.
+00400F|DATACOM TECHNOLOGIES
+004010|SONIC SYSTEMS, INC.
+004011|ANDOVER CONTROLS CORPORATION
+004012|WINDATA, INC.
+004013|NTT DATA COMM. SYSTEMS CORP.
+004014|COMSOFT GMBH
+004015|ASCOM INFRASYS AG
+004016|ADC - Global Connectivity Solutions Division
+004017|Silex Technology America
+004018|ADOBE SYSTEMS, INC.
+004019|AEON SYSTEMS, INC.
+00401A|FUJI ELECTRIC CO., LTD.
+00401B|PRINTER SYSTEMS CORP.
+00401C|AST RESEARCH, INC.
+00401D|INVISIBLE SOFTWARE, INC.
+00401E|ICC
+00401F|COLORGRAPH LTD
+004020|TE Connectivity Ltd.
+004021|RASTER GRAPHICS
+004022|KLEVER COMPUTERS, INC.
+004023|LOGIC CORPORATION
+004024|COMPAC INC.
+004025|MOLECULAR DYNAMICS
+004026|Buffalo Inc.
+004027|SMC MASSACHUSETTS, INC.
+004028|NETCOMM LIMITED
+004029|COMPEX
+00402A|CANOGA-PERKINS
+00402B|TRIGEM COMPUTER, INC.
+00402C|ISIS DISTRIBUTED SYSTEMS, INC.
+00402D|HARRIS ADACOM CORPORATION
+00402E|PRECISION SOFTWARE, INC.
+00402F|XLNT DESIGNS INC.
+004030|GK COMPUTER
+004031|KOKUSAI ELECTRIC CO., LTD
+004032|DIGITAL COMMUNICATIONS
+004033|ADDTRON TECHNOLOGY CO., LTD.
+004034|BUSTEK CORPORATION
+004035|OPCOM
+004036|Zoom Telephonics, Inc
+004037|SEA-ILAN, INC.
+004038|TALENT ELECTRIC INCORPORATED
+004039|OPTEC DAIICHI DENKO CO., LTD.
+00403A|IMPACT TECHNOLOGIES
+00403B|SYNERJET INTERNATIONAL CORP.
+00403C|FORKS, INC.
+00403D|Teradata Corporation
+00403E|RASTER OPS CORPORATION
+00403F|SSANGYONG COMPUTER SYSTEMS
+004040|RING ACCESS, INC.
+004041|FUJIKURA LTD.
+004042|N.A.T. GMBH
+004043|Nokia Siemens Networks GmbH & Co. KG.
+004044|QNIX COMPUTER CO., LTD.
+004045|TWINHEAD CORPORATION
+004046|UDC RESEARCH LIMITED
+004047|WIND RIVER SYSTEMS
+004048|SMD INFORMATICA S.A.
+004049|Roche Diagnostics International Ltd.
+00404A|WEST AUSTRALIAN DEPARTMENT
+00404B|MAPLE COMPUTER SYSTEMS
+00404C|HYPERTEC PTY LTD.
+00404D|TELECOMMUNICATIONS TECHNIQUES
+00404E|FLUENT, INC.
+00404F|SPACE & NAVAL WARFARE SYSTEMS
+004050|IRONICS, INCORPORATED
+004051|GRACILIS, INC.
+004052|STAR TECHNOLOGIES, INC.
+004053|AMPRO COMPUTERS
+004054|CONNECTION MACHINES SERVICES
+004055|METRONIX GMBH
+004056|MCM JAPAN LTD.
+004057|LOCKHEED - SANDERS
+004058|KRONOS, INC.
+004059|YOSHIDA KOGYO K. K.
+00405A|GOLDSTAR INFORMATION & COMM.
+00405B|FUNASSET LIMITED
+00405C|FUTURE SYSTEMS, INC.
+00405D|STAR-TEK, INC.
+00405E|NORTH HILLS ISRAEL
+00405F|AFE COMPUTERS LTD.
+004060|COMENDEC LTD
+004061|DATATECH ENTERPRISES CO., LTD.
+004062|E-SYSTEMS, INC./GARLAND DIV.
+004063|VIA TECHNOLOGIES, INC.
+004064|KLA INSTRUMENTS CORPORATION
+004065|GTE SPACENET
+004066|Hitachi Metals, Ltd.
+004067|OMNIBYTE CORPORATION
+004068|EXTENDED SYSTEMS
+004069|LEMCOM SYSTEMS, INC.
+00406A|KENTEK INFORMATION SYSTEMS,INC
+00406B|SYSGEN
+00406C|COPERNIQUE
+00406D|LANCO, INC.
+00406E|COROLLARY, INC.
+00406F|SYNC RESEARCH INC.
+004070|INTERWARE CO., LTD.
+004071|ATM COMPUTER GMBH
+004072|Applied Innovation Inc.
+004073|BASS ASSOCIATES
+004074|CABLE AND WIRELESS
+004075|Tattile SRL
+004076|Sun Conversion Technologies
+004077|MAXTON TECHNOLOGY CORPORATION
+004078|WEARNES AUTOMATION PTE LTD
+004079|JUKO MANUFACTURE COMPANY, LTD.
+00407A|SOCIETE D'EXPLOITATION DU CNIT
+00407B|SCIENTIFIC ATLANTA
+00407C|QUME CORPORATION
+00407D|EXTENSION TECHNOLOGY CORP.
+00407E|EVERGREEN SYSTEMS, INC.
+00407F|FLIR Systems
+004080|ATHENIX CORPORATION
+004081|MANNESMANN SCANGRAPHIC GMBH
+004082|LABORATORY EQUIPMENT CORP.
+004083|TDA INDUSTRIA DE PRODUTOS
+004084|HONEYWELL ACS
+004085|SAAB INSTRUMENTS AB
+004086|MICHELS & KLEBERHOFF COMPUTER
+004087|UBITREX CORPORATION
+004088|MOBIUS TECHNOLOGIES, INC.
+004089|MEIDENSHA CORPORATION
+00408A|TPS TELEPROCESSING SYS. GMBH
+00408B|RAYLAN CORPORATION
+00408C|AXIS COMMUNICATIONS AB
+00408D|THE GOODYEAR TIRE & RUBBER CO.
+00408E|Tattile SRL
+00408F|WM-DATA MINFO AB
+004090|ANSEL COMMUNICATIONS
+004091|PROCOMP INDUSTRIA ELETRONICA
+004092|ASP COMPUTER PRODUCTS, INC.
+004093|PAXDATA NETWORKS LTD.
+004094|SHOGRAPHICS, INC.
+004095|R.P.T. INTERGROUPS INT'L LTD.
+004096|Cisco
+004097|DATEX DIVISION OF
+004098|DRESSLER GMBH & CO.
+004099|NEWGEN SYSTEMS CORP.
+00409A|NETWORK EXPRESS, INC.
+00409B|HAL COMPUTER SYSTEMS INC.
+00409C|TRANSWARE
+00409D|DIGIBOARD, INC.
+00409E|CONCURRENT TECHNOLOGIES  LTD.
+00409F|Telco Systems, Inc.
+0040A0|GOLDSTAR CO., LTD.
+0040A1|ERGO COMPUTING
+0040A2|KINGSTAR TECHNOLOGY INC.
+0040A3|MICROUNITY SYSTEMS ENGINEERING
+0040A4|ROSE ELECTRONICS
+0040A5|CLINICOMP INTL.
+0040A6|Cray, Inc.
+0040A7|ITAUTEC PHILCO S.A.
+0040A8|IMF INTERNATIONAL LTD.
+0040A9|DATACOM INC.
+0040AA|Metso Automation
+0040AB|ROLAND DG CORPORATION
+0040AC|SUPER WORKSTATION, INC.
+0040AD|SMA REGELSYSTEME GMBH
+0040AE|DELTA CONTROLS, INC.
+0040AF|DIGITAL PRODUCTS, INC.
+0040B0|BYTEX CORPORATION, ENGINEERING
+0040B1|CODONICS INC.
+0040B2|SYSTEMFORSCHUNG
+0040B3|ParTech Inc.
+0040B4|NEXTCOM K.K.
+0040B5|VIDEO TECHNOLOGY COMPUTERS LTD
+0040B6|COMPUTERM  CORPORATION
+0040B7|STEALTH COMPUTER SYSTEMS
+0040B8|IDEA ASSOCIATES
+0040B9|MACQ ELECTRONIQUE SA
+0040BA|ALLIANT COMPUTER SYSTEMS CORP.
+0040BB|GOLDSTAR CABLE CO., LTD.
+0040BC|ALGORITHMICS LTD.
+0040BD|STARLIGHT NETWORKS, INC.
+0040BE|BOEING DEFENSE & SPACE
+0040BF|CHANNEL SYSTEMS INTERN'L INC.
+0040C0|VISTA CONTROLS CORPORATION
+0040C1|BIZERBA-WERKE WILHEIM KRAUT
+0040C2|APPLIED COMPUTING DEVICES
+0040C3|FISCHER AND PORTER CO.
+0040C4|KINKEI SYSTEM CORPORATION
+0040C5|MICOM COMMUNICATIONS INC.
+0040C6|FIBERNET RESEARCH, INC.
+0040C7|RUBY TECH CORPORATION
+0040C8|MILAN TECHNOLOGY CORPORATION
+0040C9|NCUBE
+0040CA|FIRST INTERNAT'L COMPUTER, INC
+0040CB|LANWAN TECHNOLOGIES
+0040CC|SILCOM MANUF'G TECHNOLOGY INC.
+0040CD|TERA MICROSYSTEMS, INC.
+0040CE|NET-SOURCE, INC.
+0040CF|STRAWBERRY TREE, INC.
+0040D0|MITAC INTERNATIONAL CORP.
+0040D1|FUKUDA DENSHI CO., LTD.
+0040D2|PAGINE CORPORATION
+0040D3|KIMPSION INTERNATIONAL CORP.
+0040D4|GAGE TALKER CORP.
+0040D5|Sartorius Mechatronics T&H GmbH
+0040D6|LOCAMATION B.V.
+0040D7|STUDIO GEN INC.
+0040D8|OCEAN OFFICE AUTOMATION LTD.
+0040D9|AMERICAN MEGATRENDS INC.
+0040DA|TELSPEC LTD
+0040DB|ADVANCED TECHNICAL SOLUTIONS
+0040DC|TRITEC ELECTRONIC GMBH
+0040DD|HONG TECHNOLOGIES
+0040DE|Elsag Datamat spa
+0040DF|DIGALOG SYSTEMS, INC.
+0040E0|ATOMWIDE LTD.
+0040E1|MARNER INTERNATIONAL, INC.
+0040E2|MESA RIDGE TECHNOLOGIES, INC.
+0040E3|QUIN SYSTEMS LTD
+0040E4|E-M TECHNOLOGY, INC.
+0040E5|SYBUS CORPORATION
+0040E6|C.A.E.N.
+0040E7|ARNOS INSTRUMENTS & COMPUTER
+0040E8|CHARLES RIVER DATA SYSTEMS,INC
+0040E9|ACCORD SYSTEMS, INC.
+0040EA|PLAIN TREE SYSTEMS INC
+0040EB|MARTIN MARIETTA CORPORATION
+0040EC|MIKASA SYSTEM ENGINEERING
+0040ED|NETWORK CONTROLS INT'NATL INC.
+0040EE|OPTIMEM
+0040EF|HYPERCOM, INC.
+0040F0|MicroBrain,Inc.
+0040F1|CHUO ELECTRONICS CO., LTD.
+0040F2|JANICH & KLASS COMPUTERTECHNIK
+0040F3|NETCOR
+0040F4|CAMEO COMMUNICATIONS, INC.
+0040F5|OEM ENGINES
+0040F6|KATRON COMPUTERS INC.
+0040F7|Polaroid Corporation
+0040F8|SYSTEMHAUS DISCOM
+0040F9|COMBINET
+0040FA|MICROBOARDS, INC.
+0040FB|CASCADE COMMUNICATIONS CORP.
+0040FC|IBR COMPUTER TECHNIK GMBH
+0040FD|LXE
+0040FE|SYMPLEX COMMUNICATIONS
+0040FF|TELEBIT CORPORATION
+0041B4|Wuxi Zhongxing Optoelectronics Technology Co.,Ltd.
+004252|RLX Technologies
+0043FF|KETRON S.R.L.
+004501|Versus Technology, Inc.
+00464B|HUAWEI TECHNOLOGIES CO.,LTD
+004D32|Andon Health Co.,Ltd.
+005000|NEXO COMMUNICATIONS, INC.
+005001|YAMASHITA SYSTEMS CORP.
+005002|OMNISEC AG
+005003|Xrite Inc
+005004|3COM CORPORATION
+005006|TAC AB
+005007|SIEMENS TELECOMMUNICATION SYSTEMS LIMITED
+005008|TIVA MICROCOMPUTER CORP. (TMC)
+005009|PHILIPS BROADBAND NETWORKS
+00500A|IRIS TECHNOLOGIES, INC.
+00500B|Cisco
+00500C|e-Tek Labs, Inc.
+00500D|SATORI ELECTORIC CO., LTD.
+00500E|CHROMATIS NETWORKS, INC.
+00500F|Cisco
+005010|NovaNET Learning, Inc.
+005012|CBL - GMBH
+005013|Chaparral Network Storage
+005014|Cisco
+005015|BRIGHT STAR ENGINEERING
+005016|SST/WOODHEAD INDUSTRIES
+005017|RSR S.R.L.
+005018|AMIT, Inc.
+005019|SPRING TIDE NETWORKS, INC.
+00501A|IQinVision
+00501B|ABL CANADA, INC.
+00501C|JATOM SYSTEMS, INC.
+00501E|Miranda Technologies, Inc.
+00501F|MRG SYSTEMS, LTD.
+005020|MEDIASTAR CO., LTD.
+005021|EIS INTERNATIONAL, INC.
+005022|ZONET TECHNOLOGY, INC.
+005023|PG DESIGN ELECTRONICS, INC.
+005024|NAVIC SYSTEMS, INC.
+005026|COSYSTEMS, INC.
+005027|GENICOM CORPORATION
+005028|AVAL COMMUNICATIONS
+005029|1394 PRINTER WORKING GROUP
+00502A|Cisco
+00502B|GENRAD LTD.
+00502C|SOYO COMPUTER, INC.
+00502D|ACCEL, INC.
+00502E|CAMBEX CORPORATION
+00502F|TollBridge Technologies, Inc.
+005030|FUTURE PLUS SYSTEMS
+005031|AEROFLEX LABORATORIES, INC.
+005032|PICAZO COMMUNICATIONS, INC.
+005033|MAYAN NETWORKS
+005036|NETCAM, LTD.
+005037|KOGA ELECTRONICS CO.
+005038|DAIN TELECOM CO., LTD.
+005039|MARINER NETWORKS
+00503A|DATONG ELECTRONICS LTD.
+00503B|MEDIAFIRE CORPORATION
+00503C|TSINGHUA NOVEL ELECTRONICS
+00503E|Cisco
+00503F|ANCHOR GAMES
+005040|Panasonic Electric Works Co., Ltd.
+005041|Coretronic Corporation
+005042|SCI MANUFACTURING SINGAPORE PTE, LTD.
+005043|MARVELL SEMICONDUCTOR, INC.
+005044|ASACA CORPORATION
+005045|RIOWORKS SOLUTIONS, INC.
+005046|MENICX INTERNATIONAL CO., LTD.
+005047|HONEYWELL DEFENSE AVI 
+005048|INFOLIBRIA
+005049|Arbor Networks Inc
+00504A|ELTECO A.S.
+00504B|BARCONET N.V.
+00504C|Galil Motion Control
+00504D|Tokyo Electron Device Limited
+00504E|SIERRA MONITOR CORP.
+00504F|OLENCOM ELECTRONICS
+005050|Cisco
+005051|IWATSU ELECTRIC CO., LTD.
+005052|TIARA NETWORKS, INC.
+005053|Cisco
+005054|Cisco
+005055|DOMS A/S
+005056|VMware, Inc.
+005057|BROADBAND ACCESS SYSTEMS
+005058|VegaStream Group Limted
+005059|iBAHN
+00505A|NETWORK ALCHEMY, INC.
+00505B|KAWASAKI LSI U.S.A., INC.
+00505C|TUNDO CORPORATION
+00505E|DIGITEK MICROLOGIC S.A.
+00505F|BRAND INNOVATORS
+005060|TANDBERG TELECOM AS
+005062|KOUWELL ELECTRONICS CORP.  **
+005063|OY COMSEL SYSTEM AB
+005064|CAE ELECTRONICS
+005065|TDK-Lambda Corporation
+005066|AtecoM GmbH advanced telecomunication modules
+005067|AEROCOMM, INC.
+005068|ELECTRONIC INDUSTRIES ASSOCIATION
+005069|PixStream Incorporated
+00506A|EDEVA, INC.
+00506B|SPX-ATEG
+00506C|Beijer Electronics Products AB
+00506D|VIDEOJET SYSTEMS
+00506E|CORDER ENGINEERING CORPORATION
+00506F|G-CONNECT
+005070|CHAINTECH COMPUTER CO., LTD.
+005071|AIWA CO., LTD.
+005072|CORVIS CORPORATION
+005073|Cisco
+005074|ADVANCED HI-TECH CORP.
+005075|KESTREL SOLUTIONS
+005076|IBM Corp
+005077|PROLIFIC TECHNOLOGY, INC.
+005078|MEGATON HOUSE, LTD.
+005079|IEEE STANDARDS 
+00507A|XPEED, INC.
+00507B|MERLOT COMMUNICATIONS
+00507C|VIDEOCON AG
+00507D|IFP
+00507E|NEWER TECHNOLOGY
+00507F|DrayTek Corp.
+005080|Cisco
+005081|MURATA MACHINERY, LTD.
+005082|FORESSON CORPORATION
+005083|GILBARCO, INC.
+005084|ATL PRODUCTS
+005086|TELKOM SA, LTD.
+005087|TERASAKI ELECTRIC CO., LTD.
+005088|AMANO CORPORATION
+005089|SAFETY MANAGEMENT SYSTEMS
+00508B|Hewlett-Packard Company
+00508C|RSI SYSTEMS
+00508D|ABIT COMPUTER CORPORATION
+00508E|OPTIMATION, INC.
+00508F|ASITA TECHNOLOGIES INT'L LTD.
+005090|DCTRI
+005091|NETACCESS, INC.
+005092|Rigaku Corporation Osaka Plant
+005093|BOEING
+005094|PACE plc
+005095|PERACOM NETWORKS
+005096|SALIX TECHNOLOGIES, INC.
+005097|MMC-EMBEDDED COMPUTERTECHNIK GmbH
+005098|GLOBALOOP, LTD.
+005099|3COM EUROPE, LTD.
+00509A|TAG ELECTRONIC SYSTEMS
+00509B|SWITCHCORE AB
+00509C|BETA RESEARCH
+00509D|THE INDUSTREE B.V.
+00509E|Les Technologies SoftAcoustik Inc.
+00509F|HORIZON COMPUTER
+0050A0|DELTA COMPUTER SYSTEMS, INC.
+0050A1|CARLO GAVAZZI, INC.
+0050A2|Cisco
+0050A3|TransMedia Communications, Inc.
+0050A4|IO TECH, INC.
+0050A5|CAPITOL BUSINESS SYSTEMS, LTD.
+0050A6|OPTRONICS
+0050A7|Cisco
+0050A8|OpenCon Systems, Inc.
+0050A9|MOLDAT WIRELESS TECHNOLGIES
+0050AA|KONICA MINOLTA HOLDINGS, INC.
+0050AB|NALTEC, Inc.
+0050AC|MAPLE COMPUTER CORPORATION
+0050AD|CommUnique Wireless Corp.
+0050AE|FDK Co., Ltd
+0050AF|INTERGON, INC.
+0050B0|TECHNOLOGY ATLANTA CORPORATION
+0050B1|GIDDINGS & LEWIS
+0050B2|BRODEL GmbH
+0050B3|VOICEBOARD CORPORATION
+0050B4|SATCHWELL CONTROL SYSTEMS, LTD
+0050B5|FICHET-BAUCHE
+0050B6|GOOD WAY IND. CO., LTD.
+0050B7|BOSER TECHNOLOGY CO., LTD.
+0050B8|INOVA COMPUTERS GMBH & CO. KG
+0050B9|XITRON TECHNOLOGIES, INC.
+0050BA|D-LINK
+0050BB|CMS TECHNOLOGIES
+0050BC|HAMMER STORAGE SOLUTIONS
+0050BD|Cisco
+0050BE|FAST MULTIMEDIA AG
+0050BF|Metalligence Technology Corp.
+0050C0|GATAN, INC.
+0050C1|GEMFLEX NETWORKS, LTD.
+0050C2|IEEE REGISTRATION AUTHORITY  - Please see IAB public listing for more information.
+0050C4|IMD
+0050C5|ADS Technologies, Inc
+0050C6|LOOP TELECOMMUNICATION INTERNATIONAL, INC.
+0050C8|Addonics Technologies, Inc.
+0050C9|MASPRO DENKOH CORP.
+0050CA|NET TO NET TECHNOLOGIES
+0050CB|JETTER
+0050CC|XYRATEX
+0050CD|DIGIANSWER A/S
+0050CE|LG INTERNATIONAL CORP.
+0050CF|VANLINK COMMUNICATION TECHNOLOGY RESEARCH INSTITUTE
+0050D0|MINERVA SYSTEMS
+0050D1|Cisco
+0050D2|CMC Electronics Inc
+0050D3|DIGITAL AUDIO PROCESSING PTY. LTD.
+0050D4|JOOHONG INFORMATION &
+0050D5|AD SYSTEMS CORP.
+0050D6|ATLAS COPCO TOOLS AB
+0050D7|TELSTRAT
+0050D8|UNICORN COMPUTER CORP.
+0050D9|ENGETRON-ENGENHARIA ELETRONICA IND. e COM. LTDA
+0050DA|3COM CORPORATION
+0050DB|CONTEMPORARY CONTROL
+0050DC|TAS TELEFONBAU A. SCHWABE GMBH & CO. KG
+0050DD|SERRA SOLDADURA, S.A.
+0050DE|SIGNUM SYSTEMS CORP.
+0050DF|AirFiber, Inc.
+0050E1|NS TECH ELECTRONICS SDN BHD
+0050E2|Cisco
+0050E3|ARRIS Group, Inc.
+0050E4|Apple
+0050E6|HAKUSAN CORPORATION
+0050E7|PARADISE INNOVATIONS (ASIA)
+0050E8|NOMADIX INC.
+0050EA|XEL COMMUNICATIONS, INC.
+0050EB|ALPHA-TOP CORPORATION
+0050EC|OLICOM A/S
+0050ED|ANDA NETWORKS
+0050EE|TEK DIGITEL CORPORATION
+0050EF|SPE Systemhaus GmbH
+0050F0|Cisco
+0050F1|Intel Corporate
+0050F2|Microsoft
+0050F3|GLOBAL NET INFORMATION CO., Ltd.
+0050F4|SIGMATEK GMBH & CO. KG
+0050F6|PAN-INTERNATIONAL INDUSTRIAL CORP.
+0050F7|VENTURE MANUFACTURING (SINGAPORE) LTD.
+0050F8|ENTREGA TECHNOLOGIES, INC.
+0050F9|Sensormatic Electronics LLC
+0050FA|OXTEL, LTD.
+0050FB|VSK ELECTRONICS
+0050FC|EDIMAX TECHNOLOGY CO., LTD.
+0050FD|VISIONCOMM CO., LTD.
+0050FE|PCTVnet ASA
+0050FF|HAKKO ELECTRONICS CO., LTD.
+005218|Wuxi Keboda Electron Co.Ltd
+0054AF|Continental Automotive Systems Inc.
+005907|LenovoEMC Products USA, LLC
+005A39|SHENZHEN FAST TECHNOLOGIES CO., LTD.
+005CB1|Gospell DIGITAL TECHNOLOGY CO., LTD
+005D03|Xilinx, Inc
+006000|XYCOM INC.
+006001|InnoSys, Inc.
+006002|SCREEN SUBTITLING SYSTEMS, LTD
+006003|TERAOKA WEIGH SYSTEM PTE, LTD.
+006004|COMPUTADORES MODULARES SA
+006005|FEEDBACK DATA LTD.
+006006|SOTEC CO., LTD
+006007|ACRES GAMING, INC.
+006008|3COM CORPORATION
+006009|Cisco
+00600A|SORD COMPUTER CORPORATION
+00600B|LOGWARE GmbH
+00600C|Eurotech Inc.
+00600D|Digital Logic GmbH
+00600E|WAVENET INTERNATIONAL, INC.
+00600F|WESTELL, INC.
+006010|NETWORK MACHINES, INC.
+006011|CRYSTAL SEMICONDUCTOR CORP.
+006012|POWER COMPUTING CORPORATION
+006013|NETSTAL MASCHINEN AG
+006014|EDEC CO., LTD.
+006015|NET2NET CORPORATION
+006016|CLARIION
+006017|TOKIMEC INC.
+006018|STELLAR ONE CORPORATION
+006019|Roche Diagnostics
+00601A|KEITHLEY INSTRUMENTS
+00601B|MESA ELECTRONICS
+00601C|TELXON CORPORATION
+00601D|LUCENT TECHNOLOGIES
+00601E|SOFTLAB, INC.
+00601F|STALLION TECHNOLOGIES
+006020|PIVOTAL NETWORKING, INC.
+006021|DSC CORPORATION
+006022|VICOM SYSTEMS, INC.
+006023|PERICOM SEMICONDUCTOR CORP.
+006024|GRADIENT TECHNOLOGIES, INC.
+006025|ACTIVE IMAGING PLC
+006026|VIKING Modular Solutions
+006027|Superior Modular Products
+006028|MACROVISION CORPORATION
+006029|CARY PERIPHERALS INC.
+00602A|SYMICRON COMPUTER COMMUNICATIONS, LTD.
+00602B|PEAK AUDIO
+00602C|LINX Data Terminals, Inc.
+00602D|ALERTON TECHNOLOGIES, INC.
+00602E|CYCLADES CORPORATION
+00602F|Cisco
+006030|VILLAGE TRONIC ENTWICKLUNG
+006031|HRK SYSTEMS
+006032|I-CUBE, INC.
+006033|ACUITY IMAGING, INC.
+006034|ROBERT BOSCH GmbH
+006035|DALLAS SEMICONDUCTOR, INC.
+006036|AIT Austrian Institute of Technology GmbH
+006037|NXP Semiconductors
+006038|Nortel Networks
+006039|SanCom Technology, Inc.
+00603A|QUICK CONTROLS LTD.
+00603B|AMTEC spa
+00603C|HAGIWARA SYS-COM CO., LTD.
+00603D|3CX
+00603E|Cisco
+00603F|PATAPSCO DESIGNS
+006040|NETRO CORP.
+006041|Yokogawa Electric Corporation
+006042|TKS (USA), INC.
+006043|iDirect, INC.
+006044|LITTON/POLY-SCIENTIFIC
+006045|PATHLIGHT TECHNOLOGIES
+006046|VMETRO, INC.
+006047|Cisco
+006048|EMC CORPORATION
+006049|VINA TECHNOLOGIES
+00604A|SAIC IDEAS GROUP
+00604B|Safe-com GmbH & Co. KG
+00604C|SAGEM COMMUNICATION
+00604D|MMC NETWORKS, INC.
+00604E|CYCLE COMPUTER CORPORATION, INC.
+00604F|Tattile SRL
+006050|INTERNIX INC.
+006051|QUALITY SEMICONDUCTOR
+006052|PERIPHERALS ENTERPRISE CO., Ltd.
+006053|TOYODA MACHINE WORKS, LTD.
+006054|CONTROLWARE GMBH
+006055|CORNELL UNIVERSITY
+006056|NETWORK TOOLS, INC.
+006057|MURATA MANUFACTURING CO., LTD.
+006058|COPPER MOUNTAIN COMMUNICATIONS, INC.
+006059|TECHNICAL COMMUNICATIONS CORP.
+00605A|CELCORE, INC.
+00605B|IntraServer Technology, Inc.
+00605C|Cisco
+00605D|SCANIVALVE CORP.
+00605E|LIBERTY TECHNOLOGY NETWORKING
+00605F|NIPPON UNISOFT CORPORATION
+006060|Data Innovations North America
+006061|WHISTLE COMMUNICATIONS CORP.
+006062|TELESYNC, INC.
+006063|PSION DACOM PLC.
+006064|NETCOMM LIMITED
+006065|BERNECKER & RAINER INDUSTRIE-ELEKTRONIC GmbH
+006066|LACROIX Trafic
+006067|ACER NETXUS INC.
+006068|Dialogic Corporation
+006069|Brocade Communications Systems, Inc.
+00606A|MITSUBISHI WIRELESS COMMUNICATIONS. INC.
+00606B|Synclayer Inc.
+00606C|ARESCOM
+00606D|DIGITAL EQUIPMENT CORP.
+00606E|DAVICOM SEMICONDUCTOR, INC.
+00606F|CLARION CORPORATION OF AMERICA
+006070|Cisco
+006071|MIDAS LAB, INC.
+006072|VXL INSTRUMENTS, LIMITED
+006073|REDCREEK COMMUNICATIONS, INC.
+006074|QSC AUDIO PRODUCTS
+006075|PENTEK, INC.
+006076|SCHLUMBERGER TECHNOLOGIES RETAIL PETROLEUM SYSTEMS
+006077|PRISA NETWORKS
+006078|POWER MEASUREMENT LTD.
+006079|Mainstream Data, Inc.
+00607A|DVS GmbH
+00607B|FORE SYSTEMS, INC.
+00607C|WaveAccess, Ltd.
+00607D|SENTIENT NETWORKS INC.
+00607E|GIGALABS, INC.
+00607F|AURORA TECHNOLOGIES, INC.
+006080|MICROTRONIX DATACOM LTD.
+006081|TV/COM INTERNATIONAL
+006082|NOVALINK TECHNOLOGIES, INC.
+006083|Cisco
+006084|DIGITAL VIDEO
+006085|Storage Concepts
+006086|LOGIC REPLACEMENT TECH. LTD.
+006087|KANSAI ELECTRIC CO., LTD.
+006088|WHITE MOUNTAIN DSP, INC.
+006089|XATA
+00608A|CITADEL COMPUTER
+00608B|ConferTech International
+00608C|3COM CORPORATION
+00608D|UNIPULSE CORP.
+00608E|HE ELECTRONICS, TECHNOLOGIE & SYSTEMTECHNIK GmbH
+00608F|TEKRAM TECHNOLOGY CO., LTD.
+006090|Artiza Networks Inc
+006091|FIRST PACIFIC NETWORKS, INC.
+006092|MICRO/SYS, INC.
+006093|VARIAN
+006094|IBM Corp
+006095|ACCU-TIME SYSTEMS, INC.
+006096|T.S. MICROTECH INC.
+006097|3COM CORPORATION
+006098|HT COMMUNICATIONS
+006099|SBE, Inc.
+00609A|NJK TECHNO CO.
+00609B|ASTRO-MED, INC.
+00609C|Perkin-Elmer Incorporated
+00609D|PMI FOOD EQUIPMENT GROUP
+00609E|ASC X3 - INFORMATION TECHNOLOGY STANDARDS SECRETARIATS
+00609F|PHAST CORPORATION
+0060A0|SWITCHED NETWORK TECHNOLOGIES, INC.
+0060A1|VPNet, Inc.
+0060A2|NIHON UNISYS LIMITED CO.
+0060A3|CONTINUUM TECHNOLOGY CORP.
+0060A4|GEW Technologies (PTY)Ltd
+0060A5|PERFORMANCE TELECOM CORP.
+0060A6|PARTICLE MEASURING SYSTEMS
+0060A7|MICROSENS GmbH & CO. KG
+0060A8|TIDOMAT AB
+0060A9|GESYTEC MbH
+0060AA|INTELLIGENT DEVICES INC. (IDI)
+0060AB|LARSCOM INCORPORATED
+0060AC|RESILIENCE CORPORATION
+0060AD|MegaChips Corporation
+0060AE|TRIO INFORMATION SYSTEMS AB
+0060AF|PACIFIC MICRO DATA, INC.
+0060B0|HEWLETT-PACKARD CO.
+0060B1|INPUT/OUTPUT, INC.
+0060B2|PROCESS CONTROL CORP.
+0060B3|Z-Com, Inc.
+0060B4|GLENAYRE R&D INC.
+0060B5|KEBA GmbH
+0060B6|LAND COMPUTER CO., LTD.
+0060B7|CHANNELMATIC, INC.
+0060B8|CORELIS Inc.
+0060B9|NEC Platforms, Ltd
+0060BA|SAHARA NETWORKS, INC.
+0060BB|CABLETRON - NETLINK, INC.
+0060BC|KeunYoung Electronics & Communication Co., Ltd.
+0060BD|HUBBELL-PULSECOM
+0060BE|WEBTRONICS
+0060BF|MACRAIGOR SYSTEMS, INC.
+0060C0|Nera Networks AS
+0060C1|WaveSpan Corporation
+0060C2|MPL AG
+0060C3|NETVISION CORPORATION
+0060C4|SOLITON SYSTEMS K.K.
+0060C5|ANCOT CORP.
+0060C6|DCS AG
+0060C7|AMATI COMMUNICATIONS CORP.
+0060C8|KUKA WELDING SYSTEMS & ROBOTS
+0060C9|ControlNet, Inc.
+0060CA|HARMONIC SYSTEMS INCORPORATED
+0060CB|HITACHI ZOSEN CORPORATION
+0060CC|EMTRAK, INCORPORATED
+0060CD|VideoServer, Inc.
+0060CE|ACCLAIM COMMUNICATIONS
+0060CF|ALTEON NETWORKS, INC.
+0060D0|SNMP RESEARCH INCORPORATED
+0060D1|CASCADE COMMUNICATIONS
+0060D2|LUCENT TECHNOLOGIES TAIWAN TELECOMMUNICATIONS CO., LTD.
+0060D3|AT&T
+0060D4|ELDAT COMMUNICATION LTD.
+0060D5|MIYACHI TECHNOS CORP.
+0060D6|NovAtel Wireless Technologies Ltd.
+0060D7|ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE (EPFL)
+0060D8|ELMIC SYSTEMS, INC.
+0060D9|TRANSYS NETWORKS INC.
+0060DA|Red Lion Controls, LP
+0060DB|NTP ELEKTRONIK A/S
+0060DC|Toyo Network Systems  & System Integration Co. LTD
+0060DD|MYRICOM, INC.
+0060DE|Kayser-Threde GmbH
+0060DF|Brocade Communications Systems, Inc.
+0060E0|AXIOM TECHNOLOGY CO., LTD.
+0060E1|ORCKIT COMMUNICATIONS LTD.
+0060E2|QUEST ENGINEERING & DEVELOPMENT
+0060E3|ARBIN INSTRUMENTS
+0060E4|COMPUSERVE, INC.
+0060E5|FUJI AUTOMATION CO., LTD.
+0060E6|SHOMITI SYSTEMS INCORPORATED
+0060E7|RANDATA
+0060E8|HITACHI COMPUTER PRODUCTS (AMERICA), INC.
+0060E9|ATOP TECHNOLOGIES, INC.
+0060EA|StreamLogic
+0060EB|FOURTHTRACK SYSTEMS
+0060EC|HERMARY OPTO ELECTRONICS INC.
+0060ED|RICARDO TEST AUTOMATION LTD.
+0060EE|APOLLO
+0060EF|FLYTECH TECHNOLOGY CO., LTD.
+0060F0|JOHNSON & JOHNSON MEDICAL, INC
+0060F1|EXP COMPUTER, INC.
+0060F2|LASERGRAPHICS, INC.
+0060F3|Performance Analysis Broadband, Spirent plc
+0060F4|ADVANCED COMPUTER SOLUTIONS, Inc.
+0060F5|ICON WEST, INC.
+0060F6|NEXTEST COMMUNICATIONS PRODUCTS, INC.
+0060F7|DATAFUSION SYSTEMS
+0060F8|Loran International Technologies Inc.
+0060F9|DIAMOND LANE COMMUNICATIONS
+0060FA|EDUCATIONAL TECHNOLOGY RESOURCES, INC.
+0060FB|PACKETEER, INC.
+0060FC|CONSERVATION THROUGH INNOVATION LTD.
+0060FD|NetICs, Inc.
+0060FE|LYNX SYSTEM DEVELOPERS, INC.
+0060FF|QuVis, Inc.
+006171|Apple
+006440|Cisco
+0064A6|Maquet CardioVascular
+00664B|Huawei Technologies Co., Ltd
+006B8E|Shanghai Feixun Communication Co.,Ltd.
+006B9E|VIZIO Inc
+006BA0|SHENZHEN UNIVERSAL INTELLISYS PTE LTD
+006DFB|Vutrix (UK) Ltd
+0070B0|M/A-COM INC. COMPANIES
+0070B3|DATA RECALL LTD.
+0071C2|PEGATRON CORPORATION
+0071CC|Hon Hai Precision Ind. Co.,Ltd.
+00738D|Tinno Mobile Technology Corp
+0073E0|Samsung
+007532|INID BV
+0075E1|Ampt, LLC
+00789E|SAGEMCOM
+007DFA|Volkswagen Group of America
+007E56|China Dragon Technology Limited
+007F28|Actiontec Electronics, Inc
+008000|MULTITECH SYSTEMS, INC.
+008001|PERIPHONICS CORPORATION
+008002|SATELCOM (UK) LTD
+008003|HYTEC ELECTRONICS LTD.
+008004|ANTLOW COMMUNICATIONS, LTD.
+008005|CACTUS COMPUTER INC.
+008006|COMPUADD CORPORATION
+008007|DLOG NC-SYSTEME
+008008|DYNATECH COMPUTER SYSTEMS
+008009|JUPITER SYSTEMS, INC.
+00800A|JAPAN COMPUTER CORP.
+00800B|CSK CORPORATION
+00800C|VIDECOM LIMITED
+00800D|VOSSWINKEL F.U.
+00800E|ATLANTIX CORPORATION
+00800F|STANDARD MICROSYSTEMS
+008010|COMMODORE INTERNATIONAL
+008011|DIGITAL SYSTEMS INT'L. INC.
+008012|INTEGRATED MEASUREMENT SYSTEMS
+008013|THOMAS-CONRAD CORPORATION
+008014|ESPRIT SYSTEMS
+008015|SEIKO SYSTEMS, INC.
+008016|WANDEL AND GOLTERMANN
+008017|PFU LIMITED
+008018|KOBE STEEL, LTD.
+008019|DAYNA COMMUNICATIONS, INC.
+00801A|BELL ATLANTIC
+00801B|KODIAK TECHNOLOGY
+00801C|NEWPORT SYSTEMS SOLUTIONS
+00801D|INTEGRATED INFERENCE MACHINES
+00801E|XINETRON, INC.
+00801F|KRUPP ATLAS ELECTRONIK GMBH
+008020|NETWORK PRODUCTS
+008021|Alcatel Canada Inc.
+008022|SCAN-OPTICS
+008023|INTEGRATED BUSINESS NETWORKS
+008024|KALPANA, INC.
+008025|STOLLMANN GMBH
+008026|NETWORK PRODUCTS CORPORATION
+008027|ADAPTIVE SYSTEMS, INC.
+008028|TRADPOST (HK) LTD
+008029|EAGLE TECHNOLOGY, INC.
+00802A|TEST SYSTEMS & SIMULATIONS INC
+00802B|INTEGRATED MARKETING CO
+00802C|THE SAGE GROUP PLC
+00802D|XYLOGICS INC
+00802E|CASTLE ROCK COMPUTING
+00802F|NATIONAL INSTRUMENTS CORP.
+008030|NEXUS ELECTRONICS
+008031|BASYS, CORP.
+008032|ACCESS CO., LTD.
+008033|EMS Aviation, Inc.
+008034|SMT GOUPIL
+008035|TECHNOLOGY WORKS, INC.
+008036|REFLEX MANUFACTURING SYSTEMS
+008037|Ericsson Group
+008038|DATA RESEARCH & APPLICATIONS
+008039|ALCATEL STC AUSTRALIA
+00803A|VARITYPER, INC.
+00803B|APT COMMUNICATIONS, INC.
+00803C|TVS ELECTRONICS LTD
+00803D|SURIGIKEN CO.,  LTD.
+00803E|SYNERNETICS
+00803F|TATUNG COMPANY
+008040|JOHN FLUKE MANUFACTURING CO.
+008041|VEB KOMBINAT ROBOTRON
+008042|Artesyn Embedded Technologies
+008043|NETWORLD, INC.
+008044|SYSTECH COMPUTER CORP.
+008045|MATSUSHITA ELECTRIC IND. CO
+008046|Tattile SRL
+008047|IN-NET CORP.
+008048|COMPEX INCORPORATED
+008049|NISSIN ELECTRIC CO., LTD.
+00804A|PRO-LOG
+00804B|EAGLE TECHNOLOGIES PTY.LTD.
+00804C|CONTEC CO., LTD.
+00804D|CYCLONE MICROSYSTEMS, INC.
+00804E|APEX COMPUTER COMPANY
+00804F|DAIKIN INDUSTRIES, LTD.
+008050|ZIATECH CORPORATION
+008051|FIBERMUX
+008052|TECHNICALLY ELITE CONCEPTS
+008053|INTELLICOM, INC.
+008054|FRONTIER TECHNOLOGIES CORP.
+008055|FERMILAB
+008056|SPHINX ELEKTRONIK GMBH
+008057|ADSOFT, LTD.
+008058|PRINTER SYSTEMS CORPORATION
+008059|STANLEY ELECTRIC CO., LTD
+00805A|TULIP COMPUTERS INTERNAT'L B.V
+00805B|CONDOR SYSTEMS, INC.
+00805C|AGILIS CORPORATION
+00805D|CANSTAR
+00805E|LSI LOGIC CORPORATION
+00805F|Hewlett-Packard Company
+008060|NETWORK INTERFACE CORPORATION
+008061|LITTON SYSTEMS, INC.
+008062|INTERFACE  CO.
+008063|Hirschmann Automation and Control GmbH
+008064|WYSE TECHNOLOGY LLC
+008065|CYBERGRAPHIC SYSTEMS PTY LTD.
+008066|ARCOM CONTROL SYSTEMS, LTD.
+008067|SQUARE D COMPANY
+008068|YAMATECH SCIENTIFIC LTD.
+008069|COMPUTONE SYSTEMS
+00806A|ERI (EMPAC RESEARCH INC.)
+00806B|SCHMID TELECOMMUNICATION
+00806C|CEGELEC PROJECTS LTD
+00806D|CENTURY SYSTEMS CORP.
+00806E|NIPPON STEEL CORPORATION
+00806F|ONELAN LTD.
+008070|COMPUTADORAS MICRON
+008071|SAI TECHNOLOGY
+008072|MICROPLEX SYSTEMS LTD.
+008073|DWB ASSOCIATES
+008074|FISHER CONTROLS
+008075|PARSYTEC GMBH
+008076|MCNC
+008077|BROTHER INDUSTRIES, LTD.
+008078|PRACTICAL PERIPHERALS, INC.
+008079|MICROBUS DESIGNS LTD.
+00807A|AITECH SYSTEMS LTD.
+00807B|ARTEL COMMUNICATIONS CORP.
+00807C|FIBERCOM, INC.
+00807D|EQUINOX SYSTEMS INC.
+00807E|SOUTHERN PACIFIC LTD.
+00807F|DY-4 INCORPORATED
+008080|DATAMEDIA CORPORATION
+008081|KENDALL SQUARE RESEARCH CORP.
+008082|PEP MODULAR COMPUTERS GMBH
+008083|AMDAHL
+008084|THE CLOUD INC.
+008085|H-THREE SYSTEMS CORPORATION
+008086|COMPUTER GENERATION INC.
+008087|OKI ELECTRIC INDUSTRY CO., LTD
+008088|VICTOR COMPANY OF JAPAN, LTD.
+008089|TECNETICS (PTY) LTD.
+00808A|SUMMIT MICROSYSTEMS CORP.
+00808B|DACOLL LIMITED
+00808C|NetScout Systems, Inc.
+00808D|WESTCOAST TECHNOLOGY B.V.
+00808E|RADSTONE TECHNOLOGY
+00808F|C. ITOH ELECTRONICS, INC.
+008090|MICROTEK INTERNATIONAL, INC.
+008091|TOKYO ELECTRIC CO.,LTD
+008092|Silex Technology, Inc.
+008093|XYRON CORPORATION
+008094|ALFA LAVAL AUTOMATION AB
+008095|BASIC MERTON HANDELSGES.M.B.H.
+008096|HUMAN DESIGNED SYSTEMS, INC.
+008097|CENTRALP AUTOMATISMES
+008098|TDK CORPORATION
+008099|Eaton Industries GmbH
+00809A|NOVUS NETWORKS LTD
+00809B|JUSTSYSTEM CORPORATION
+00809C|LUXCOM, INC.
+00809D|Commscraft Ltd.
+00809E|DATUS GMBH
+00809F|Alcatel-Lucent Enterprise
+0080A0|EDISA HEWLETT PACKARD S/A
+0080A1|MICROTEST, INC.
+0080A2|CREATIVE ELECTRONIC SYSTEMS
+0080A3|Lantronix
+0080A4|LIBERTY ELECTRONICS
+0080A5|SPEED INTERNATIONAL
+0080A6|REPUBLIC TECHNOLOGY, INC.
+0080A7|Honeywell International Inc
+0080A8|VITACOM CORPORATION
+0080A9|CLEARPOINT RESEARCH
+0080AA|MAXPEED
+0080AB|DUKANE NETWORK INTEGRATION
+0080AC|IMLOGIX, DIVISION OF GENESYS
+0080AD|CNET TECHNOLOGY, INC.
+0080AE|HUGHES NETWORK SYSTEMS
+0080AF|ALLUMER CO., LTD.
+0080B0|ADVANCED INFORMATION
+0080B1|SOFTCOM A/S
+0080B2|NETWORK EQUIPMENT TECHNOLOGIES
+0080B3|AVAL DATA CORPORATION
+0080B4|SOPHIA SYSTEMS
+0080B5|UNITED NETWORKS INC.
+0080B6|THEMIS COMPUTER
+0080B7|STELLAR COMPUTER
+0080B8|B.U.G. MORISEIKI, INCORPORATED
+0080B9|ARCHE TECHNOLIGIES INC.
+0080BA|SPECIALIX (ASIA) PTE, LTD
+0080BB|HUGHES LAN SYSTEMS
+0080BC|HITACHI ENGINEERING CO., LTD
+0080BD|THE FURUKAWA ELECTRIC CO., LTD
+0080BE|ARIES RESEARCH
+0080BF|TAKAOKA ELECTRIC MFG. CO. LTD.
+0080C0|PENRIL DATACOMM
+0080C1|LANEX CORPORATION
+0080C2|IEEE 802.1 COMMITTEE
+0080C3|BICC INFORMATION SYSTEMS & SVC
+0080C4|DOCUMENT TECHNOLOGIES, INC.
+0080C5|NOVELLCO DE MEXICO
+0080C6|NATIONAL DATACOMM CORPORATION
+0080C7|XIRCOM
+0080C8|D-LINK SYSTEMS, INC.
+0080C9|ALBERTA MICROELECTRONIC CENTRE
+0080CA|NETCOM RESEARCH INCORPORATED
+0080CB|FALCO DATA PRODUCTS
+0080CC|MICROWAVE BYPASS SYSTEMS
+0080CD|MICRONICS COMPUTER, INC.
+0080CE|BROADCAST TELEVISION SYSTEMS
+0080CF|EMBEDDED PERFORMANCE INC.
+0080D0|COMPUTER PERIPHERALS, INC.
+0080D1|KIMTRON CORPORATION
+0080D2|SHINNIHONDENKO CO., LTD.
+0080D3|SHIVA CORP.
+0080D4|CHASE RESEARCH LTD.
+0080D5|CADRE TECHNOLOGIES
+0080D6|NUVOTECH, INC.
+0080D7|Fantum Engineering
+0080D8|NETWORK PERIPHERALS INC.
+0080D9|EMK Elektronik GmbH & Co. KG
+0080DA|Bruel & Kjaer Sound & Vibration Measurement A/S
+0080DB|GRAPHON CORPORATION
+0080DC|PICKER INTERNATIONAL
+0080DD|GMX INC/GIMIX
+0080DE|GIPSI S.A.
+0080DF|ADC CODENOLL TECHNOLOGY CORP.
+0080E0|XTP SYSTEMS, INC.
+0080E1|STMICROELECTRONICS
+0080E2|T.D.I. CO., LTD.
+0080E3|CORAL NETWORK CORPORATION
+0080E4|NORTHWEST DIGITAL SYSTEMS, INC
+0080E5|NetApp, Inc
+0080E6|PEER NETWORKS, INC.
+0080E7|LYNWOOD SCIENTIFIC DEV. LTD.
+0080E8|CUMULUS CORPORATIION
+0080E9|Madge Ltd.
+0080EA|ADVA Optical Networking Ltd.
+0080EB|COMPCONTROL B.V.
+0080EC|SUPERCOMPUTING SOLUTIONS, INC.
+0080ED|IQ TECHNOLOGIES, INC.
+0080EE|THOMSON CSF
+0080EF|RATIONAL
+0080F0|Panasonic Communications Co., Ltd.
+0080F1|OPUS SYSTEMS
+0080F2|RAYCOM SYSTEMS INC
+0080F3|SUN ELECTRONICS CORP.
+0080F4|TELEMECANIQUE ELECTRIQUE
+0080F5|Quantel Ltd
+0080F6|SYNERGY MICROSYSTEMS
+0080F7|ZENITH ELECTRONICS
+0080F8|MIZAR, INC.
+0080F9|HEURIKON CORPORATION
+0080FA|RWT GMBH
+0080FB|BVM LIMITED
+0080FC|AVATAR CORPORATION
+0080FD|EXSCEED CORPRATION
+0080FE|AZURE TECHNOLOGIES, INC.
+0080FF|SOC. DE TELEINFORMATIQUE RTC
+0086A0|ZZZZ 
+008865|Apple
+008B43|RFTECH
+008C10|Black Box Corp.
+008C54|ADB Broadband Italia
+008CFA|Inventec Corporation
+008D4E|CJSC NII STT
+008DDA|Link One Co., Ltd.
+008EF2|Netgear
+009000|DIAMOND MULTIMEDIA
+009001|NISHIMU ELECTRONICS INDUSTRIES CO., LTD.
+009002|ALLGON AB
+009003|APLIO
+009004|3COM EUROPE LTD.
+009005|PROTECH SYSTEMS CO., LTD.
+009006|HAMAMATSU PHOTONICS K.K.
+009007|DOMEX TECHNOLOGY CORP.
+009008|HanA Systems Inc.
+009009|I Controls, Inc.
+00900A|PROTON ELECTRONIC INDUSTRIAL CO., LTD.
+00900B|LANNER ELECTRONICS, INC.
+00900C|Cisco
+00900D|Overland Storage Inc.
+00900E|HANDLINK TECHNOLOGIES, INC.
+00900F|KAWASAKI HEAVY INDUSTRIES, LTD
+009010|SIMULATION LABORATORIES, INC.
+009011|WAVTrace, Inc.
+009012|GLOBESPAN SEMICONDUCTOR, INC.
+009013|SAMSAN CORP.
+009014|ROTORK INSTRUMENTS, LTD.
+009015|CENTIGRAM COMMUNICATIONS CORP.
+009016|ZAC
+009017|Zypcom, Inc
+009018|ITO ELECTRIC INDUSTRY CO, LTD.
+009019|HERMES ELECTRONICS CO., LTD.
+00901A|UNISPHERE SOLUTIONS
+00901B|DIGITAL CONTROLS
+00901C|mps Software Gmbh
+00901D|PEC (NZ) LTD.
+00901E|Selesta Ingegneria S.p.A.
+00901F|ADTEC PRODUCTIONS, INC.
+009020|PHILIPS ANALYTICAL X-RAY B.V.
+009021|Cisco
+009022|IVEX
+009023|ZILOG INC.
+009024|PIPELINKS, INC.
+009025|BAE Systems Australia (Electronic Systems) Pty Ltd
+009026|ADVANCED SWITCHING COMMUNICATIONS, INC.
+009027|Intel Corporate
+009028|NIPPON SIGNAL CO., LTD.
+009029|CRYPTO AG
+00902A|COMMUNICATION DEVICES, INC.
+00902B|Cisco
+00902C|DATA & CONTROL EQUIPMENT LTD.
+00902D|DATA ELECTRONICS (AUST.) PTY, LTD.
+00902E|NAMCO LIMITED
+00902F|NETCORE SYSTEMS, INC.
+009030|HONEYWELL-DATING
+009031|MYSTICOM, LTD.
+009032|PELCOMBE GROUP LTD.
+009033|INNOVAPHONE AG
+009034|IMAGIC, INC.
+009035|ALPHA TELECOM, INC.
+009036|ens, inc.
+009037|ACUCOMM, INC.
+009038|FOUNTAIN TECHNOLOGIES, INC.
+009039|SHASTA NETWORKS
+00903A|NIHON MEDIA TOOL INC.
+00903B|TriEMS Research Lab, Inc.
+00903C|ATLANTIC NETWORK SYSTEMS
+00903D|BIOPAC SYSTEMS, INC.
+00903E|N.V. PHILIPS INDUSTRIAL ACTIVITIES
+00903F|AZTEC RADIOMEDIA
+009040|Siemens Network Convergence LLC
+009041|APPLIED DIGITAL ACCESS
+009042|ECCS, Inc.
+009043|Tattile SRL
+009044|ASSURED DIGITAL, INC.
+009045|Marconi Communications
+009046|DEXDYNE, LTD.
+009047|GIGA FAST E. LTD.
+009048|ZEAL CORPORATION
+009049|ENTRIDIA CORPORATION
+00904A|CONCUR SYSTEM TECHNOLOGIES
+00904B|GemTek Technology Co., Ltd.
+00904C|EPIGRAM, INC.
+00904D|SPEC S.A.
+00904E|DELEM BV
+00904F|ABB POWER T&D COMPANY, INC.
+009050|TELESTE OY
+009051|ULTIMATE TECHNOLOGY CORP.
+009052|SELCOM ELETTRONICA S.R.L.
+009053|DAEWOO ELECTRONICS CO., LTD.
+009054|INNOVATIVE SEMICONDUCTORS, INC
+009055|PARKER HANNIFIN CORPORATION COMPUMOTOR DIVISION
+009056|TELESTREAM, INC.
+009057|AANetcom, Inc.
+009058|Ultra Electronics Ltd., Command and Control Systems
+009059|TELECOM DEVICE K.K.
+00905A|DEARBORN GROUP, INC.
+00905B|RAYMOND AND LAE ENGINEERING
+00905C|EDMI
+00905D|NETCOM SICHERHEITSTECHNIK GmbH
+00905E|RAULAND-BORG CORPORATION
+00905F|Cisco
+009060|SYSTEM CREATE CORP.
+009061|PACIFIC RESEARCH & ENGINEERING CORPORATION
+009062|ICP VORTEX COMPUTERSYSTEME GmbH
+009063|COHERENT COMMUNICATIONS SYSTEMS CORPORATION
+009064|Thomson Inc.
+009065|FINISAR CORPORATION
+009066|Troika Networks, Inc.
+009067|WalkAbout Computers, Inc.
+009068|DVT CORP.
+009069|JUNIPER NETWORKS, INC.
+00906A|TURNSTONE SYSTEMS, INC.
+00906B|APPLIED RESOURCES, INC.
+00906C|Sartorius Hamburg GmbH
+00906D|Cisco
+00906E|PRAXON, INC.
+00906F|Cisco
+009070|NEO NETWORKS, INC.
+009071|Applied Innovation Inc.
+009072|SIMRAD AS
+009073|GAIO TECHNOLOGY
+009074|ARGON NETWORKS, INC.
+009075|NEC DO BRASIL S.A.
+009076|FMT AIRCRAFT GATE SUPPORT SYSTEMS AB
+009077|ADVANCED FIBRE COMMUNICATIONS
+009078|MER TELEMANAGEMENT SOLUTIONS, LTD.
+009079|ClearOne, Inc.
+00907A|Spectralink, Inc
+00907B|E-TECH, INC.
+00907C|DIGITALCAST, INC.
+00907D|Lake Communications
+00907E|VETRONIX CORP.
+00907F|WatchGuard Technologies, Inc.
+009080|NOT LIMITED, INC.
+009081|ALOHA NETWORKS, INC.
+009082|FORCE INSTITUTE
+009083|TURBO COMMUNICATION, INC.
+009084|ATECH SYSTEM
+009085|GOLDEN ENTERPRISES, INC.
+009086|Cisco
+009087|ITIS
+009088|BAXALL SECURITY LTD.
+009089|SOFTCOM MICROSYSTEMS, INC.
+00908A|BAYLY COMMUNICATIONS, INC.
+00908B|Tattile SRL
+00908C|ETREND ELECTRONICS, INC.
+00908D|VICKERS ELECTRONICS SYSTEMS
+00908E|Nortel Networks Broadband Access
+00908F|AUDIO CODES LTD.
+009090|I-BUS
+009091|DigitalScape, Inc.
+009092|Cisco
+009093|NANAO CORPORATION
+009094|OSPREY TECHNOLOGIES, INC.
+009095|UNIVERSAL AVIONICS
+009096|ASKEY COMPUTER CORP.
+009097|Sycamore Networks
+009098|SBC DESIGNS, INC.
+009099|ALLIED TELESIS, K.K.
+00909A|ONE WORLD SYSTEMS, INC.
+00909B|MARKEM-IMAJE
+00909C|ARRIS Group, Inc.
+00909D|NovaTech Process Solutions, LLC
+00909E|Critical IO, LLC
+00909F|DIGI-DATA CORPORATION
+0090A0|8X8 INC.
+0090A1|Flying Pig Systems/High End Systems Inc.
+0090A2|CYBERTAN TECHNOLOGY, INC.
+0090A3|Corecess Inc.
+0090A4|ALTIGA NETWORKS
+0090A5|SPECTRA LOGIC
+0090A6|Cisco
+0090A7|CLIENTEC CORPORATION
+0090A8|NineTiles Networks, Ltd.
+0090A9|WESTERN DIGITAL
+0090AA|INDIGO ACTIVE VISION SYSTEMS LIMITED
+0090AB|Cisco
+0090AC|OPTIVISION, INC.
+0090AD|ASPECT ELECTRONICS, INC.
+0090AE|ITALTEL S.p.A.
+0090AF|J. MORITA MFG. CORP.
+0090B0|VADEM
+0090B1|Cisco
+0090B2|AVICI SYSTEMS INC.
+0090B3|AGRANAT SYSTEMS
+0090B4|WILLOWBROOK TECHNOLOGIES
+0090B5|NIKON CORPORATION
+0090B6|FIBEX SYSTEMS
+0090B7|DIGITAL LIGHTWAVE, INC.
+0090B8|ROHDE & SCHWARZ GMBH & CO. KG
+0090B9|BERAN INSTRUMENTS LTD.
+0090BA|VALID NETWORKS, INC.
+0090BB|TAINET COMMUNICATION SYSTEM Corp.
+0090BC|TELEMANN CO., LTD.
+0090BD|OMNIA COMMUNICATIONS, INC.
+0090BE|IBC/INTEGRATED BUSINESS COMPUTERS
+0090BF|Cisco
+0090C0|K.J. LAW ENGINEERS, INC.
+0090C1|Peco II, Inc.
+0090C2|JK microsystems, Inc.
+0090C3|TOPIC SEMICONDUCTOR CORP.
+0090C4|JAVELIN SYSTEMS, INC.
+0090C5|INTERNET MAGIC, INC.
+0090C6|OPTIM SYSTEMS, INC.
+0090C7|ICOM INC.
+0090C8|WAVERIDER COMMUNICATIONS (CANADA) INC.
+0090C9|DPAC Technologies
+0090CA|ACCORD VIDEO TELECOMMUNICATIONS, LTD.
+0090CB|Wireless OnLine, Inc.
+0090CC|Planex Communications
+0090CD|ENT-EMPRESA NACIONAL DE TELECOMMUNICACOES, S.A.
+0090CE|TETRA GmbH
+0090CF|NORTEL
+0090D0|Thomson Telecom Belgium
+0090D1|LEICHU ENTERPRISE CO., LTD.
+0090D2|ARTEL VIDEO SYSTEMS
+0090D3|GIESECKE & DEVRIENT GmbH
+0090D4|BindView Development Corp.
+0090D5|EUPHONIX, INC.
+0090D6|CRYSTAL GROUP
+0090D7|NetBoost Corp.
+0090D8|WHITECROSS SYSTEMS
+0090D9|Cisco
+0090DA|DYNARC, INC.
+0090DB|NEXT LEVEL COMMUNICATIONS
+0090DC|TECO INFORMATION SYSTEMS
+0090DD|MIHARU COMMUNICATIONS Inc
+0090DE|CARDKEY SYSTEMS, INC.
+0090DF|MITSUBISHI CHEMICAL AMERICA, INC.
+0090E0|SYSTRAN CORP.
+0090E1|TELENA S.P.A.
+0090E2|DISTRIBUTED PROCESSING TECHNOLOGY
+0090E3|AVEX ELECTRONICS INC.
+0090E4|NEC AMERICA, INC.
+0090E5|TEKNEMA, INC.
+0090E6|ALi Corporation
+0090E7|HORSCH ELEKTRONIK AG
+0090E8|MOXA TECHNOLOGIES CORP., LTD.
+0090E9|JANZ COMPUTER AG
+0090EA|ALPHA TECHNOLOGIES, INC.
+0090EB|SENTRY TELECOM SYSTEMS
+0090EC|PYRESCOM
+0090ED|CENTRAL SYSTEM RESEARCH CO., LTD.
+0090EE|PERSONAL COMMUNICATIONS TECHNOLOGIES
+0090EF|INTEGRIX, INC.
+0090F0|Harmonic Video Systems Ltd.
+0090F1|DOT HILL SYSTEMS CORPORATION
+0090F2|Cisco
+0090F3|ASPECT COMMUNICATIONS
+0090F4|LIGHTNING INSTRUMENTATION
+0090F5|CLEVO CO.
+0090F6|ESCALATE NETWORKS, INC.
+0090F7|NBASE COMMUNICATIONS LTD.
+0090F8|MEDIATRIX TELECOM
+0090F9|LEITCH
+0090FA|Emulex Corporation
+0090FB|PORTWELL, INC.
+0090FC|NETWORK COMPUTING DEVICES
+0090FD|CopperCom, Inc.
+0090FE|ELECOM CO., LTD.  (LANEED DIV.)
+0090FF|TELLUS TECHNOLOGY INC.
+0091D6|Crystal Group, Inc.
+0091FA|Synapse Product Development
+0092FA|SHENZHEN WISKY TECHNOLOGY CO.,LTD
+009363|Uni-Link Technology Co., Ltd.
+009569|LSD Science and Technology Co.,Ltd.
+0097FF|Heimann Sensor GmbH
+009C02|Hewlett-Packard Company
+009D8E|CARDIAC RECORDERS, INC.
+009EC8|Beijing Xiaomi Electronic Products Co., Ltd.
+00A000|CENTILLION NETWORKS, INC.
+00A001|DRS Signal Solutions
+00A002|LEEDS & NORTHRUP AUSTRALIA PTY LTD
+00A003|Siemens Switzerland Ltd., I B T HVP
+00A004|NETPOWER, INC.
+00A005|DANIEL INSTRUMENTS, LTD.
+00A006|IMAGE DATA PROCESSING SYSTEM GROUP
+00A007|APEXX TECHNOLOGY, INC.
+00A008|NETCORP
+00A009|WHITETREE NETWORK
+00A00A|Airspan
+00A00B|COMPUTEX CO., LTD.
+00A00C|KINGMAX TECHNOLOGY, INC.
+00A00D|THE PANDA PROJECT
+00A00E|VISUAL NETWORKS, INC.
+00A00F|Broadband Technologies
+00A010|SYSLOGIC DATENTECHNIK AG
+00A011|MUTOH INDUSTRIES LTD.
+00A012|Telco Systems, Inc.
+00A013|TELTREND LTD.
+00A014|CSIR
+00A015|WYLE
+00A016|MICROPOLIS CORP.
+00A017|J B M CORPORATION
+00A018|CREATIVE CONTROLLERS, INC.
+00A019|NEBULA CONSULTANTS, INC.
+00A01A|BINAR ELEKTRONIK AB
+00A01B|PREMISYS COMMUNICATIONS, INC.
+00A01C|NASCENT NETWORKS CORPORATION
+00A01D|Red Lion Controls, LP
+00A01E|EST CORPORATION
+00A01F|TRICORD SYSTEMS, INC.
+00A020|CITICORP/TTI
+00A021|General Dynamics
+00A022|CENTRE FOR DEVELOPMENT OF ADVANCED COMPUTING
+00A023|APPLIED CREATIVE TECHNOLOGY, INC.
+00A024|3COM CORPORATION
+00A025|REDCOM LABS INC.
+00A026|TELDAT, S.A.
+00A027|FIREPOWER SYSTEMS, INC.
+00A028|CONNER PERIPHERALS
+00A029|COULTER CORPORATION
+00A02A|TRANCELL SYSTEMS
+00A02B|TRANSITIONS RESEARCH CORP.
+00A02C|interWAVE Communications
+00A02D|1394 Trade Association
+00A02E|BRAND COMMUNICATIONS, LTD.
+00A02F|PIRELLI CAVI
+00A030|CAPTOR NV/SA
+00A031|HAZELTINE CORPORATION, MS 1-17
+00A032|GES SINGAPORE PTE. LTD.
+00A033|imc MeBsysteme GmbH
+00A034|AXEL
+00A035|CYLINK CORPORATION
+00A036|APPLIED NETWORK TECHNOLOGY
+00A037|Mindray DS USA, Inc.
+00A038|EMAIL ELECTRONICS
+00A039|ROSS TECHNOLOGY, INC.
+00A03A|KUBOTEK CORPORATION
+00A03B|TOSHIN ELECTRIC CO., LTD.
+00A03C|EG&G NUCLEAR INSTRUMENTS
+00A03D|OPTO-22
+00A03E|ATM FORUM
+00A03F|COMPUTER SOCIETY MICROPROCESSOR & MICROPROCESSOR STANDARDS C
+00A040|Apple
+00A041|INFICON
+00A042|SPUR PRODUCTS CORP.
+00A043|AMERICAN TECHNOLOGY LABS, INC.
+00A044|NTT IT CO., LTD.
+00A045|PHOENIX CONTACT GMBH & CO.
+00A046|SCITEX CORP. LTD.
+00A047|INTEGRATED FITNESS CORP.
+00A048|QUESTECH, LTD.
+00A049|DIGITECH INDUSTRIES, INC.
+00A04A|NISSHIN ELECTRIC CO., LTD.
+00A04B|TFL LAN INC.
+00A04C|INNOVATIVE SYSTEMS & TECHNOLOGIES, INC.
+00A04D|EDA INSTRUMENTS, INC.
+00A04E|VOELKER TECHNOLOGIES, INC.
+00A04F|AMERITEC CORP.
+00A050|CYPRESS SEMICONDUCTOR
+00A051|ANGIA COMMUNICATIONS. INC.
+00A052|STANILITE ELECTRONICS PTY. LTD
+00A053|COMPACT DEVICES, INC.
+00A054|gassan salman 
+00A055|Data Device Corporation
+00A056|MICROPROSS
+00A057|LANCOM Systems GmbH
+00A058|GLORY, LTD.
+00A059|HAMILTON HALLMARK
+00A05A|KOFAX IMAGE PRODUCTS
+00A05B|MARQUIP, INC.
+00A05C|INVENTORY CONVERSION, INC./
+00A05D|CS COMPUTER SYSTEME GmbH
+00A05E|MYRIAD LOGIC INC.
+00A05F|BTG Electronics Design BV
+00A060|ACER PERIPHERALS, INC.
+00A061|PURITAN BENNETT
+00A062|AES PRODATA
+00A063|JRL SYSTEMS, INC.
+00A064|KVB/ANALECT
+00A065|Symantec Corporation
+00A066|ISA CO., LTD.
+00A067|NETWORK SERVICES GROUP
+00A068|BHP LIMITED
+00A069|Symmetricom, Inc.
+00A06A|Verilink Corporation
+00A06B|DMS DORSCH MIKROSYSTEM GMBH
+00A06C|SHINDENGEN ELECTRIC MFG. CO., LTD.
+00A06D|MANNESMANN TALLY CORPORATION
+00A06E|AUSTRON, INC.
+00A06F|THE APPCON GROUP, INC.
+00A070|COASTCOM
+00A071|VIDEO LOTTERY TECHNOLOGIES,INC
+00A072|OVATION SYSTEMS LTD.
+00A073|COM21, INC.
+00A074|PERCEPTION TECHNOLOGY
+00A075|MICRON TECHNOLOGY, INC.
+00A076|CARDWARE LAB, INC.
+00A077|FUJITSU NEXION, INC.
+00A078|Marconi Communications
+00A079|ALPS ELECTRIC (USA), INC.
+00A07A|ADVANCED PERIPHERALS TECHNOLOGIES, INC.
+00A07B|DAWN COMPUTER INCORPORATION
+00A07C|TONYANG NYLON CO., LTD.
+00A07D|SEEQ TECHNOLOGY, INC.
+00A07E|AVID TECHNOLOGY, INC.
+00A07F|GSM-SYNTEL, LTD.
+00A080|Tattile SRL
+00A081|ALCATEL DATA NETWORKS
+00A082|NKT ELEKTRONIK A/S
+00A083|ASIMMPHONY TURKEY
+00A084|Dataplex Pty Ltd
+00A085|IEEE STANDARDS DEPART 
+00A086|AMBER WAVE SYSTEMS, INC.
+00A087|Microsemi Corporation
+00A088|ESSENTIAL COMMUNICATIONS
+00A089|XPOINT TECHNOLOGIES, INC.
+00A08A|BROOKTROUT TECHNOLOGY, INC.
+00A08B|ASTON ELECTRONIC DESIGNS LTD.
+00A08C|MultiMedia LANs, Inc.
+00A08D|JACOMO CORPORATION
+00A08E|Check Point Software Technologies
+00A08F|DESKNET SYSTEMS, INC.
+00A090|TimeStep Corporation
+00A091|APPLICOM INTERNATIONAL
+00A092|H. BOLLMANN MANUFACTURERS, LTD
+00A093|B/E AEROSPACE, Inc.
+00A094|COMSAT CORPORATION
+00A095|ACACIA NETWORKS, INC.
+00A096|MITSUMI ELECTRIC CO., LTD.
+00A097|JC INFORMATION SYSTEMS
+00A098|NetApp
+00A099|K-NET LTD.
+00A09A|NIHON KOHDEN AMERICA
+00A09B|QPSX COMMUNICATIONS, LTD.
+00A09C|Xyplex, Inc.
+00A09D|JOHNATHON FREEMAN TECHNOLOGIES
+00A09E|ICTV
+00A09F|COMMVISION CORP.
+00A0A0|COMPACT DATA, LTD.
+00A0A1|EPIC DATA INC.
+00A0A2|DIGICOM S.P.A.
+00A0A3|RELIABLE POWER METERS
+00A0A4|MICROS SYSTEMS, INC.
+00A0A5|TEKNOR MICROSYSTEME, INC.
+00A0A6|M.I. SYSTEMS, K.K.
+00A0A7|VORAX CORPORATION
+00A0A8|RENEX CORPORATION
+00A0A9|NAVTEL COMMUNICATIONS INC.
+00A0AA|SPACELABS MEDICAL
+00A0AB|NETCS INFORMATIONSTECHNIK GMBH
+00A0AC|GILAT SATELLITE NETWORKS, LTD.
+00A0AD|MARCONI SPA
+00A0AE|NUCOM SYSTEMS, INC.
+00A0AF|WMS INDUSTRIES
+00A0B0|I-O DATA DEVICE, INC.
+00A0B1|FIRST VIRTUAL CORPORATION
+00A0B2|SHIMA SEIKI
+00A0B3|ZYKRONIX
+00A0B4|TEXAS MICROSYSTEMS, INC.
+00A0B5|3H TECHNOLOGY
+00A0B6|SANRITZ AUTOMATION CO., LTD.
+00A0B7|CORDANT, INC.
+00A0B8|SYMBIOS LOGIC INC.
+00A0B9|EAGLE TECHNOLOGY, INC.
+00A0BA|PATTON ELECTRONICS CO.
+00A0BB|HILAN GMBH
+00A0BC|VIASAT, INCORPORATED
+00A0BD|I-TECH CORP.
+00A0BE|INTEGRATED CIRCUIT SYSTEMS, INC. COMMUNICATIONS GROUP
+00A0BF|WIRELESS DATA GROUP MOTOROLA
+00A0C0|DIGITAL LINK CORP.
+00A0C1|ORTIVUS MEDICAL AB
+00A0C2|R.A. SYSTEMS CO., LTD.
+00A0C3|UNICOMPUTER GMBH
+00A0C4|CRISTIE ELECTRONICS LTD.
+00A0C5|ZYXEL COMMUNICATION
+00A0C6|QUALCOMM INCORPORATED
+00A0C7|TADIRAN TELECOMMUNICATIONS
+00A0C8|ADTRAN INC.
+00A0C9|Intel Corporate
+00A0CA|FUJITSU DENSO LTD.
+00A0CB|ARK TELECOMMUNICATIONS, INC.
+00A0CC|LITE-ON COMMUNICATIONS, INC.
+00A0CD|DR. JOHANNES HEIDENHAIN GmbH
+00A0CE|Ecessa
+00A0CF|SOTAS, INC.
+00A0D0|TEN X TECHNOLOGY, INC.
+00A0D1|INVENTEC CORPORATION
+00A0D2|ALLIED TELESIS INTERNATIONAL CORPORATION
+00A0D3|INSTEM COMPUTER SYSTEMS, LTD.
+00A0D4|RADIOLAN,  INC.
+00A0D5|SIERRA WIRELESS INC.
+00A0D6|SBE, INC.
+00A0D7|KASTEN CHASE APPLIED RESEARCH
+00A0D8|SPECTRA - TEK
+00A0D9|CONVEX COMPUTER CORPORATION
+00A0DA|INTEGRATED SYSTEMS Technology, Inc.
+00A0DB|FISHER & PAYKEL PRODUCTION
+00A0DC|O.N. ELECTRONIC CO., LTD.
+00A0DD|AZONIX CORPORATION
+00A0DE|YAMAHA CORPORATION
+00A0DF|STS TECHNOLOGIES, INC.
+00A0E0|TENNYSON TECHNOLOGIES PTY LTD
+00A0E1|WESTPORT RESEARCH ASSOCIATES, INC.
+00A0E2|Keisokugiken Corporation
+00A0E3|XKL SYSTEMS CORP.
+00A0E4|OPTIQUEST
+00A0E5|NHC COMMUNICATIONS
+00A0E6|DIALOGIC CORPORATION
+00A0E7|CENTRAL DATA CORPORATION
+00A0E8|REUTERS HOLDINGS PLC
+00A0E9|ELECTRONIC RETAILING SYSTEMS INTERNATIONAL
+00A0EA|ETHERCOM CORP.
+00A0EB|Encore Networks, Inc.
+00A0EC|TRANSMITTON LTD.
+00A0ED|Brooks Automation, Inc.
+00A0EE|NASHOBA NETWORKS
+00A0EF|LUCIDATA LTD.
+00A0F0|TORONTO MICROELECTRONICS INC.
+00A0F1|MTI
+00A0F2|INFOTEK COMMUNICATIONS, INC.
+00A0F3|STAUBLI
+00A0F4|GE
+00A0F5|RADGUARD LTD.
+00A0F6|AutoGas Systems Inc.
+00A0F7|V.I COMPUTER CORP.
+00A0F8|Zebra Technologies Inc
+00A0F9|BINTEC COMMUNICATIONS GMBH
+00A0FA|Marconi Communication GmbH
+00A0FB|TORAY ENGINEERING CO., LTD.
+00A0FC|IMAGE SCIENCES, INC.
+00A0FD|SCITEX DIGITAL PRINTING, INC.
+00A0FE|BOSTON TECHNOLOGY, INC.
+00A0FF|TELLABS OPERATIONS, INC.
+00A1DE|ShenZhen ShiHua Technology CO.,LTD
+00A2DA|INAT GmbH
+00A2F5|Guangzhou Yuanyun Network Technology Co.,Ltd
+00A2FF|abatec group AG
+00A509|WigWag Inc.
+00A784|ITX security
+00AA00|Intel Corporate
+00AA01|Intel Corporate
+00AA02|Intel Corporate
+00AA3C|OLIVETTI TELECOM SPA (OLTECO)
+00AA70|LG Electronics
+00ACE0|ARRIS Group, Inc.
+00AEFA|Murata Manufacturing Co., Ltd.
+00B009|Grass Valley Group
+00B017|InfoGear Technology Corp.
+00B019|UTC CCS
+00B01C|Westport Technologies
+00B01E|Rantic Labs, Inc.
+00B02A|ORSYS GmbH
+00B02D|ViaGate Technologies, Inc.
+00B033|OAO "Izhevskiy radiozavod"
+00B03B|HiQ Networks
+00B048|Marconi Communications Inc.
+00B04A|Cisco
+00B052|Atheros Communications
+00B064|Cisco
+00B069|Honewell Oy
+00B06D|Jones Futurex Inc.
+00B080|Mannesmann Ipulsys B.V.
+00B086|LocSoft Limited
+00B08E|Cisco
+00B091|Transmeta Corp.
+00B094|Alaris, Inc.
+00B09A|Morrow Technologies Corp.
+00B09D|Point Grey Research Inc.
+00B0AC|SIAE-Microelettronica S.p.A.
+00B0AE|Symmetricom
+00B0B3|Xstreamis PLC
+00B0C2|Cisco
+00B0C7|Tellabs Operations, Inc.
+00B0CE|TECHNOLOGY RESCUE
+00B0D0|Dell Computer Corp.
+00B0DB|Nextcell, Inc.
+00B0DF|Starboard Storage Systems
+00B0E7|British Federal Ltd.
+00B0EC|EACEM
+00B0EE|Ajile Systems, Inc.
+00B0F0|CALY NETWORKS
+00B0F5|NetWorth Technologies, Inc.
+00B338|Kontron Design Manufacturing Services (M) Sdn. Bhd
+00B342|MacroSAN Technologies Co., Ltd.
+00B56D|David Electronics Co., LTD.
+00B5D6|Omnibit Inc.
+00B78D|Nanjing Shining Electric Automation Co., Ltd
+00B9F6|Shenzhen Super Rich Electronics Co.,Ltd
+00BAC0|Biometric Access Company
+00BB01|OCTOTHORPE CORP.
+00BB3A|ZZZZ 
+00BB8E|HME Co., Ltd.
+00BBF0|UNGERMANN-BASS INC.
+00BD27|Exar Corp.
+00BD3A|Nokia Corporation
+00BF15|Genetec Inc.
+00C000|LANOPTICS, LTD.
+00C001|DIATEK PATIENT MANAGMENT
+00C002|SERCOMM CORPORATION
+00C003|GLOBALNET COMMUNICATIONS
+00C004|JAPAN BUSINESS COMPUTER CO.LTD
+00C005|LIVINGSTON ENTERPRISES, INC.
+00C006|NIPPON AVIONICS CO., LTD.
+00C007|PINNACLE DATA SYSTEMS, INC.
+00C008|SECO SRL
+00C009|KT TECHNOLOGY (S) PTE LTD
+00C00A|MICRO CRAFT
+00C00B|NORCONTROL A.S.
+00C00C|RELIA TECHNOLGIES
+00C00D|ADVANCED LOGIC RESEARCH, INC.
+00C00E|PSITECH, INC.
+00C00F|QUANTUM SOFTWARE SYSTEMS LTD.
+00C010|HIRAKAWA HEWTECH CORP.
+00C011|INTERACTIVE COMPUTING DEVICES
+00C012|NETSPAN CORPORATION
+00C013|NETRIX
+00C014|TELEMATICS CALABASAS INT'L,INC
+00C015|NEW MEDIA CORPORATION
+00C016|ELECTRONIC THEATRE CONTROLS
+00C017|Fluke Corporation
+00C018|LANART CORPORATION
+00C019|LEAP TECHNOLOGY, INC.
+00C01A|COROMETRICS MEDICAL SYSTEMS
+00C01B|SOCKET COMMUNICATIONS, INC.
+00C01C|INTERLINK COMMUNICATIONS LTD.
+00C01D|GRAND JUNCTION NETWORKS, INC.
+00C01E|LA FRANCAISE DES JEUX
+00C01F|S.E.R.C.E.L.
+00C020|ARCO ELECTRONIC, CONTROL LTD.
+00C021|NETEXPRESS
+00C022|LASERMASTER TECHNOLOGIES, INC.
+00C023|TUTANKHAMON ELECTRONICS
+00C024|EDEN SISTEMAS DE COMPUTACAO SA
+00C025|DATAPRODUCTS CORPORATION
+00C026|LANS TECHNOLOGY CO., LTD.
+00C027|CIPHER SYSTEMS, INC.
+00C028|JASCO CORPORATION
+00C029|Nexans Deutschland GmbH - ANS
+00C02A|OHKURA ELECTRIC CO., LTD.
+00C02B|GERLOFF GESELLSCHAFT FUR
+00C02C|CENTRUM COMMUNICATIONS, INC.
+00C02D|FUJI PHOTO FILM CO., LTD.
+00C02E|NETWIZ
+00C02F|OKUMA CORPORATION
+00C030|INTEGRATED ENGINEERING B. V.
+00C031|DESIGN RESEARCH SYSTEMS, INC.
+00C032|I-CUBED LIMITED
+00C033|TELEBIT COMMUNICATIONS APS
+00C034|TRANSACTION NETWORK
+00C035|QUINTAR COMPANY
+00C036|RAYTECH ELECTRONIC CORP.
+00C037|DYNATEM
+00C038|RASTER IMAGE PROCESSING SYSTEM
+00C039|Teridian Semiconductor Corporation
+00C03A|MEN-MIKRO ELEKTRONIK GMBH
+00C03B|MULTIACCESS COMPUTING CORP.
+00C03C|TOWER TECH S.R.L.
+00C03D|WIESEMANN & THEIS GMBH
+00C03E|FA. GEBR. HELLER GMBH
+00C03F|STORES AUTOMATED SYSTEMS, INC.
+00C040|ECCI
+00C041|DIGITAL TRANSMISSION SYSTEMS
+00C042|DATALUX CORP.
+00C043|STRATACOM
+00C044|EMCOM CORPORATION
+00C045|ISOLATION SYSTEMS, LTD.
+00C046|Blue Chip Technology Ltd
+00C047|UNIMICRO SYSTEMS, INC.
+00C048|BAY TECHNICAL ASSOCIATES
+00C049|U.S. ROBOTICS, INC.
+00C04A|GROUP 2000 AG
+00C04B|CREATIVE MICROSYSTEMS
+00C04C|DEPARTMENT OF FOREIGN AFFAIRS
+00C04D|MITEC, INC.
+00C04E|COMTROL CORPORATION
+00C04F|DELL COMPUTER CORPORATION
+00C050|TOYO DENKI SEIZO K.K.
+00C051|ADVANCED INTEGRATION RESEARCH
+00C052|BURR-BROWN
+00C053|Aspect Software Inc.
+00C054|NETWORK PERIPHERALS, LTD.
+00C055|MODULAR COMPUTING TECHNOLOGIES
+00C056|SOMELEC
+00C057|MYCO ELECTRONICS
+00C058|DATAEXPERT CORP.
+00C059|DENSO CORPORATION
+00C05A|SEMAPHORE COMMUNICATIONS CORP.
+00C05B|NETWORKS NORTHWEST, INC.
+00C05C|ELONEX PLC
+00C05D|L&N TECHNOLOGIES
+00C05E|VARI-LITE, INC.
+00C05F|FINE-PAL COMPANY LIMITED
+00C060|ID SCANDINAVIA AS
+00C061|SOLECTEK CORPORATION
+00C062|IMPULSE TECHNOLOGY
+00C063|MORNING STAR TECHNOLOGIES, INC
+00C064|GENERAL DATACOMM IND. INC.
+00C065|SCOPE COMMUNICATIONS, INC.
+00C066|DOCUPOINT, INC.
+00C067|UNITED BARCODE INDUSTRIES
+00C068|HME Clear-Com LTD.
+00C069|Axxcelera Broadband Wireless
+00C06A|ZAHNER-ELEKTRIK GMBH & CO. KG
+00C06B|OSI PLUS CORPORATION
+00C06C|SVEC COMPUTER CORP.
+00C06D|BOCA RESEARCH, INC.
+00C06E|HAFT TECHNOLOGY, INC.
+00C06F|KOMATSU LTD.
+00C070|SECTRA SECURE-TRANSMISSION AB
+00C071|AREANEX COMMUNICATIONS, INC.
+00C072|KNX LTD.
+00C073|XEDIA CORPORATION
+00C074|TOYODA AUTOMATIC LOOM
+00C075|XANTE CORPORATION
+00C076|I-DATA INTERNATIONAL A-S
+00C077|DAEWOO TELECOM LTD.
+00C078|COMPUTER SYSTEMS ENGINEERING
+00C079|FONSYS CO.,LTD.
+00C07A|PRIVA B.V.
+00C07B|ASCEND COMMUNICATIONS, INC.
+00C07C|HIGHTECH INFORMATION
+00C07D|RISC DEVELOPMENTS LTD.
+00C07E|KUBOTA CORPORATION ELECTRONIC
+00C07F|NUPON COMPUTING CORP.
+00C080|NETSTAR, INC.
+00C081|METRODATA LTD.
+00C082|MOORE PRODUCTS CO.
+00C083|TRACE MOUNTAIN PRODUCTS, INC.
+00C084|DATA LINK CORP. LTD.
+00C085|ELECTRONICS FOR IMAGING, INC.
+00C086|THE LYNK CORPORATION
+00C087|UUNET TECHNOLOGIES, INC.
+00C088|EKF ELEKTRONIK GMBH
+00C089|TELINDUS DISTRIBUTION
+00C08A|Lauterbach GmbH
+00C08B|RISQ MODULAR SYSTEMS, INC.
+00C08C|PERFORMANCE TECHNOLOGIES, INC.
+00C08D|TRONIX PRODUCT DEVELOPMENT
+00C08E|NETWORK INFORMATION TECHNOLOGY
+00C08F|Panasonic Electric Works Co., Ltd.
+00C090|PRAIM S.R.L.
+00C091|JABIL CIRCUIT, INC.
+00C092|MENNEN MEDICAL INC.
+00C093|ALTA RESEARCH CORP.
+00C094|VMX INC.
+00C095|ZNYX
+00C096|TAMURA CORPORATION
+00C097|ARCHIPEL SA
+00C098|CHUNTEX ELECTRONIC CO., LTD.
+00C099|YOSHIKI INDUSTRIAL CO.,LTD.
+00C09A|PHOTONICS CORPORATION
+00C09B|RELIANCE COMM/TEC, R-TEC
+00C09C|HIOKI E.E. CORPORATION
+00C09D|DISTRIBUTED SYSTEMS INT'L, INC
+00C09E|CACHE COMPUTERS, INC.
+00C09F|QUANTA COMPUTER, INC.
+00C0A0|ADVANCE MICRO RESEARCH, INC.
+00C0A1|TOKYO DENSHI SEKEI CO.
+00C0A2|INTERMEDIUM A/S
+00C0A3|DUAL ENTERPRISES CORPORATION
+00C0A4|UNIGRAF OY
+00C0A5|DICKENS DATA SYSTEMS
+00C0A6|EXICOM AUSTRALIA PTY. LTD
+00C0A7|SEEL LTD.
+00C0A8|GVC CORPORATION
+00C0A9|BARRON MCCANN LTD.
+00C0AA|SILICON VALLEY COMPUTER
+00C0AB|Telco Systems, Inc.
+00C0AC|GAMBIT COMPUTER COMMUNICATIONS
+00C0AD|MARBEN COMMUNICATION SYSTEMS
+00C0AE|TOWERCOM CO. INC. DBA PC HOUSE
+00C0AF|TEKLOGIX INC.
+00C0B0|GCC TECHNOLOGIES,INC.
+00C0B1|GENIUS NET CO.
+00C0B2|NORAND CORPORATION
+00C0B3|COMSTAT DATACOMM CORPORATION
+00C0B4|MYSON TECHNOLOGY, INC.
+00C0B5|CORPORATE NETWORK SYSTEMS,INC.
+00C0B6|Overland Storage, Inc.
+00C0B7|AMERICAN POWER CONVERSION CORP
+00C0B8|FRASER'S HILL LTD.
+00C0B9|FUNK SOFTWARE, INC.
+00C0BA|NETVANTAGE
+00C0BB|FORVAL CREATIVE, INC.
+00C0BC|TELECOM AUSTRALIA/CSSC
+00C0BD|INEX TECHNOLOGIES, INC.
+00C0BE|ALCATEL - SEL
+00C0BF|TECHNOLOGY CONCEPTS, LTD.
+00C0C0|SHORE MICROSYSTEMS, INC.
+00C0C1|QUAD/GRAPHICS, INC.
+00C0C2|INFINITE NETWORKS LTD.
+00C0C3|ACUSON COMPUTED SONOGRAPHY
+00C0C4|COMPUTER OPERATIONAL
+00C0C5|SID INFORMATICA
+00C0C6|PERSONAL MEDIA CORP.
+00C0C7|SPARKTRUM MICROSYSTEMS, INC.
+00C0C8|MICRO BYTE PTY. LTD.
+00C0C9|ELSAG BAILEY PROCESS
+00C0CA|ALFA, INC.
+00C0CB|CONTROL TECHNOLOGY CORPORATION
+00C0CC|TELESCIENCES CO SYSTEMS, INC.
+00C0CD|COMELTA, S.A.
+00C0CE|CEI SYSTEMS & ENGINEERING PTE
+00C0CF|IMATRAN VOIMA OY
+00C0D0|RATOC SYSTEM INC.
+00C0D1|COMTREE TECHNOLOGY CORPORATION
+00C0D2|SYNTELLECT, INC.
+00C0D3|OLYMPUS IMAGE SYSTEMS, INC.
+00C0D4|AXON NETWORKS, INC.
+00C0D5|Werbeagentur Jurgen Siebert
+00C0D6|J1 SYSTEMS, INC.
+00C0D7|TAIWAN TRADING CENTER DBA
+00C0D8|UNIVERSAL DATA SYSTEMS
+00C0D9|QUINTE NETWORK CONFIDENTIALITY
+00C0DA|NICE SYSTEMS LTD.
+00C0DB|IPC CORPORATION (PTE) LTD.
+00C0DC|EOS TECHNOLOGIES, INC.
+00C0DD|QLogic Corporation
+00C0DE|ZCOMM, INC.
+00C0DF|KYE Systems Corp.
+00C0E0|DSC COMMUNICATION CORP.
+00C0E1|SONIC SOLUTIONS
+00C0E2|CALCOMP, INC.
+00C0E3|OSITECH COMMUNICATIONS, INC.
+00C0E4|SIEMENS BUILDING
+00C0E5|GESPAC, S.A.
+00C0E6|Verilink Corporation
+00C0E7|FIBERDATA AB
+00C0E8|PLEXCOM, INC.
+00C0E9|OAK SOLUTIONS, LTD.
+00C0EA|ARRAY TECHNOLOGY LTD.
+00C0EB|SEH COMPUTERTECHNIK GMBH
+00C0EC|DAUPHIN TECHNOLOGY
+00C0ED|US ARMY ELECTRONIC
+00C0EE|KYOCERA CORPORATION
+00C0EF|ABIT CORPORATION
+00C0F0|KINGSTON TECHNOLOGY CORP.
+00C0F1|SHINKO ELECTRIC CO., LTD.
+00C0F2|TRANSITION NETWORKS
+00C0F3|NETWORK COMMUNICATIONS CORP.
+00C0F4|INTERLINK SYSTEM CO., LTD.
+00C0F5|METACOMP, INC.
+00C0F6|CELAN TECHNOLOGY INC.
+00C0F7|ENGAGE COMMUNICATION, INC.
+00C0F8|ABOUT COMPUTING INC.
+00C0F9|Artesyn Embedded Technologies
+00C0FA|CANARY COMMUNICATIONS, INC.
+00C0FB|ADVANCED TECHNOLOGY LABS
+00C0FC|ELASTIC REALITY, INC.
+00C0FD|PROSUM
+00C0FE|APTEC COMPUTER SYSTEMS, INC.
+00C0FF|DOT HILL SYSTEMS CORPORATION
+00C14F|DDL Co,.ltd.
+00C2C6|Intel Corporate
+00C5DB|Datatech Sistemas Digitales Avanzados SL
+00C610|Apple
+00CBBD|Cambridge Broadband Networks Ltd.
+00CD90|MAS Elektronik AG
+00CF1C|COMMUNICATION MACHINERY CORP.
+00D000|FERRAN SCIENTIFIC, INC.
+00D001|VST TECHNOLOGIES, INC.
+00D002|DITECH CORPORATION
+00D003|COMDA ENTERPRISES CORP.
+00D004|PENTACOM LTD.
+00D005|ZHS ZEITMANAGEMENTSYSTEME
+00D006|Cisco
+00D007|MIC ASSOCIATES, INC.
+00D008|MACTELL CORPORATION
+00D009|HSING TECH. ENTERPRISE CO. LTD
+00D00A|LANACCESS TELECOM S.A.
+00D00B|RHK TECHNOLOGY, INC.
+00D00C|SNIJDER MICRO SYSTEMS
+00D00D|MICROMERITICS INSTRUMENT
+00D00E|PLURIS, INC.
+00D00F|SPEECH DESIGN GMBH
+00D010|CONVERGENT NETWORKS, INC.
+00D011|PRISM VIDEO, INC.
+00D012|GATEWORKS CORP.
+00D013|PRIMEX AEROSPACE COMPANY
+00D014|ROOT, INC.
+00D015|UNIVEX MICROTECHNOLOGY CORP.
+00D016|SCM MICROSYSTEMS, INC.
+00D017|SYNTECH INFORMATION CO., LTD.
+00D018|QWES. COM, INC.
+00D019|DAINIPPON SCREEN CORPORATE
+00D01A|URMET  TLC S.P.A.
+00D01B|MIMAKI ENGINEERING CO., LTD.
+00D01C|SBS TECHNOLOGIES,
+00D01D|FURUNO ELECTRIC CO., LTD.
+00D01E|PINGTEL CORP.
+00D01F|Senetas Security
+00D020|AIM SYSTEM, INC.
+00D021|REGENT ELECTRONICS CORP.
+00D022|INCREDIBLE TECHNOLOGIES, INC.
+00D023|INFORTREND TECHNOLOGY, INC.
+00D024|Cognex Corporation
+00D025|XROSSTECH, INC.
+00D026|HIRSCHMANN AUSTRIA GMBH
+00D027|APPLIED AUTOMATION, INC.
+00D028|Harmonic, Inc
+00D029|WAKEFERN FOOD CORPORATION
+00D02A|Voxent Systems Ltd.
+00D02B|JETCELL, INC.
+00D02C|CAMPBELL SCIENTIFIC, INC.
+00D02D|ADEMCO
+00D02E|COMMUNICATION AUTOMATION CORP.
+00D02F|VLSI TECHNOLOGY INC.
+00D030|Safetran Systems Corp
+00D031|INDUSTRIAL LOGIC CORPORATION
+00D032|YANO ELECTRIC CO., LTD.
+00D033|DALIAN DAXIAN NETWORK
+00D034|ORMEC SYSTEMS CORP.
+00D035|BEHAVIOR TECH. COMPUTER CORP.
+00D036|TECHNOLOGY ATLANTA CORP.
+00D037|Pace France
+00D038|FIVEMERE, LTD.
+00D039|UTILICOM, INC.
+00D03A|ZONEWORX, INC.
+00D03B|VISION PRODUCTS PTY. LTD.
+00D03C|Vieo, Inc.
+00D03D|GALILEO TECHNOLOGY, LTD.
+00D03E|ROCKETCHIPS, INC.
+00D03F|AMERICAN COMMUNICATION
+00D040|SYSMATE CO., LTD.
+00D041|AMIGO TECHNOLOGY CO., LTD.
+00D042|MAHLO GMBH & CO. UG
+00D043|ZONAL RETAIL DATA SYSTEMS
+00D044|ALIDIAN NETWORKS, INC.
+00D045|KVASER AB
+00D046|DOLBY LABORATORIES, INC.
+00D047|XN TECHNOLOGIES
+00D048|ECTON, INC.
+00D049|IMPRESSTEK CO., LTD.
+00D04A|PRESENCE TECHNOLOGY GMBH
+00D04B|LA CIE GROUP S.A.
+00D04C|EUROTEL TELECOM LTD.
+00D04D|DIV OF RESEARCH & STATISTICS
+00D04E|LOGIBAG
+00D04F|BITRONICS, INC.
+00D050|ISKRATEL
+00D051|O2 MICRO, INC.
+00D052|ASCEND COMMUNICATIONS, INC.
+00D053|CONNECTED SYSTEMS
+00D054|SAS INSTITUTE INC.
+00D055|KATHREIN-WERKE KG
+00D056|SOMAT CORPORATION
+00D057|ULTRAK, INC.
+00D058|Cisco
+00D059|AMBIT MICROSYSTEMS CORP.
+00D05A|SYMBIONICS, LTD.
+00D05B|ACROLOOP MOTION CONTROL
+00D05C|KATHREIN TechnoTrend GmbH
+00D05D|INTELLIWORXX, INC.
+00D05E|STRATABEAM TECHNOLOGY, INC.
+00D05F|VALCOM, INC.
+00D060|Panasonic Europe Ltd.
+00D061|TREMON ENTERPRISES CO., LTD.
+00D062|DIGIGRAM
+00D063|Cisco
+00D064|MULTITEL
+00D065|TOKO ELECTRIC
+00D066|WINTRISS ENGINEERING CORP.
+00D067|CAMPIO COMMUNICATIONS
+00D068|IWILL CORPORATION
+00D069|TECHNOLOGIC SYSTEMS
+00D06A|LINKUP SYSTEMS CORPORATION
+00D06B|SR TELECOM INC.
+00D06C|SHAREWAVE, INC.
+00D06D|ACRISON, INC.
+00D06E|TRENDVIEW RECORDERS LTD.
+00D06F|KMC CONTROLS
+00D070|LONG WELL ELECTRONICS CORP.
+00D071|ECHELON CORP.
+00D072|BROADLOGIC
+00D073|ACN ADVANCED COMMUNICATIONS
+00D074|TAQUA SYSTEMS, INC.
+00D075|ALARIS MEDICAL SYSTEMS, INC.
+00D076|Bank of America
+00D077|LUCENT TECHNOLOGIES
+00D078|Eltex of Sweden AB
+00D079|Cisco
+00D07A|AMAQUEST COMPUTER CORP.
+00D07B|COMCAM INTERNATIONAL INC
+00D07C|KOYO ELECTRONICS INC. CO.,LTD.
+00D07D|COSINE COMMUNICATIONS
+00D07E|KEYCORP LTD.
+00D07F|STRATEGY & TECHNOLOGY, LIMITED
+00D080|EXABYTE CORPORATION
+00D081|RTD Embedded Technologies, Inc.
+00D082|IOWAVE INC.
+00D083|INVERTEX, INC.
+00D084|NEXCOMM SYSTEMS, INC.
+00D085|OTIS ELEVATOR COMPANY
+00D086|FOVEON, INC.
+00D087|MICROFIRST INC.
+00D088|ARRIS Group, Inc.
+00D089|DYNACOLOR, INC.
+00D08A|PHOTRON USA
+00D08B|ADVA Optical Networking Ltd.
+00D08C|GENOA TECHNOLOGY, INC.
+00D08D|PHOENIX GROUP, INC.
+00D08E|NVISION INC.
+00D08F|ARDENT TECHNOLOGIES, INC.
+00D090|Cisco
+00D091|SMARTSAN SYSTEMS, INC.
+00D092|GLENAYRE WESTERN MULTIPLEX
+00D093|TQ - COMPONENTS GMBH
+00D094|Seeion Control LLC
+00D095|Alcatel-Lucent, Enterprise Business Group
+00D096|3COM EUROPE LTD.
+00D097|Cisco
+00D098|Photon Dynamics Canada Inc.
+00D099|Elcard Wireless Systems Oy
+00D09A|FILANET CORPORATION
+00D09B|SPECTEL LTD.
+00D09C|KAPADIA COMMUNICATIONS
+00D09D|VERIS INDUSTRIES
+00D09E|2WIRE, INC.
+00D09F|NOVTEK TEST SYSTEMS
+00D0A0|MIPS DENMARK
+00D0A1|OSKAR VIERLING GMBH + CO. KG
+00D0A2|INTEGRATED DEVICE
+00D0A3|VOCAL DATA, INC.
+00D0A4|ALANTRO COMMUNICATIONS
+00D0A5|AMERICAN ARIUM
+00D0A6|LANBIRD TECHNOLOGY CO., LTD.
+00D0A7|TOKYO SOKKI KENKYUJO CO., LTD.
+00D0A8|NETWORK ENGINES, INC.
+00D0A9|SHINANO KENSHI CO., LTD.
+00D0AA|CHASE COMMUNICATIONS
+00D0AB|DELTAKABEL TELECOM CV
+00D0AC|GRAYSON WIRELESS
+00D0AD|TL INDUSTRIES
+00D0AE|ORESIS COMMUNICATIONS, INC.
+00D0AF|CUTLER-HAMMER, INC.
+00D0B0|BITSWITCH LTD.
+00D0B1|OMEGA ELECTRONICS SA
+00D0B2|XIOTECH CORPORATION
+00D0B3|DRS Technologies Canada Ltd
+00D0B4|KATSUJIMA CO., LTD.
+00D0B5|IPricot formerly DotCom
+00D0B6|CRESCENT NETWORKS, INC.
+00D0B7|Intel Corporate
+00D0B8|Iomega Corporation
+00D0B9|MICROTEK INTERNATIONAL, INC.
+00D0BA|Cisco
+00D0BB|Cisco
+00D0BC|Cisco
+00D0BD|Silicon Image GmbH
+00D0BE|EMUTEC INC.
+00D0BF|PIVOTAL TECHNOLOGIES
+00D0C0|Cisco
+00D0C1|HARMONIC DATA SYSTEMS, LTD.
+00D0C2|BALTHAZAR TECHNOLOGY AB
+00D0C3|VIVID TECHNOLOGY PTE, LTD.
+00D0C4|TERATECH CORPORATION
+00D0C5|COMPUTATIONAL SYSTEMS, INC.
+00D0C6|THOMAS & BETTS CORP.
+00D0C7|PATHWAY, INC.
+00D0C8|Prevas A/S
+00D0C9|ADVANTECH CO., LTD.
+00D0CA|Intrinsyc Software International Inc.
+00D0CB|DASAN CO., LTD.
+00D0CC|TECHNOLOGIES LYRE INC.
+00D0CD|ATAN TECHNOLOGY INC.
+00D0CE|ASYST ELECTRONIC
+00D0CF|MORETON BAY
+00D0D0|ZHONGXING TELECOM LTD.
+00D0D1|Sycamore Networks
+00D0D2|EPILOG CORPORATION
+00D0D3|Cisco
+00D0D4|V-BITS, INC.
+00D0D5|GRUNDIG AG
+00D0D6|AETHRA TELECOMUNICAZIONI
+00D0D7|B2C2, INC.
+00D0D8|3Com Corporation
+00D0D9|DEDICATED MICROCOMPUTERS
+00D0DA|TAICOM DATA SYSTEMS CO., LTD.
+00D0DB|MCQUAY INTERNATIONAL
+00D0DC|MODULAR MINING SYSTEMS, INC.
+00D0DD|SUNRISE TELECOM, INC.
+00D0DE|PHILIPS MULTIMEDIA NETWORK
+00D0DF|KUZUMI ELECTRONICS, INC.
+00D0E0|DOOIN ELECTRONICS CO.
+00D0E1|AVIONITEK ISRAEL INC.
+00D0E2|MRT MICRO, INC.
+00D0E3|ELE-CHEM ENGINEERING CO., LTD.
+00D0E4|Cisco
+00D0E5|SOLIDUM SYSTEMS CORP.
+00D0E6|IBOND INC.
+00D0E7|VCON TELECOMMUNICATION LTD.
+00D0E8|MAC SYSTEM CO., LTD.
+00D0E9|Advantage Century Telecommunication Corp.
+00D0EA|NEXTONE COMMUNICATIONS, INC.
+00D0EB|LIGHTERA NETWORKS, INC.
+00D0EC|NAKAYO TELECOMMUNICATIONS, INC
+00D0ED|XIOX
+00D0EE|DICTAPHONE CORPORATION
+00D0EF|IGT
+00D0F0|CONVISION TECHNOLOGY GMBH
+00D0F1|SEGA ENTERPRISES, LTD.
+00D0F2|MONTEREY NETWORKS
+00D0F3|SOLARI DI UDINE SPA
+00D0F4|CARINTHIAN TECH INSTITUTE
+00D0F5|ORANGE MICRO, INC.
+00D0F6|Alcatel Canada
+00D0F7|NEXT NETS CORPORATION
+00D0F8|FUJIAN STAR TERMINAL
+00D0F9|ACUTE COMMUNICATIONS CORP.
+00D0FA|Thales e-Security Ltd.
+00D0FB|TEK MICROSYSTEMS, INCORPORATED
+00D0FC|GRANITE MICROSYSTEMS
+00D0FD|OPTIMA TELE.COM, INC.
+00D0FE|ASTRAL POINT
+00D0FF|Cisco
+00D11C|ACETEL
+00D38D|Hotel Technology Next Generation
+00D632|GE Energy
+00D9D1|Sony Computer Entertainment Inc.
+00DB1E|Albedo Telecom SL
+00DB45|THAMWAY CO.,LTD.
+00DBDF|Intel Corporate
+00DD00|UNGERMANN-BASS INC.
+00DD01|UNGERMANN-BASS INC.
+00DD02|UNGERMANN-BASS INC.
+00DD03|UNGERMANN-BASS INC.
+00DD04|UNGERMANN-BASS INC.
+00DD05|UNGERMANN-BASS INC.
+00DD06|UNGERMANN-BASS INC.
+00DD07|UNGERMANN-BASS INC.
+00DD08|UNGERMANN-BASS INC.
+00DD09|UNGERMANN-BASS INC.
+00DD0A|UNGERMANN-BASS INC.
+00DD0B|UNGERMANN-BASS INC.
+00DD0C|UNGERMANN-BASS INC.
+00DD0D|UNGERMANN-BASS INC.
+00DD0E|UNGERMANN-BASS INC.
+00DD0F|UNGERMANN-BASS INC.
+00DEFB|Cisco
+00E000|Fujitsu Limited
+00E001|STRAND LIGHTING LIMITED
+00E002|CROSSROADS SYSTEMS, INC.
+00E003|NOKIA WIRELESS BUSINESS COMMUN
+00E004|PMC-SIERRA, INC.
+00E005|TECHNICAL CORP.
+00E006|SILICON INTEGRATED SYS. CORP.
+00E007|Avaya ECS Ltd
+00E008|AMAZING CONTROLS! INC.
+00E009|MARATHON TECHNOLOGIES CORP.
+00E00A|DIBA, INC.
+00E00B|ROOFTOP COMMUNICATIONS CORP.
+00E00C|Motorola
+00E00D|RADIANT SYSTEMS
+00E00E|AVALON IMAGING SYSTEMS, INC.
+00E00F|SHANGHAI BAUD DATA
+00E010|HESS SB-AUTOMATENBAU GmbH
+00E011|Uniden Corporation
+00E012|PLUTO TECHNOLOGIES INTERNATIONAL INC.
+00E013|EASTERN ELECTRONIC CO., LTD.
+00E014|Cisco
+00E015|HEIWA CORPORATION
+00E016|RAPID CITY COMMUNICATIONS
+00E017|EXXACT GmbH
+00E018|ASUSTEK COMPUTER INC.
+00E019|ING. GIORDANO ELETTRONICA
+00E01A|COMTEC SYSTEMS. CO., LTD.
+00E01B|SPHERE COMMUNICATIONS, INC.
+00E01C|Cradlepoint, Inc
+00E01D|WebTV NETWORKS, INC.
+00E01E|Cisco
+00E01F|AVIDIA Systems, Inc.
+00E020|TECNOMEN OY
+00E021|FREEGATE CORP.
+00E022|Analog Devices Inc.
+00E023|TELRAD
+00E024|GADZOOX NETWORKS
+00E025|dit Co., Ltd.
+00E026|Redlake MASD LLC
+00E027|DUX, INC.
+00E028|APTIX CORPORATION
+00E029|STANDARD MICROSYSTEMS CORP.
+00E02A|TANDBERG TELEVISION AS
+00E02B|EXTREME NETWORKS
+00E02C|AST COMPUTER
+00E02D|InnoMediaLogic, Inc.
+00E02E|SPC ELECTRONICS CORPORATION
+00E02F|MCNS HOLDINGS, L.P.
+00E030|MELITA INTERNATIONAL CORP.
+00E031|HAGIWARA ELECTRIC CO., LTD.
+00E032|MISYS FINANCIAL SYSTEMS, LTD.
+00E033|E.E.P.D. GmbH
+00E034|Cisco
+00E035|Artesyn Embedded Technologies
+00E036|PIONEER CORPORATION
+00E037|CENTURY CORPORATION
+00E038|PROXIMA CORPORATION
+00E039|PARADYNE CORP.
+00E03A|CABLETRON SYSTEMS, INC.
+00E03B|PROMINET CORPORATION
+00E03C|AdvanSys
+00E03D|FOCON ELECTRONIC SYSTEMS A/S
+00E03E|ALFATECH, INC.
+00E03F|JATON CORPORATION
+00E040|DeskStation Technology, Inc.
+00E041|CSPI
+00E042|Pacom Systems Ltd.
+00E043|VitalCom
+00E044|LSICS CORPORATION
+00E045|TOUCHWAVE, INC.
+00E046|BENTLY NEVADA CORP.
+00E047|InFocus Corporation
+00E048|SDL COMMUNICATIONS, INC.
+00E049|MICROWI ELECTRONIC GmbH
+00E04A|ZX Technologies, Inc
+00E04B|JUMP INDUSTRIELLE COMPUTERTECHNIK GmbH
+00E04C|REALTEK SEMICONDUCTOR CORP.
+00E04D|INTERNET INITIATIVE JAPAN, INC
+00E04E|SANYO DENKI CO., LTD.
+00E04F|Cisco
+00E050|EXECUTONE INFORMATION SYSTEMS, INC.
+00E051|TALX CORPORATION
+00E052|Brocade Communications Systems, Inc
+00E053|CELLPORT LABS, INC.
+00E054|KODAI HITEC CO., LTD.
+00E055|INGENIERIA ELECTRONICA COMERCIAL INELCOM S.A.
+00E056|HOLONTECH CORPORATION
+00E057|HAN MICROTELECOM. CO., LTD.
+00E058|PHASE ONE DENMARK A/S
+00E059|CONTROLLED ENVIRONMENTS, LTD.
+00E05A|GALEA NETWORK SECURITY
+00E05B|WEST END SYSTEMS CORP.
+00E05C|MATSUSHITA KOTOBUKI ELECTRONICS INDUSTRIES, LTD.
+00E05D|UNITEC CO., LTD.
+00E05E|JAPAN AVIATION ELECTRONICS INDUSTRY, LTD.
+00E05F|e-Net, Inc.
+00E060|SHERWOOD
+00E061|EdgePoint Networks, Inc.
+00E062|HOST ENGINEERING
+00E063|CABLETRON - YAGO SYSTEMS, INC.
+00E064|Samsung
+00E065|OPTICAL ACCESS INTERNATIONAL
+00E066|ProMax Systems, Inc.
+00E067|eac AUTOMATION-CONSULTING GmbH
+00E068|MERRIMAC SYSTEMS INC.
+00E069|JAYCOR
+00E06A|KAPSCH AG
+00E06B|W&G SPECIAL PRODUCTS
+00E06C|Ultra Electronics Limited (AEP Networks)
+00E06D|COMPUWARE CORPORATION
+00E06E|FAR SYSTEMS S.p.A.
+00E06F|ARRIS Group, Inc.
+00E070|DH TECHNOLOGY
+00E071|EPIS MICROCOMPUTER
+00E072|LYNK
+00E073|NATIONAL AMUSEMENT NETWORK, INC.
+00E074|TIERNAN COMMUNICATIONS, INC.
+00E075|Verilink Corporation
+00E076|DEVELOPMENT CONCEPTS, INC.
+00E077|WEBGEAR, INC.
+00E078|BERKELEY NETWORKS
+00E079|A.T.N.R.
+00E07A|MIKRODIDAKT AB
+00E07B|BAY NETWORKS
+00E07C|METTLER-TOLEDO, INC.
+00E07D|NETRONIX, INC.
+00E07E|WALT DISNEY IMAGINEERING
+00E07F|LOGISTISTEM s.r.l.
+00E080|CONTROL RESOURCES CORPORATION
+00E081|TYAN COMPUTER CORP.
+00E082|ANERMA
+00E083|JATO TECHNOLOGIES, INC.
+00E084|COMPULITE R&D
+00E085|GLOBAL MAINTECH, INC.
+00E086|Emerson Network Power, Avocent Division
+00E087|LeCroy - Networking Productions Division
+00E088|LTX-Credence CORPORATION
+00E089|ION Networks, Inc.
+00E08A|GEC AVERY, LTD.
+00E08B|QLogic Corp.
+00E08C|NEOPARADIGM LABS, INC.
+00E08D|PRESSURE SYSTEMS, INC.
+00E08E|UTSTARCOM
+00E08F|Cisco
+00E090|BECKMAN LAB. AUTOMATION DIV.
+00E091|LG Electronics
+00E092|ADMTEK INCORPORATED
+00E093|ACKFIN NETWORKS
+00E094|OSAI SRL
+00E095|ADVANCED-VISION TECHNOLGIES CORP.
+00E096|SHIMADZU CORPORATION
+00E097|CARRIER ACCESS CORPORATION
+00E098|AboCom Systems, Inc.
+00E099|SAMSON AG
+00E09A|Positron Inc.
+00E09B|ENGAGE NETWORKS, INC.
+00E09C|MII
+00E09D|SARNOFF CORPORATION
+00E09E|QUANTUM CORPORATION
+00E09F|PIXEL VISION
+00E0A0|WILTRON CO.
+00E0A1|HIMA PAUL HILDEBRANDT GmbH Co. KG
+00E0A2|MICROSLATE INC.
+00E0A3|Cisco
+00E0A4|ESAOTE S.p.A.
+00E0A5|ComCore Semiconductor, Inc.
+00E0A6|TELOGY NETWORKS, INC.
+00E0A7|IPC INFORMATION SYSTEMS, INC.
+00E0A8|SAT GmbH & Co.
+00E0A9|FUNAI ELECTRIC CO., LTD.
+00E0AA|ELECTROSONIC LTD.
+00E0AB|DIMAT S.A.
+00E0AC|MIDSCO, INC.
+00E0AD|EES TECHNOLOGY, LTD.
+00E0AE|XAQTI CORPORATION
+00E0AF|GENERAL DYNAMICS INFORMATION SYSTEMS
+00E0B0|Cisco
+00E0B1|Alcatel-Lucent, Enterprise Business Group
+00E0B2|TELMAX COMMUNICATIONS CORP.
+00E0B3|EtherWAN Systems, Inc.
+00E0B4|TECHNO SCOPE CO., LTD.
+00E0B5|ARDENT COMMUNICATIONS CORP.
+00E0B6|Entrada Networks
+00E0B7|PI GROUP, LTD.
+00E0B8|GATEWAY 2000
+00E0B9|BYAS SYSTEMS
+00E0BA|BERGHOF AUTOMATIONSTECHNIK GmbH
+00E0BB|NBX CORPORATION
+00E0BC|SYMON COMMUNICATIONS, INC.
+00E0BD|INTERFACE SYSTEMS, INC.
+00E0BE|GENROCO INTERNATIONAL, INC.
+00E0BF|TORRENT NETWORKING TECHNOLOGIES CORP.
+00E0C0|SEIWA ELECTRIC MFG. CO., LTD.
+00E0C1|MEMOREX TELEX JAPAN, LTD.
+00E0C2|NECSY S.p.A.
+00E0C3|SAKAI SYSTEM DEVELOPMENT CORP.
+00E0C4|HORNER ELECTRIC, INC.
+00E0C5|BCOM ELECTRONICS INC.
+00E0C6|LINK2IT, L.L.C.
+00E0C7|EUROTECH SRL
+00E0C8|VIRTUAL ACCESS, LTD.
+00E0C9|AutomatedLogic Corporation
+00E0CA|BEST DATA PRODUCTS
+00E0CB|RESON, INC.
+00E0CC|HERO SYSTEMS, LTD.
+00E0CD|SAAB SENSIS CORPORATION
+00E0CE|ARN
+00E0CF|INTEGRATED DEVICE TECHNOLOGY, INC.
+00E0D0|NETSPEED, INC.
+00E0D1|TELSIS LIMITED
+00E0D2|VERSANET COMMUNICATIONS, INC.
+00E0D3|DATENTECHNIK GmbH
+00E0D4|EXCELLENT COMPUTER
+00E0D5|Emulex Corporation
+00E0D6|COMPUTER & COMMUNICATION RESEARCH LAB.
+00E0D7|SUNSHINE ELECTRONICS, INC.
+00E0D8|LANBit Computer, Inc.
+00E0D9|TAZMO CO., LTD.
+00E0DA|Alcatel North America ESD
+00E0DB|ViaVideo Communications, Inc.
+00E0DC|NEXWARE CORP.
+00E0DD|ZENITH ELECTRONICS CORPORATION
+00E0DE|DATAX NV
+00E0DF|KEYMILE GmbH
+00E0E0|SI ELECTRONICS, LTD.
+00E0E1|G2 NETWORKS, INC.
+00E0E2|INNOVA CORP.
+00E0E3|SK-ELEKTRONIK GmbH
+00E0E4|FANUC ROBOTICS NORTH AMERICA, Inc.
+00E0E5|CINCO NETWORKS, INC.
+00E0E6|INCAA DATACOM B.V.
+00E0E7|RAYTHEON E-SYSTEMS, INC.
+00E0E8|GRETACODER Data Systems AG
+00E0E9|DATA LABS, INC.
+00E0EA|INNOVAT COMMUNICATIONS, INC.
+00E0EB|DIGICOM SYSTEMS, INCORPORATED
+00E0EC|CELESTICA INC.
+00E0ED|SILICOM, LTD.
+00E0EE|MAREL HF
+00E0EF|DIONEX
+00E0F0|ABLER TECHNOLOGY, INC.
+00E0F1|THAT CORPORATION
+00E0F2|ARLOTTO COMNET, INC.
+00E0F3|WebSprint Communications, Inc.
+00E0F4|INSIDE Technology A/S
+00E0F5|TELES AG
+00E0F6|DECISION EUROPE
+00E0F7|Cisco
+00E0F8|DICNA CONTROL AB
+00E0F9|Cisco
+00E0FA|TRL TECHNOLOGY, LTD.
+00E0FB|LEIGHTRONIX, INC.
+00E0FC|HUAWEI TECHNOLOGIES CO., LTD.
+00E0FD|A-TREND TECHNOLOGY CO., LTD.
+00E0FE|Cisco
+00E0FF|SECURITY DYNAMICS TECHNOLOGIES, Inc.
+00E16D|Cisco
+00E175|AK-Systems Ltd
+00E3B2|Samsung
+00E666|ARIMA Communications Corp.
+00E6D3|NIXDORF COMPUTER CORP.
+00E6E8|Netzin Technology Corporation,.Ltd.
+00E8AB|Meggitt Training Systems, Inc.
+00EB2D|Sony Mobile Communications AB
+00EEBD|HTC Corporation
+00F051|KWB Gmbh
+00F3DB|WOO Sports
+00F403|Orbis Systems Oy
+00F46F|Samsung
+00F4B9|Apple
+00F76F|Apple
+00F860|PT. Panggung Electric Citrabuana
+00FA3B|CLOOS ELECTRONIC GMBH
+00FC58|WebSilicon Ltd.
+00FC70|Intrepid Control Systems, Inc.
+00FC8D|Hitron Technologies. Inc
+00FD4C|NEVATEC
+020701|RACAL-DATACOM
+021C7C|PERQ SYSTEMS CORPORATION
+026086|LOGIC REPLACEMENT TECH. LTD.
+02608C|3COM CORPORATION
+027001|RACAL-DATACOM
+0270B0|M/A-COM INC. COMPANIES
+0270B3|DATA RECALL LTD
+029D8E|CARDIAC RECORDERS INC.
+02AA3C|OLIVETTI TELECOMM SPA (OLTECO)
+02BB01|OCTOTHORPE CORP.
+02C08C|3COM CORPORATION
+02CF1C|COMMUNICATION MACHINERY CORP.
+02E6D3|NIXDORF COMPUTER CORPORATION
+040A83|Alcatel-Lucent
+040AE0|XMIT AG COMPUTER NETWORKS
+040CCE|Apple
+040EC2|ViewSonic Mobile China Limited
+041552|Apple
+04180F|Samsung
+0418B6|ZZZZ 
+0418D6|Ubiquiti Networks
+041A04|WaveIP
+041B94|Host Mobility AB
+041BBA|Samsung
+041D10|Dream Ware Inc.
+041E64|Apple
+04209A|Panasonic AVC Networks Company
+042234|Wireless Standard Extensions
+042605|GFR Gesellschaft fur Regelungstechnik und Energieeinsparung mbH
+042665|Apple
+042BBB|PicoCELA, Inc.
+042F56|ATOCS (Shenzhen) LTD
+0432F4|Partron
+043604|Gyeyoung I&T
+043D98|ChongQing QingJia Electronics CO.,LTD
+0444A1|TELECON GALICIA,S.A.
+044665|Murata Manufacturing Co., Ltd.
+04489A|Apple
+044A50|Ramaxel Technology (Shenzhen) limited company
+044BFF|GuangZhou Hedy Digital Technology Co., Ltd
+044CEF|Fujian Sanao Technology Co.,Ltd
+044E06|Ericsson AB
+044F8B|Adapteva, Inc.
+044FAA|Ruckus Wireless
+045453|Apple
+0455CA|BriView (Xiamen) Corp.
+04572F|Sertel Electronics UK Ltd
+04586F|Sichuan Whayer information industry Co.,LTD
+045A95|Nokia Corporation
+045C06|Zmodo Technology Corporation
+045C8E|gosund GROUP CO.,LTD
+045D56|camtron industrial inc.
+045FA7|Shenzhen Yichen Technology Development Co.,LTD
+046169|MEDIA GLOBAL LINKS CO., LTD.
+0462D7|ALSTOM HYDRO FRANCE
+0463E0|Nome Oy
+046785|scemtec Hard- und Software fuer Mess- und Steuerungstechnik GmbH
+046D42|Bryston Ltd.
+046E49|TaiYear Electronic Technology (Suzhou) Co., Ltd
+0470BC|Globalstar Inc.
+0474A1|Aligera Equipamentos Digitais Ltda
+0475F5|CSST
+04766E|ALPS Co,. Ltd.
+047D7B|Quanta Computer Inc.
+0481AE|Clack Corporation
+04848A|7INOVA TECHNOLOGY LIMITED
+04888C|Eifelwerk Butler Systeme GmbH
+0488E2|Beats Electronics LLC
+048A15|Avaya, Inc
+048B42|Skspruce Technology Limited
+048C03|ThinPAD Technology (Shenzhen)CO.,LTD
+048D38|Netcore Technology Inc.
+0492EE|iway AG
+0494A1|CATCH THE WIND INC
+0498F3|ALPS Electric Co,. Ltd.
+0499E6|Shenzhen Yoostar Technology Co., Ltd
+049B9C|Eadingcore  Intelligent Technology Co., Ltd.
+049C62|BMT Medical Technology s.r.o.
+049F06|Smobile Co., Ltd.
+049F81|Netscout Systems, Inc.
+04A151|Netgear
+04A3F3|Emicon
+04A82A|Nokia Corporation
+04B3B6|Seamap (UK) Ltd
+04B466|BSP Co., Ltd.
+04BD70|HUAWEI TECHNOLOGIES CO.,LTD
+04BD88|Aruba Networks
+04BFA8|ISB Corporation
+04C05B|Tigo Energy
+04C06F|Shenzhen Huawei Communication Technologies Co., Ltd
+04C09C|Tellabs Inc.
+04C1B9|Fiberhome Telecommunication Tech.Co.,Ltd.
+04C5A4|Cisco
+04C880|Samtec Inc
+04C991|Phistek INC.
+04C9D9|EchoStar Technologies Corp
+04CB1D|Traka plc
+04CE14|Wilocity LTD.
+04CF25|MANYCOLORS, INC.
+04D437|ZNV
+04D783|Y&H E&C Co.,LTD.
+04DAD2|Cisco
+04DB56|Apple
+04DB8A|Suntech International Ltd.
+04DD4C|Velocytech
+04DEDB|Rockport Networks Inc
+04DF69|Car Connectivity Consortium
+04E0C4|TRIUMPH-ADLER AG
+04E1C8|IMS Solucoes em Energia Ltda.
+04E2F8|AEP Ticketing solutions srl
+04E451|Texas Instruments
+04E536|Apple
+04E548|Cohda Wireless Pty Ltd
+04E662|Acroname Inc.
+04E676|AMPAK Technology Inc.
+04E9E5|PJRC.COM, LLC
+04EE91|x-fabric GmbH
+04F021|Compex Systems Pte Ltd
+04F13E|Apple
+04F17D|Tarana Wireless
+04F4BC|Xena Networks
+04F7E4|Apple
+04F8C2|Flaircomm Microelectronics, Inc.
+04F938|HUAWEI TECHNOLOGIES CO.,LTD
+04FE31|Samsung
+04FE7F|Cisco
+04FF51|NOVAMEDIA INNOVISION SP. Z O.O.
+080001|COMPUTERVISION CORPORATION
+080002|BRIDGE COMMUNICATIONS INC.
+080003|ADVANCED COMPUTER COMM.
+080004|CROMEMCO INCORPORATED
+080005|SYMBOLICS INC.
+080006|SIEMENS AG
+080007|Apple
+080008|BOLT BERANEK AND NEWMAN INC.
+080009|HEWLETT PACKARD
+08000A|NESTAR SYSTEMS INCORPORATED
+08000B|UNISYS CORPORATION
+08000C|MIKLYN DEVELOPMENT CO.
+08000D|INTERNATIONAL COMPUTERS LTD.
+08000E|NCR CORPORATION
+08000F|MITEL CORPORATION
+080011|TEKTRONIX INC.
+080012|BELL ATLANTIC INTEGRATED SYST.
+080013|EXXON
+080014|EXCELAN
+080015|STC BUSINESS SYSTEMS
+080016|BARRISTER INFO SYS CORP
+080017|NATIONAL SEMICONDUCTOR
+080018|PIRELLI FOCOM NETWORKS
+080019|GENERAL ELECTRIC CORPORATION
+08001A|TIARA/ 10NET
+08001B|EMC Corporation
+08001C|KDD-KOKUSAI DEBNSIN DENWA CO.
+08001D|ABLE COMMUNICATIONS INC.
+08001E|APOLLO COMPUTER INC.
+08001F|SHARP CORPORATION
+080020|Oracle Corporation
+080021|3M COMPANY
+080022|NBI INC.
+080023|Panasonic Communications Co., Ltd.
+080024|10NET COMMUNICATIONS/DCA
+080025|CONTROL DATA
+080026|NORSK DATA A.S.
+080027|CADMUS COMPUTER SYSTEMS
+080028|Texas Instruments
+080029|MEGATEK CORPORATION
+08002A|MOSAIC TECHNOLOGIES INC.
+08002B|DIGITAL EQUIPMENT CORPORATION
+08002C|BRITTON LEE INC.
+08002D|LAN-TEC INC.
+08002E|METAPHOR COMPUTER SYSTEMS
+08002F|PRIME COMPUTER INC.
+080030|NETWORK RESEARCH CORPORATION
+080030|CERN
+080030|ROYAL MELBOURNE INST OF TECH
+080031|LITTLE MACHINES INC.
+080032|TIGAN INCORPORATED
+080033|BAUSCH & LOMB
+080034|FILENET CORPORATION
+080035|MICROFIVE CORPORATION
+080036|INTERGRAPH CORPORATION
+080037|FUJI-XEROX CO. LTD.
+080038|BULL S.A.S.
+080039|SPIDER SYSTEMS LIMITED
+08003A|ORCATECH INC.
+08003B|TORUS SYSTEMS LIMITED
+08003C|SCHLUMBERGER WELL SERVICES
+08003D|CADNETIX CORPORATIONS
+08003E|CODEX CORPORATION
+08003F|FRED KOSCHARA ENTERPRISES
+080040|FERRANTI COMPUTER SYS. LIMITED
+080041|RACAL-MILGO INFORMATION SYS..
+080042|JAPAN MACNICS CORP.
+080043|PIXEL COMPUTER INC.
+080044|DAVID SYSTEMS INC.
+080045|CONCURRENT COMPUTER CORP.
+080046|Sony Corporation
+080047|SEQUENT COMPUTER SYSTEMS INC.
+080048|EUROTHERM GAUGING SYSTEMS
+080049|UNIVATION
+08004A|BANYAN SYSTEMS INC.
+08004B|PLANNING RESEARCH CORP.
+08004C|HYDRA COMPUTER SYSTEMS INC.
+08004D|CORVUS SYSTEMS INC.
+08004E|3COM EUROPE LTD.
+08004F|CYGNET SYSTEMS
+080050|DAISY SYSTEMS CORP.
+080051|EXPERDATA
+080052|INSYSTEC
+080053|MIDDLE EAST TECH. UNIVERSITY
+080055|STANFORD TELECOMM. INC.
+080056|STANFORD LINEAR ACCEL. CENTER
+080057|EVANS & SUTHERLAND
+080058|SYSTEMS CONCEPTS
+080059|A/S MYCRON
+08005A|IBM Corp
+08005B|VTA TECHNOLOGIES INC.
+08005C|FOUR PHASE SYSTEMS
+08005D|GOULD INC.
+08005E|COUNTERPOINT COMPUTER INC.
+08005F|SABER TECHNOLOGY CORP.
+080060|INDUSTRIAL NETWORKING INC.
+080061|JAROGATE LTD.
+080062|GENERAL DYNAMICS
+080063|PLESSEY
+080064|Sitasys AG
+080065|GENRAD INC.
+080066|AGFA CORPORATION
+080067|COMDESIGN
+080068|RIDGE COMPUTERS
+080069|SILICON GRAPHICS INC.
+08006A|ATT BELL LABORATORIES
+08006B|ACCEL TECHNOLOGIES INC.
+08006C|SUNTEK TECHNOLOGY INT'L
+08006D|WHITECHAPEL COMPUTER WORKS
+08006E|MASSCOMP
+08006F|PHILIPS APELDOORN B.V.
+080070|MITSUBISHI ELECTRIC CORP.
+080071|MATRA (DSIE)
+080072|XEROX CORP UNIV GRANT PROGRAM
+080073|TECMAR INC.
+080074|CASIO COMPUTER CO. LTD.
+080075|DANSK DATA ELECTRONIK
+080076|PC LAN TECHNOLOGIES
+080077|TSL COMMUNICATIONS LTD.
+080078|ACCELL CORPORATION
+080079|THE DROID WORKS
+08007A|INDATA
+08007B|SANYO ELECTRIC CO. LTD.
+08007C|VITALINK COMMUNICATIONS CORP.
+08007E|AMALGAMATED WIRELESS(AUS) LTD
+08007F|CARNEGIE-MELLON UNIVERSITY
+080080|AES DATA INC.
+080081|ASTECH INC.
+080082|VERITAS SOFTWARE
+080083|Seiko Instruments Inc.
+080084|TOMEN ELECTRONICS CORP.
+080085|ELXSI
+080086|KONICA MINOLTA HOLDINGS, INC.
+080087|XYPLEX
+080088|Brocade Communications Systems, Inc.
+080089|KINETICS
+08008A|PerfTech, Inc.
+08008B|PYRAMID TECHNOLOGY CORP.
+08008C|NETWORK RESEARCH CORPORATION
+08008D|XYVISION INC.
+08008E|TANDEM COMPUTERS
+08008F|CHIPCOM CORPORATION
+080090|SONOMA SYSTEMS
+080371|KRG CORPORATE
+0805CD|DongGuang EnMai Electronic Product Co.Ltd.
+0808C2|Samsung
+0808EA|AMSC
+0809B6|Masimo Corp
+080C0B|SysMik GmbH Dresden
+080CC9|Mission Technology Group, dba Magma
+080D84|GECO, Inc.
+080EA8|Velex s.r.l.
+080FFA|KSP INC.
+08115E|Bitel Co., Ltd.
+081196|Intel Corporate
+081443|UNIBRAIN S.A.
+081651|Shenzhen Sea Star Technology Co.,Ltd
+081735|Cisco
+0817F4|IBM Corp
+08181A|zte corporation
+08184C|A. S. Thomas, Inc.
+0819A6|HUAWEI TECHNOLOGIES CO.,LTD
+081DFB|Shanghai Mexon Communication Technology Co.,Ltd
+081F3F|WondaLink Inc.
+081FEB|BinCube
+081FF3|Cisco
+082522|ADVANSEE
+082719|APS systems/electronic AG
+082AD0|SRD Innovations Inc.
+082CB0|Network Instruments
+082E5F|Hewlett Packard
+083571|CASwell INC.
+08373D|Samsung
+08379C|Topaz Co. LTD.
+0838A5|Funkwerk plettac electronic GmbH
+083A5C|Junilab, Inc.
+083AB8|Shinoda Plasma Co., Ltd.
+083D88|Samsung
+083E0C|ARRIS Group, Inc.
+083E8E|Hon Hai Precision Ind.Co.Ltd
+083F3E|WSH GmbH
+083F76|Intellian Technologies, Inc.
+084027|Gridstore Inc.
+084656|VODALYS Ingenierie
+08482C|Raycore Taiwan Co., LTD.
+084E1C|H2A Systems, LLC
+084EBF|Broad Net Mux Corporation
+08512E|Orion Diagnostica Oy
+085240|EbV Elektronikbau- und Vertriebs GmbH
+085700|TP-LINK TECHNOLOGIES CO.,LTD.
+085AE0|Recovision Technology Co., Ltd.
+085B0E|Fortinet, Inc.
+085DDD|Mercury Corporation
+08606E|ASUSTek COMPUTER INC.
+086266|ASUSTek COMPUTER INC.
+086361|Huawei Technologies Co., Ltd
+0868D0|Japan System Design
+0868EA|EITO ELECTRONICS CO., LTD.
+086DF2|Shenzhen MIMOWAVE Technology Co.,Ltd
+087045|Apple
+0874F6|Winterhalter Gastronom GmbH
+087572|Obelux Oy
+087618|ViE Technologies Sdn. Bhd.
+087695|Auto Industrial Co., Ltd.
+0876FF|Thomson Telecom Belgium
+087999|AIM GmbH
+087A4C|Huawei Technologies Co., Ltd
+087BAA|SVYAZKOMPLEKTSERVICE, LLC
+087CBE|Quintic Corp.
+087D21|Altasec technology corporation
+088039|Cisco
+0881BC|HongKong Ipro Technology Co., Limited
+0881F4|Juniper Networks
+08863B|Belkin International, Inc.
+088DC8|Ryowa Electronics Co.,Ltd
+088E4F|SF Software Solutions
+088F2C|Hills Sound Vision & Lighting
+08952A|Technicolor CH USA Inc
+0896D7|AVM GmbH
+089758|Shenzhen Strong Rising Electronics Co.,Ltd DongGuan Subsidiary
+089E01|QUANTA COMPUTER INC.
+089F97|LEROY AUTOMATION
+08A12B|ShenZhen EZL Technology Co., Ltd
+08A5C8|Sunnovo International Limited
+08A95A|Azurewave
+08ACA5|Benu Video, Inc.
+08AF78|Totus Solutions, Inc.
+08B2A3|Cynny Italia S.r.L.
+08B4CF|Abicom International
+08B738|Lite-On Technogy Corp.
+08B7EC|Wireless Seismic
+08BBCC|AK-NORD EDV VERTRIEBSGES. mbH
+08BD43|Netgear
+08BE09|Astrol Electronic AG
+08CA45|Toyou Feiji Electronics Co., Ltd.
+08CC68|Cisco
+08CD9B|samtec automotive electronics & software GmbH
+08D09F|Cisco
+08D0B7|HISENSE ELECTRIC CO.,LTD.
+08D29A|Proformatique
+08D34B|Techman Electronics (Changshu) Co., Ltd.
+08D40C|Intel Corporate
+08D42B|Samsung
+08D5C0|Seers Technology Co., Ltd
+08D833|Shenzhen RF Technology Co,.Ltd
+08DF1F|Bose Corporation
+08E5DA|NANJING FUJITSU COMPUTER PRODUCTS CO.,LTD.
+08E672|JEBSEE ELECTRONICS CO.,LTD.
+08E84F|HUAWEI TECHNOLOGIES CO.,LTD
+08EA44|Aerohive Networks, Inc.
+08EB29|Jiangsu Huitong Group Co.,Ltd.
+08EB74|Humax
+08EBED|World Elite Technology Co.,LTD
+08ECA9|Samsung
+08EDB9|Hon Hai Precision Ind. Co.,Ltd.
+08EE8B|Samsung
+08EF3B|MCS Logic Inc.
+08EFAB|SAYME WIRELESS SENSOR NETWORK
+08F1B7|Towerstream Corpration
+08F2F4|Net One Partners Co.,Ltd.
+08F6F8|GET Engineering
+08F728|GLOBO Multimedia Sp. z o.o. Sp.k.
+08FAE0|Fohhn Audio AG
+08FC52|OpenXS BV
+08FC88|Samsung
+08FD0E|Samsung
+0C0400|Jantar d.o.o.
+0C0535|Juniper Systems
+0C1105|Ringslink (Xiamen) Network Communication Technologies Co., Ltd
+0C1262|zte corporation
+0C130B|Uniqoteq Ltd.
+0C1420|Samsung
+0C1539|Apple
+0C15C5|SDTEC Co., Ltd.
+0C17F1|TELECSYS
+0C191F|Inform Electronik
+0C1DAF|Beijing Xiaomi communications co.,ltd
+0C1DC2|SeAH Networks
+0C2026|noax Technologies AG
+0C2724|Cisco
+0C2755|Valuable Techologies Limited
+0C2A69|electric imp, incorporated
+0C2AE7|Beijing General Research Institute of Mining and Metallurgy
+0C2D89|QiiQ Communications Inc.
+0C3021|Apple
+0C37DC|Huawei Technologies Co., Ltd
+0C383E|Fanvil Technology Co., Ltd.
+0C3956|Observator instruments
+0C3C65|Dome Imaging Inc
+0C3E9F|Apple
+0C413E|Microsoft
+0C469D|MS Sedco
+0C473D|Hitron Technologies. Inc
+0C4885|LG Electronics
+0C4C39|Mitrastar Technology
+0C4DE9|Apple
+0C4F5A|ASA-RT s.r.l.
+0C51F7|CHAUVIN ARNOUX
+0C54A5|PEGATRON CORPORATION
+0C5521|Axiros GmbH
+0C565C|HyBroad Vision (Hong Kong) Technology Co Ltd
+0C57EB|Mueller Systems
+0C5A19|Axtion Sdn Bhd
+0C5CD8|DOLI Elektronik GmbH
+0C6076|Hon Hai Precision Ind. Co.,Ltd.
+0C63FC|Nanjing Signway Technology Co., Ltd
+0C6803|Cisco
+0C6E4F|PrimeVOLT Co., Ltd.
+0C715D|Samsung
+0C722C|TP-LINK TECHNOLOGIES CO.,LTD.
+0C74C2|Apple
+0C7523|BEIJING GEHUA CATV NETWORK CO.,LTD
+0C771A|Apple
+0C7D7C|Kexiang Information Technology Co, Ltd.
+0C8112|ZZZZ 
+0C8230|SHENZHEN MAGNUS TECHNOLOGIES CO.,LTD
+0C8268|TP-LINK TECHNOLOGIES CO.,LTD.
+0C826A|Wuhan Huagong Genuine Optics Technology Co., Ltd
+0C8411|A.O. Smith Water Products
+0C8484|Zenovia Electronics Inc.
+0C84DC|Hon Hai Precision Ind. Co.,Ltd.
+0C8525|Cisco
+0C8910|Samsung
+0C8BFD|Intel Corporate
+0C8C8F|Kamo Technology Limited
+0C8CDC|Suunto Oy
+0C8D98|TOP EIGHT IND CORP
+0C924E|Rice Lake Weighing Systems
+0C9301|PT. Prasimax Inovasi Teknologi
+0C93FB|BNS Solutions
+0C96BF|Huawei Technologies Co., Ltd
+0C9B13|Shanghai Magic Mobile Telecommunication Co.Ltd.
+0C9D56|Consort Controls Ltd
+0C9E91|Sankosha Corporation
+0CA138|Blinq Wireless Inc.
+0CA2F4|Chameleon Technology (UK) Limited
+0CA402|Alcatel Lucent IPD
+0CA42A|OB Telecom Electronic Technology Co., Ltd
+0CA694|Sunitec Enterprise Co.,Ltd
+0CAC05|Unitend Technologies Inc.
+0CAF5A|GENUS POWER INFRASTRUCTURES LIMITED
+0CB319|Samsung
+0CB4EF|Digience Co.,Ltd.
+0CB5DE|Alcatel Lucent
+0CBC9F|Apple
+0CBD51|TCT Mobile Limited
+0CBF15|Genetec
+0CC0C0|MAGNETI MARELLI SISTEMAS ELECTRONICOS MEXICO
+0CC3A7|Meritec
+0CC47A|Super Micro Computer, Inc.
+0CC47E|EUCAST Co., Ltd.
+0CC655|Wuxi YSTen Technology Co.,Ltd.
+0CC66A|Nokia Corporation
+0CC6AC|DAGS
+0CC81F|Summer Infant, Inc.
+0CC9C6|Samwin Hong Kong Limited
+0CCB8D|ASCO Numatics GmbH
+0CCDD3|EASTRIVER TECHNOLOGY CO., LTD.
+0CCDFB|EDIC Systems Inc.
+0CCFD1|SPRINGWAVE Co., Ltd
+0CD292|Intel Corporate
+0CD2B5|Binatone Telecommunication Pvt. Ltd
+0CD502|Westell
+0CD696|Amimon Ltd
+0CD7C2|Axium Technologies, Inc.
+0CD996|Cisco
+0CD9C1|Visteon Corporation
+0CDA41|Hangzhou H3C Technologies Co., Limited
+0CDCCC|Inala Technologies
+0CDDEF|Nokia Corporation
+0CDFA4|Samsung
+0CE0E4|Plantronics, Inc
+0CE5D3|DH electronics GmbH
+0CE709|Fox Crypto B.V.
+0CE82F|Bonfiglioli Vectron GmbH
+0CE936|ELIMOS srl
+0CEEE6|Hon Hai Precision Ind. Co.,Ltd.
+0CEF7C|AnaCom Inc
+0CEFAF|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+0CF019|Malgn Technology Co., Ltd.
+0CF0B4|Globalsat International Technology Ltd
+0CF361|Java Information
+0CF3EE|EM Microelectronic
+0CF405|Beijing Signalway Technologies Co.,Ltd
+0CF5A4|Cisco
+0CF893|ARRIS Group, Inc.
+0CFC83|Airoha Technology Corp.,
+0CFE45|Sony Computer Entertainment Inc.
+100000|PUBLIC 
+10005A|IBM Corp
+1000E8|NATIONAL SEMICONDUCTOR
+1000FD|LaonPeople
+1001CA|Ashley Butterworth
+1005CA|Cisco
+100723|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+1008B1|Hon Hai Precision Ind. Co.,Ltd.
+10090C|Janome Sewing Machine Co., Ltd.
+100BA9|Intel Corporate
+100C24|pomdevices, LLC
+100D2F|Online Security Pty. Ltd.
+100D32|Embedian, Inc.
+100D7F|Netgear
+100E2B|NEC CASIO Mobile Communications
+100E7E|Juniper networks
+100F18|Fu Gang Electronic(KunShan)CO.,LTD
+1010B6|McCain Inc
+101212|Vivo International Corporation Pty Ltd
+101218|Korins Inc.
+101248|ITG, Inc.
+1013EE|Justec International Technology INC.
+10189E|Elmo Motion Control
+101B54|HUAWEI TECHNOLOGIES CO.,LTD
+101C0C|Apple
+101D51|ON-Q LLC dba ON-Q Mesh Networks
+101DC0|Samsung
+101F74|Hewlett-Packard Company
+102279|ZeroDesktop, Inc.
+1027BE|TVIP
+102831|Morion Inc.
+102C83|XIMEA
+102D96|Looxcie Inc.
+102EAF|Texas Instruments
+102F6B|Microsoft
+103047|Samsung
+103378|FLECTRON Co., LTD
+103711|Simlink AS
+103B59|Samsung
+103DEA|HFC Technology (Beijing) Ltd. Co.
+1040F3|Apple
+10417F|Apple
+104369|Soundmax Electronic Limited
+10445A|Shaanxi Hitech Electronic Co., LTD
+1045BE|Norphonic AS
+1045F8|LNT-Automation GmbH
+104780|HUAWEI TECHNOLOGIES CO.,LTD
+1048B1|Beijing Duokan Technology Limited
+104A7D|Intel Corporate
+104B46|Mitsubishi Electric Corporation
+104D77|Innovative Computer Engineering
+104E07|Shanghai Genvision Industries Co.,Ltd
+105172|HUAWEI TECHNOLOGIES CO.,LTD
+1056CA|Peplink International Ltd.
+105C3B|Perma-Pipe, Inc.
+105CBF|DuroByte Inc
+105F06|Actiontec Electronics, Inc
+105F49|Cisco
+10604B|Hewlett Packard
+1062C9|Adatis GmbH & Co. KG
+1064E2|ADFweb.com s.r.l.
+1065A3|Core Brands LLC
+1065CF|IQSIM
+106682|NEC Platforms, Ltd.
+10683F|LG Electronics
+106F3F|Buffalo Inc.
+106FEF|Ad-Sol Nissin Corp
+1071F9|Cloud Telecomputers, LLC
+10768A|EoCell
+1077B1|Samsung
+107873|Shenzhen Jinkeyi Communication Co., Ltd.
+1078CE|Hanvit SI, Inc.
+1078D2|ELITEGROUP COMPUTER SYSTEM CO., LTD.
+107A86|U&U ENGINEERING INC.
+107BEF|ZyXEL Communications Corp
+1083D2|Microseven Systems, LLC
+10880F|Daruma Telecomunicacoes e Informatica S.A.
+1088CE|Fiberhome Telecommunication Tech.Co.,Ltd.
+108A1B|RAONIX Inc.
+108CCF|Cisco
+109266|Samsung
+1093E9|Apple
+109836|Dell Inc.
+109AB9|Tosibox Oy
+109ADD|Apple
+109FA9|Actiontec Electronics, Inc
+10A13B|FUJIKURA RUBBER LTD.
+10A5D0|Murata Manufacturing Co.,Ltd.
+10A659|Mobile Create Co.,Ltd.
+10A743|SK Mtek Limited
+10A932|Beijing Cyber Cloud Technology Co. ,Ltd.
+10AF78|Shenzhen ATUE Technology Co., Ltd
+10B26B|base Co.,Ltd.
+10B7F6|Plastoform Industries Ltd.
+10B9FE|Lika srl
+10BAA5|GANA I&C CO., LTD
+10BD18|Cisco
+10BF48|ASUSTEK COMPUTER INC.
+10C07C|Blu-ray Disc Association
+10C2BA|UTT Co., Ltd.
+10C37B|ASUSTek COMPUTER INC.
+10C586|BIO SOUND LAB CO., LTD.
+10C61F|Huawei Technologies Co., Ltd
+10C67E|SHENZHEN JUCHIN TECHNOLOGY CO., LTD
+10C6FC|Garmin International
+10C73F|Midas Klark Teknik Ltd
+10CA81|PRECIA
+10CCDB|AXIMUM PRODUITS ELECTRONIQUES
+10CDAE|Avaya, Inc
+10D1DC|INSTAR Deutschland GmbH
+10D38A|Samsung
+10D542|Samsung
+10DDB1|Apple
+10DDF4|Maxway Electronics CO.,LTD
+10DEE4|automationNEXT GmbH
+10DF8B|Shenzhen CareDear Communication Technology Co.,Ltd
+10E2D5|Qi Hardware Inc.
+10E3C7|Seohwa Telecom
+10E4AF|APR, LLC
+10E6AE|Source Technologies, LLC
+10E878|Alcatel-Lucent
+10E8EE|PhaseSpace
+10EA59|Cisco
+10EED9|Canoga Perkins Corporation
+10F311|Cisco
+10F3DB|Gridco Systems, Inc.
+10F49A|T3 Innovation
+10F681|vivo Mobile Communication Co., Ltd.
+10F96F|LG Electronics
+10F9EE|Nokia Corporation
+10FACE|Reacheng Communication Technology Co.,Ltd
+10FBF0|KangSheng LTD.
+10FC54|Shany Electronic Co., Ltd.
+10FEED|TP-LINK TECHNOLOGIES CO., LTD.
+1100AA|IEEE STANDARDS OFFICE 
+140708|ZZZZ 
+1407E0|Abrantix AG
+140C76|FREEBOX SAS
+140D4F|Flextronics International
+14109F|Apple
+141330|Anakreon UK LLP
+14144B|FUJIAN STAR-NET COMMUNICATION CO.,LTD
+14157C|TOKYO COSMOS ELECTRIC CO.,LTD.
+141A51|Treetech Sistemas Digitais
+141AA3|Motorola
+141BBD|Volex Inc.
+141BF0|Intellimedia Systems Ltd
+141FBA|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+1422DB|eero inc.
+1423D7|EUTRONIX CO., LTD.
+142971|NEMOA ELECTRONICS (HK) CO. LTD
+142BD2|Armtel Ltd.
+142BD6|Guangdong Appscomm Co.,Ltd
+142D27|Hon Hai Precision Ind. Co.,Ltd.
+142D8B|Incipio Technologies, Inc
+142DF5|Amphitech
+14307A|Avermetrics
+1430C6|Motorola
+1432D1|Samsung
+14358B|Mediabridge Products, LLC.
+1435B3|Future Designs, Inc.
+143605|Nokia Corporation
+1436C6|Lenovo Mobile Communication Technology Ltd.
+14373B|PROCOM Systems
+143AEA|Dynapower Company LLC
+143DF2|Beijing Shidai Hongyuan Network Communication Co.,Ltd
+143E60|Alcatel-Lucent
+144146|Honeywell (China) Co., LTD
+1441E2|Monaco Enterprises, Inc.
+144319|Creative&Link Technology Limited
+1446E4|AVISTEL
+14488B|Shenzhen Doov Technology Co.,Ltd
+144978|Digital Control Incorporated
+1449E0|Samsung
+144C1A|Max Communication GmbH
+145412|Entis Co., Ltd.
+145645|Savitech Corp.
+1458D0|Hewlett Packard
+145A05|Apple
+145A83|Logi-D inc
+145BD1|ARRIS Group, Inc.
+146080|zte corporation
+146308|JABIL CIRCUIT (SHANGHAI) LTD.
+146A0B|Cypress Electronics Limited
+146B72|Shenzhen Fortune Ship Technology Co., Ltd.
+146E0A|ASSIGNED - PRIVATE REGISTRATION 
+147373|TUBITAK UEKAE
+147411|RIM
+147590|TP-LINK TECHNOLOGIES CO.,LTD.
+147DB3|JOA TELECOM.CO.,LTD
+147DC5|Murata Manufacturing Co., Ltd.
+14825B|Hefei Radio Communication Technology Co., Ltd
+148692|TP-LINK TECHNOLOGIES CO.,LTD.
+14893E|VIXTEL TECHNOLOGIES LIMTED
+1489FD|Samsung
+148A70|ADS GmbH
+148F21|Garmin International
+148FC6|Apple
+149090|KongTop industrial(shen zhen)CO.,LTD
+149448|BLU CASTLE S.A.
+1499E2|Apple
+149A10|Microsoft
+149FE8|Lenovo Mobile Communication Technology Ltd.
+14A364|Samsung
+14A62C|S.M. Dezac S.A.
+14A86B|ShenZhen Telacom Science&Technology Co., Ltd
+14A9E3|MST CORPORATION
+14ABF0|ARRIS Group, Inc.
+14AEDB|VTech Telecommunications Ltd.
+14B126|Industrial Software Co
+14B1C8|InfiniWing, Inc.
+14B484|Samsung
+14B73D|ARCHEAN Technologies
+14B968|Huawei Technologies Co., Ltd
+14C089|DUNE HD LTD
+14C126|Nokia Corporation
+14C21D|Sabtech Industries
+14CC20|TP-LINK TECHNOLOGIES CO.,LTD
+14CF8D|OHSUNG ELECTRONICS CO., LTD.
+14CF92|TP-LINK TECHNOLOGIES CO., LTD.
+14CFE2|ARRIS Group, Inc.
+14D4FE|Pace plc
+14D64D|D-Link International
+14D76E|CONCH ELECTRONIC Co.,Ltd
+14DAE9|ASUSTek COMPUTER INC.
+14DB85|S NET MEDIA
+14DDA9|ASUSTek COMPUTER INC.
+14E4EC|mLogic LLC
+14E6E4|TP-LINK TECHNOLOGIES CO., LTD.
+14EB33|BSMediasoft Co., Ltd.
+14EDA5|Wachter GmbH Sicherheitssysteme
+14EDE4|Kaiam Corporation
+14EE9D|AirNav Systems LLC
+14F0C5|Xtremio Ltd.
+14F28E|ShenYang ZhongKe-Allwin Technology Co.LTD
+14F42A|Samsung
+14F65A|Xiaomi
+14F893|Wuhan FiberHome Digital Technology Co.,Ltd.
+14FEAF|SAGITTAR LIMITED
+14FEB5|Dell Inc
+18002D|Sony Mobile Communications AB
+1800DB|Fitbit Inc.
+1801E3|Elektrobit Wireless Communications Ltd
+180373|Dell Inc
+1803FA|IBT Interfaces
+180675|DILAX Intelcom GmbH
+180B52|Nanotron Technologies GmbH
+180C14|iSonea Limited
+180C77|Westinghouse Electric Company, LLC
+180CAC|CANON INC.
+18104E|CEDINT-UPM
+181420|TEB SAS
+181456|Nokia Corporation
+1816C9|Samsung
+181714|DAEWOOIS
+181725|Cameo Communications, Inc.
+18193F|Tamtron Oy
+181BEB|Actiontec Electronics, Inc
+181E78|SAGEMCOM
+181EB0|Samsung
+182012|Aztech Associates Inc.
+182032|Apple
+1820A6|Sage Co., Ltd.
+18227E|Samsung
+182666|Samsung
+182861|AirTies Wireless Networks
+182A7B|Nintendo Co., Ltd.
+182B05|8D Technologies
+182C91|Concept Development, Inc.
+183009|Woojin Industrial Systems Co., Ltd.
+1832A2|LAON TECHNOLOGY CO., LTD.
+18339D|Cisco
+183451|Apple
+1836FC|Elecsys International Corporation
+183825|Wuhan Lingjiu High-tech Co.,Ltd.
+183864|CAP-TECH INTERNATIONAL CO., LTD.
+183919|Unicoi Systems
+183A2D|Samsung
+183BD2|BYD Precision Manufacture Company Ltd.
+183DA2|Intel Corporate
+183F47|Samsung
+18421D|ZZZZ 
+18422F|Alcatel Lucent
+184462|Riava Networks, Inc.
+1844E6|zte corporation
+184617|Samsung
+1848D8|Fastback Networks
+184A6F|Alcatel-Lucent Shanghai Bell Co., Ltd
+184E94|MESSOA TECHNOLOGIES INC.
+184F32|Hon Hai Precision Ind. Co.,Ltd.
+185253|Pixord Corporation
+1853E0|Hanyang Digitech Co.Ltd
+18550F|Cisco
+185933|Cisco
+185936|Xiaomi
+185AE8|Zenotech.Co.,Ltd
+185D9A|BobjGear LLC
+18622C|SAGEMCOM SAS
+186472|Aruba Networks
+186571|Top Victory Electronics (Taiwan) Co., Ltd.
+1866E3|Veros Systems, Inc.
+18673F|Hanover Displays Limited
+186751|KOMEG Industrielle Messtechnik GmbH
+1867B0|Samsung
+186882|Beward R&D Co., Ltd.
+186D99|Adanis Inc.
+187117|eta plus electronic gmbh
+1879A2|GMJ ELECTRIC LIMITED
+187A93|AMICCOM Electronics Corporation
+187C81|Valeo Vision Systems
+187ED5|shenzhen kaism technology Co. Ltd
+1880CE|Barberry Solutions Ltd
+1880F5|Alcatel-Lucent Shanghai Bell Co., Ltd
+188219|Alibaba Cloud Computing Ltd.
+188331|Samsung
+1883BF|Arcadyan Technology Corporation
+188410|CoreTrust Inc.
+18863A|DIGITAL ART SYSTEM
+1886AC|Nokia Danmark A/S
+188796|HTC Corporation
+188857|Beijing Jinhong Xi-Dian Information Technology Corp.
+1889DF|CerebrEX Inc.
+188ED5|TP Vision Belgium N.V. - innovation site Brugge
+188EF9|G2C Co. Ltd.
+18922C|Virtual Instruments
+1897FF|TechFaith Wireless Technology Limited
+189A67|CSE-Servelec Limited
+189C5D|Cisco
+189EFC|Apple
+18A3E8|Fiberhome Telecommunication Tech.Co.,Ltd.
+18A905|Hewlett-Packard Company
+18A958|PROVISION THAI CO., LTD.
+18A99B|Dell Inc
+18AA45|Fon Technology
+18ABF5|Ultra Electronics - Electrics
+18AD4D|Polostar Technology Corporation
+18AEBB|Siemens Convergence Creators GmbH&Co.KG
+18AF61|Apple
+18AF8F|Apple
+18AF9F|DIGITRONIC Automationsanlagen GmbH
+18B169|Sonicwall
+18B209|Torrey Pines Logic, Inc
+18B3BA|Netlogic AB
+18B430|Nest Labs Inc.
+18B591|I-Storm
+18B79E|Invoxia
+18BDAD|L-TECH CORPORATION
+18C086|Broadcom Corporation
+18C451|Tucson Embedded Systems
+18C58A|HUAWEI TECHNOLOGIES CO.,LTD
+18C8E7|Shenzhen Hualistone Technology Co.,Ltd
+18CC23|Philio Technology Corporation
+18CF5E|Liteon Technology Corporation
+18D071|DASAN CO., LTD.
+18D5B6|SMG Holdings LLC
+18D66A|Inmarsat
+18D6CF|Kurth Electronic GmbH
+18D949|Qvis Labs, LLC
+18DC56|Yulong Computer Telecommunication Scientific(shenzhen)Co.,Lt
+18E288|STT Condigi
+18E2C2|Samsung
+18E728|Cisco
+18E7F4|Apple
+18E80F|Viking Electronics Inc.
+18E8DD|MODULETEK
+18EE69|Apple
+18EF63|Cisco
+18F145|NetComm Wireless Limited
+18F46A|Hon Hai Precision Ind. Co.,Ltd.
+18F643|Apple
+18F650|Multimedia Pacific Limited
+18F87A|i3 International Inc.
+18FA6F|ISC applied systems corp
+18FB7B|Dell Inc
+18FC9F|Changhe Electronics Co., Ltd.
+18FE34|Espressif Inc.
+18FF0F|Intel Corporate
+18FF2E|Shenzhen Rui Ying Da Technology Co., Ltd
+1C0656|IDY Corporation
+1C08C1|Lg Innotek
+1C0B52|EPICOM S.A
+1C0FCF|Sypro Optics GmbH
+1C11E1|Wartsila Finland Oy
+1C129D|IEEE PES PSRC/SUB
+1C1448|ARRIS Group, Inc.
+1C14B3|Pinyon Technologies
+1C17D3|Cisco
+1C184A|ShenZhen RicherLink Technologies Co.,LTD
+1C19DE|eyevis GmbH
+1C1AC0|Apple
+1C1B68|ARRIS Group, Inc.
+1C1CFD|Dalian Hi-Think Computer Technology, Corp
+1C1D67|Shenzhen Huawei Communication Technologies Co., Ltd
+1C1D86|Cisco
+1C334D|ITS Telecom
+1C3477|Innovation Wireless
+1C35F1|NEW Lift Neue Elektronische Wege Steuerungsbau GmbH
+1C37BF|Cloudium Systems Ltd.
+1C3947|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+1C3A4F|AccuSpec Electronics, LLC
+1C3DE7|Sigma Koki Co.,Ltd.
+1C3E84|Hon Hai Precision Ind. Co.,Ltd.
+1C4158|Gemalto M2M GmbH
+1C43EC|JAPAN CIRCUIT CO.,LTD
+1C4593|Texas Instruments
+1C4840|IMS Messsysteme GmbH
+1C48F9|GN Netcom A/S
+1C4AF7|AMON INC
+1C4BB9|SMG ENTERPRISE, LLC
+1C4BD6|AzureWave
+1C51B5|Techaya LTD
+1C5216|DONGGUAN HELE ELECTRONICS CO., LTD
+1C52D6|FLAT DISPLAY TECHNOLOGY CORPORATION
+1C5A3E|Samsung
+1C5A6B|Philips Electronics Nederland BV
+1C5C55|PRIMA Cinema, Inc
+1C5C60|Shenzhen Belzon Technology Co.,LTD.
+1C5FFF|Beijing Ereneben Information Technology Co.,Ltd Shenzhen Branch
+1C62B8|Samsung
+1C63B7|OpenProducts 237 AB
+1C659D|Liteon Technology Corporation
+1C666D|Hon Hai Precision Ind.Co.Ltd
+1C66AA|Samsung
+1C69A5|Research In Motion
+1C6A7A|Cisco
+1C6BCA|Mitsunami Co., Ltd.
+1C6F65|GIGA-BYTE TECHNOLOGY CO.,LTD.
+1C7508|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+1C76CA|Terasic Technologies Inc.
+1C7839|Shenzhen Tencent Computer System Co., Ltd.
+1C7B21|Sony Mobile Communications AB
+1C7C11|EID
+1C7C45|Vitek Industrial Video Products, Inc.
+1C7CC7|Coriant GmbH
+1C7D22|Fuji Xerox Co., Ltd.
+1C7E51|3bumen.com
+1C7EE5|D-Link International
+1C8341|Hefei Bitland Information Technology Co.Ltd
+1C83B0|Linked IP GmbH
+1C8464|FORMOSA WIRELESS COMMUNICATION CORP.
+1C86AD|MCT CO., LTD.
+1C8E5C|Huawei Technologies Co., Ltd
+1C8E8E|DB Communication & Systems Co., ltd.
+1C8F8A|Phase Motion Control SpA
+1C9179|Integrated System Technologies Ltd
+1C9492|RUAG Schweiz AG
+1C955D|I-LAX ELECTRONICS INC.
+1C959F|Veethree Electronics And Marine LLC
+1C965A|Weifang goertek Electronics CO.,LTD
+1C973D|PRICOM Design
+1C994C|Murata Manufactuaring Co.,Ltd.
+1C9C26|Zoovel Technologies
+1C9ECB|Beijing Nari Smartchip Microelectronics Company Limited
+1CA2B1|ruwido austria gmbh
+1CA532|Shenzhen Gongjin Electronics Co.,Ltd
+1CA770|SHENZHEN CHUANGWEI-RGB ELECTRONICS CO.,LT
+1CAA07|Cisco
+1CAB01|Innovolt
+1CABA7|Apple
+1CADD1|Bosung Electronics Co., Ltd.
+1CAF05|Samsung
+1CAFF7|D-LINK INTERNATIONAL PTE LIMITED
+1CB094|HTC Corporation
+1CB17F|NEC Platforms, Ltd.
+1CB243|TDC A/S
+1CB72C|ASUSTek COMPUTER INC.
+1CBA8C|Texas Instruments
+1CBBA8|OJSC "Ufimskiy Zavod "Promsvyaz"
+1CBD0E|Amplified Engineering Pty Ltd
+1CBDB9|D-LINK INTERNATIONAL PTE LIMITED
+1CC11A|Wavetronix
+1CC1DE|Hewlett-Packard Company
+1CC316|MileSight Technology Co., Ltd.
+1CC586|Absolute Acoustics
+1CC63C|Arcadyan Technology Corporation
+1CC72D|Shenzhen Huapu Digital CO.,Ltd
+1CCAE3|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+1CD40C|Kriwan Industrie-Elektronik GmbH
+1CDEA7|Cisco
+1CDF0F|Cisco
+1CE165|Marshal Corporation
+1CE192|Qisda Corporation
+1CE2CC|Texas Instruments
+1CE62B|Apple
+1CE6C7|Cisco
+1CE85D|Cisco
+1CEEE8|Ilshin Elecom
+1CF03E|Wearhaus Inc.
+1CF061|SCAPS GmbH
+1CF4CA|ZZZZ 
+1CF5E7|Turtle Industry Co., Ltd.
+1CFA68|TP-LINK TECHNOLOGIES CO.,LTD.
+1CFCBB|Realfiction ApS
+1CFEA7|IDentytech Solutins Ltd.
+20014F|Linea Research Ltd
+2002AF|Murata Manufactuaring Co.,Ltd.
+200505|RADMAX COMMUNICATION PRIVATE LIMITED
+2005E8|OOO InProMedia
+2008ED|Huawei Technologies Co., Ltd
+200A5E|Xiangshan Giant Eagle Technology Developing co.,LTD
+200BC7|HUAWEI TECHNOLOGIES CO.,LTD
+200CC8|Netgear
+200E95|IEC TC9 WG43
+20107A|Gemtek Technology Co., Ltd.
+201257|Most Lucky Trading Ltd
+2012D5|Scientech Materials Corporation
+2013E0|Samsung
+2016D8|Liteon Technology Corporation
+20180E|Shenzhen Sunchip Technology Co., Ltd
+201A06|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+201D03|Elatec GmbH
+2021A5|LG Electronics
+202564|PEGATRON CORPORATION
+202598|Teleview
+2028BC|Visionscape Co,. Ltd.
+202BC1|Shenzhen Huawei Communication Technologies Co., Ltd
+202CB7|Kong Yue Electronics & Information Industry (Xinhui) Ltd.
+2031EB|HDSN
+203706|Cisco
+2037BC|Kuipers Electronic Engineering BV
+203A07|Cisco
+204005|feno GmbH
+20415A|Smarteh d.o.o.
+20443A|Schneider Electric Asia Pacific Ltd
+2046A1|VECOW Co., Ltd
+2046F9|Advanced Network Devices (dba:AND)
+204747|Dell Inc.
+204AAA|Hanscan Spain S.A.
+204C6D|Hugo Brennenstuhl Gmbh & Co. KG.
+204C9E|Cisco
+204E6B|Axxana(israel) ltd
+204E7F|Netgear
+2053CA|Risk Technology Ltd
+205476|Sony Mobile Communications AB
+205721|Salix Technology CO., Ltd.
+2059A0|Paragon Technologies Inc.
+205A00|Coval
+205B2A|ZZZZ 
+205B5E|Shenzhen Wonhe Technology Co., Ltd
+205CFA|Yangzhou ChangLian Network Technology Co,ltd.
+206274|Microsoft
+20635F|Abeeway
+206432|Samsung
+2067B1|Pluto inc.
+20689D|Liteon Technology Corporation
+206A8A|Wistron InfoComm Manufacturing(Kunshan)Co.,Ltd.
+206AFF|Atlas Elektronik UK Limited
+206E9C|Samsung
+206FEC|Braemac CA LLC
+207355|ARRIS Group, Inc.
+2074CF|Shenzhen Voxtech Co.,Ltd
+207600|Actiontec Electronics, Inc
+207693|Lenovo (Beijing) Limited.
+207C8F|Quanta Microsystems,Inc.
+207D74|Apple
+20858C|Assa
+2087AC|AES motomation
+208984|COMPAL INFORMATION (KUNSHAN) CO., LTD
+208986|zte corporation
+209148|Texas Instruments
+20918A|PROFALUX
+2091D9|I'M SPA
+20934D|Fujian Star-net Communication Co., Ltd
+209AE9|Volacomm Co., Ltd
+209BA5|JIAXING GLEAD Electronics Co.,Ltd
+20A2E4|Apple
+20A2E7|Lee-Dickens Ltd
+20A787|Bointec Taiwan Corporation Limited
+20A99B|Microsoft
+20AA25|IP-NET LLC
+20AA4B|Cisco
+20B0F7|Enclustra GmbH
+20B399|Enterasys
+20B5C6|Mimosa Networks
+20B7C0|Omicron electronics GmbH
+20BBC0|Cisco
+20BBC6|Jabil Circuit Hungary Ltd.
+20BFDB|DVL
+20C06D|SHENZHEN SPACETEK TECHNOLOGY CO.,LTD
+20C1AF|i Wit Digital Co., Limited
+20C38F|Texas Instruments Inc
+20C60D|Shanghai annijie Information technology Co.,LTD
+20C6EB|Panasonic Corporation AVC Networks Company
+20C8B3|SHENZHEN BUL-TECH CO.,LTD.
+20C9D0|Apple
+20CD39|Texas Instruments, Inc
+20CEC4|Peraso Technologies
+20CF30|ASUSTek COMPUTER INC.
+20D21F|Wincal Technology Corp.
+20D390|Samsung
+20D5AB|Korea Infocom Co.,Ltd.
+20D5BF|Samsung
+20D607|Nokia Corporation
+20D75A|Posh Mobile Limited
+20D906|Iota, Inc.
+20DC93|Cheetah Hi-Tech, Inc.
+20DCE6|TP-LINK TECHNOLOGIES CO., LTD.
+20DF3F|Nanjing SAC Power Grid Automation Co., Ltd.
+20E407|Spark srl
+20E52A|Netgear
+20E564|ARRIS Group, Inc.
+20E791|Siemens Healthcare Diagnostics, Inc
+20EAC7|SHENZHEN RIOPINE ELECTRONICS CO., LTD
+20ED74|Ability enterprise co., Ltd.
+20EEC6|Elefirst Science & Tech Co ., ltd
+20F002|MTData Developments Pty. Ltd.
+20F3A3|Huawei Technologies Co., Ltd
+20F41B|Shenzhen Bilian electronic CO.,LTD
+20F85E|Delta Electronics
+20FABB|Cambridge Executive Limited
+20FDF1|3COM EUROPE LTD
+20FECD|System In Frontier Inc.
+20FEDB|M2M Solution S.A.S.
+2401C7|Cisco
+24050F|MTN Electronic Co. Ltd
+240917|Devlin Electronics Limited
+240995|Huawei Technologies Co., Ltd
+240A11|TCT Mobile Limited
+240A64|AzureWaveTechnologies,Inc
+240B2A|Viettel Group
+240BB1|KOSTAL Industrie Elektrik GmbH
+241064|Shenzhen Ecsino Tecnical Co. Ltd
+241125|Hutek Co., Ltd.
+241148|Entropix, LLC
+2411D0|Chongqing Ehs Science and Technology Development Co.,Ltd.
+241A8C|Squarehead Technology AS
+241B13|Shanghai Nutshell Electronic Co., Ltd.
+241B44|Hangzhou Tuners Electronics Co., Ltd
+241C04|SHENZHEN JEHE TECHNOLOGY DEVELOPMENT CO., LTD.
+241F2C|Calsys, Inc.
+2421AB|Sony Ericsson Mobile Communications
+24240E|Apple
+242642|SHARP Corporation.
+242FFA|Toshiba Global Commerce Solutions
+24374C|Cisco
+2437EF|EMC Electronic Media Communication SA
+243C20|Dynamode Group
+2442BC|Alinco,incorporated
+244597|GEMUE Gebr. Mueller Apparatebau
+24470E|PentronicAB
+24497B|Innovative Converged Devices Inc
+244B03|Samsung
+244B81|Samsung
+244F1D|iRule LLC
+245FDF|KYOCERA Corporation
+246278|sysmocom - systems for mobile communications GmbH
+2464EF|CYG SUNRI CO.,LTD.
+246511|AVM GmbH
+24693E|innodisk Corporation
+24694A|Jasmine Systems Inc.
+2469A5|Huawei Technologies Co., Ltd
+246AAB|IT-IS International
+247189|Texas Instruments
+247656|Shanghai Net Miles Fiber Optics Technology Co., LTD.
+24767D|Cisco
+247703|Intel Corporate
+247F3C|Huawei Technologies Co., Ltd
+248000|Westcontrol AS
+2481AA|KSH International Co., Ltd.
+24828A|Prowave Technologies Ltd.
+2486F4|Ctek, Inc.
+248707|SEnergy Corporation
+2493CA|Voxtronic Technology Computer-Systeme GmbH
+249442|OPEN ROAD SOLUTIONS , INC.
+249504|SFR
+2497ED|Techvision Intelligent Technology Limited
+249EAB|HUAWEI TECHNOLOGIES CO.,LTD
+24A074|Apple
+24A2E1|Apple
+24A42C|KOUKAAM a.s.
+24A43C|Ubiquiti Networks
+24A495|Thales Canada Inc.
+24A87D|Panasonic Automotive Systems Asia Pacific(Thailand)Co.,Ltd.
+24A937|PURE Storage
+24AB81|Apple
+24AF4A|Alcatel-Lucent-IPD
+24AF54|NEXGEN Mediatech Inc.
+24B0A9|Shanghai Mobiletek Communication Ltd.
+24B657|Cisco
+24B6B8|FRIEM SPA
+24B6FD|Dell Inc
+24B88C|Crenus Co.,Ltd.
+24B8D2|Opzoon Technology Co.,Ltd.
+24BA30|Technical Consumer Products, Inc.
+24BBC1|Absolute Analysis
+24BC82|Dali Wireless, Inc.
+24BE05|Hewlett Packard
+24BF74|ASSIGNED - PRIVATE REGISTRATION 
+24C0B3|RSF
+24C696|Samsung
+24C848|mywerk system GmbH
+24C86E|Chaney Instrument Co.
+24C9A1|Ruckus Wireless
+24C9DE|Genoray
+24CBE7|MYK, Inc.
+24CF21|Shenzhen State Micro Technology Co., Ltd
+24D13F|MEXUS CO.,LTD
+24D2CC|SmartDrive Systems Inc.
+24D921|Avaya, Inc
+24DAB6|Sistemas de Gestion Energetica S.A. de C.V
+24DBAC|Shenzhen Huawei Communication Technologies Co., Ltd
+24DBAD|ShopperTrak RCT Corporation
+24DBED|Samsung
+24DEC6|Aruba Networks
+24E271|Qingdao Hisense Communications Co.,Ltd
+24E314|Apple
+24E5AA|Philips Oral Healthcare, Inc.
+24E6BA|JSC Zavod im. Kozitsky
+24E9B3|Cisco
+24EA40|Systeme Helmholz GmbH
+24EB65|SAET I.S. S.r.l.
+24EC99|Askey Computer Corp
+24ECD6|CSG Science & Technology Co.,Ltd.Hefei
+24EE3A|Chengdu Yingji Electronic Hi-tech Co Ltd
+24F0FF|GHT Co., Ltd.
+24F2DD|Radiant Zemax LLC
+24F5AA|Samsung
+24FD52|Liteon Technology Corporation
+2804E0|FERMAX ELECTRONICA S.A.U.
+28061E|NINGBO GLOBAL USEFUL ELECTRIC CO.,LTD
+28068D|ITL, LLC
+280B5C|Apple
+280CB8|Mikrosay Yazilim ve Elektronik A.S.
+280DFC|Sony Computer Entertainment Inc.
+28107B|D-Link International
+281471|Lantis co., LTD.
+28162E|2Wire
+2817CE|Omnisense Ltd
+281878|Microsoft
+2818FD|Aditya Infotech Ltd.
+282246|Beijing Sinoix Communication Co., LTD
+2826A6|PBR electronics GmbH
+28285D|ZyXEL Communications Corporation
+2829CC|Corsa Technology Incorporated
+2829D9|GlobalBeiMing technology (Beijing)Co. Ltd
+282CB2|TP-LINK TECHNOLOGIES CO.,LTD.
+283152|HUAWEI TECHNOLOGIES CO.,LTD
+2832C5|Humax.co.,ltd
+283410|Enigma Diagnostics Limited
+2834A2|Cisco
+283737|Apple
+2838CF|Gen2wave
+2839E7|Preceno Technology Pte.Ltd.
+283B96|Cool Control LTD
+283CE4|Huawei Technologies Co., Ltd
+28401A|C8 MediSensors, Inc.
+284121|OptiSense Network, LLC
+284430|GenesisTechnical Systems (UK) Ltd
+2847AA|Nokia Corporation
+284846|GridCentric Inc.
+284C53|Intune Networks
+284D92|Luminator
+284ED7|OutSmart Power Systems, Inc.
+284FCE|Liaoning Wontel Science and Technology Development Co.,Ltd.
+285132|Shenzhen Prayfly Technology Co.,Ltd
+2852E0|Layon international Electronic & Telecom Co.,Ltd
+285767|Echostar Technologies Corp
+285AEB|Apple
+285FDB|Shenzhen Huawei Communication Technologies Co., Ltd
+286046|Lantech Communications Global, Inc.
+286094|CAPELEC
+286336|Siemens AG - Industrial Automation - EWA
+28656B|Keystone Microtech Corporation
+286AB8|Apple
+286ABA|Apple
+286D97|SAMJIN Co., Ltd.
+286ED4|HUAWEI TECHNOLOGIES CO.,LTD
+287184|Spire Payments
+2872C5|Smartmatic Corp
+2872F0|ATHENA
+287610|IgniteNet
+287994|Realplay Digital Technology(Shenzhen) Co.,Ltd
+288023|Hewlett Packard
+2884FA|SHARP Corporation
+28852D|Touch Networks
+288915|CashGuard Sverige AB
+288A1C|Juniper networks
+2891D0|Stage Tec Entwicklungsgesellschaft fur professionelle Audiotechnik mbH
+28924A|Hewlett Packard
+2893FE|Cisco
+28940F|Cisco
+2894AF|Samhwa Telecom
+28987B|Samsung
+289A4B|SteelSeries ApS
+289AFA|TCT Mobile Limited
+289EDF|Danfoss Turbocor Compressors, Inc
+28A186|enblink
+28A192|GERP Solution
+28A1EB|ETEK TECHNOLOGY (SHENZHEN) CO.,LTD
+28A241|exlar corp
+28A574|Miller Electric Mfg. Co.
+28A5EE|Shenzhen SDGI CATV Co., Ltd
+28AF0A|Sirius XM Radio Inc
+28B0CC|Xenya d.o.o.
+28B2BD|Intel Corporate
+28B3AB|Genmark Automation
+28BA18|NextNav, LLC
+28BAB5|Samsung
+28BB59|RNET Technologies, Inc.
+28BE9B|Technicolor USA Inc.
+28C0DA|Juniper Networks
+28C2DD|AzureWave Technologies, Inc.
+28C671|Yota Devices OY
+28C68E|Netgear
+28C718|Altierre
+28C7CE|Cisco
+28C825|DellKing Industrial Co., Ltd
+28C914|Taimag Corporation
+28CBEB|One
+28CC01|Samsung
+28CCFF|Corporacion Empresarial Altra SL
+28CD1C|Espotel Oy
+28CD4C|Individual Computers GmbH
+28CD9C|Shenzhen Dynamax Software Development Co.,Ltd.
+28CFDA|Apple
+28CFE9|Apple
+28D1AF|Nokia Corporation
+28D244|LCFC(HeFei) Electronics Technology Co., Ltd.
+28D576|Premier Wireless, Inc.
+28D93E|Telecor Inc.
+28D98A|Hangzhou Konke Technology Co.,Ltd.
+28D997|Yuduan Mobile Co., Ltd.
+28DB81|Shanghai Guao Electronic Technology Co., Ltd
+28DEF6|bioMerieux Inc.
+28E02C|Apple
+28E14C|Apple
+28E297|Shanghai InfoTM Microelectronics Co.,Ltd.
+28E31F|Xiaomi
+28E347|Liteon Technology Corporation
+28E476|Pi-Coral
+28E608|Tokheim
+28E6E9|SIS Sat Internet Services GmbH
+28E794|Microtime Computer Inc.
+28E7CF|Apple
+28ED58|JAG Jakob AG
+28EE2C|Frontline Test Equipment
+28EF01|ASSIGNED - PRIVATE REGISTRATION 
+28F358|2C - Trifonov & Co
+28F532|ADD-Engineering BV
+28F606|Syes srl
+28FBD3|Ragentek Technology Group
+28FC51|The Electric Controller and Manufacturing Co., LLC
+28FCF6|Shenzhen Xin KingBrand enterprises Co.,Ltd
+28FD80|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+2C002C|UNOWHY
+2C0033|EControls, LLC
+2C00F7|XOS
+2C010B|NASCENT Technology, LLC - RemKon
+2C0623|Win Leader Inc.
+2C073C|DEVLINE LIMITED
+2C10C1|Nintendo Co., Ltd.
+2C18AE|Trend Electronics Co., Ltd.
+2C1984|IDN Telecom, Inc.
+2C1A31|Electronics Company Limited
+2C1EEA|AERODEV
+2C1F23|Apple
+2C2172|Juniper Networks
+2C245F|Babolat VS
+2C265F|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+2C26C5|zte corporation
+2C27D7|Hewlett-Packard Company
+2C282D|BBK COMMUNICATIAO TECHNOLOGY CO.,LTD.
+2C2997|Microsoft
+2C2D48|bct electronic GesmbH
+2C3068|Pantech Co.,Ltd
+2C337A|Hon Hai Precision Ind. Co.,Ltd.
+2C3427|ERCO & GENER
+2C3557|ELLIY Power CO..Ltd
+2C36A0|Capisco Limited
+2C36F8|Cisco
+2C3731|ShenZhen Yifang Digital Technology Co.,LTD
+2C3796|CYBO CO.,LTD.
+2C3996|SAGEMCOM
+2C39C1|Ciena Corporation
+2C3A28|Fagor Electronica
+2C3BFD|Netstor Technology Co., Ltd.
+2C3ECF|Cisco
+2C3F38|Cisco
+2C3F3E|Alge-Timing GmbH
+2C4138|Hewlett-Packard Company
+2C4401|Samsung
+2C441B|Spectrum Medical Limited
+2C44FD|Hewlett Packard
+2C5089|Shenzhen Kaixuan Visual Technology Co.,Limited
+2C534A|Shenzhen Winyao Electronic Limited
+2C542D|Cisco
+2C54CF|LG Electronics
+2C553C|Gainspeed, Inc.
+2C59E5|Hewlett Packard
+2C5A05|Nokia Corporation
+2C5AA3|PROMATE ELECTRONIC CO.LTD
+2C5BE1|Centripetal Networks, Inc
+2C5D93|Ruckus Wireless
+2C5FF3|Pertronic Industries
+2C600C|QUANTA COMPUTER INC.
+2C625A|Finest Security Systems Co., Ltd
+2C6289|Regenersis (Glenrothes) Ltd
+2C67FB|ShenZhen Zhengjili Electronics Co., LTD
+2C69BA|RF Controls, LLC
+2C6A6F|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+2C6BF5|Juniper networks
+2C7155|HiveMotion
+2C72C3|Soundmatters
+2C750F|Shanghai Dongzhou-Lawton Communication Technology Co. Ltd.
+2C768A|Hewlett-Packard Company
+2C7B5A|Milper Ltd
+2C7B84|OOO Petr Telegin
+2C7ECF|Onzo Ltd
+2C8065|HARTING Inc. of North America
+2C8158|Hon Hai Precision Ind. Co.,Ltd
+2C8A72|HTC Corporation
+2C8BF2|Hitachi Metals America Ltd
+2C9127|Eintechno Corporation
+2C922C|Kishu Giken Kogyou Company Ltd,.
+2C9464|Cincoze Co., Ltd.
+2C957F|zte corporation
+2C9717|I.C.Y. B.V.
+2C9AA4|NGI SpA
+2C9E5F|ARRIS Group, Inc.
+2C9EFC|CANON INC.
+2CA157|acromate, Inc.
+2CA2B4|Fortify Technologies, LLC
+2CA30E|POWER DRAGON DEVELOPMENT LIMITED
+2CA780|True Technologies Inc.
+2CA835|RIM
+2CAB25|Shenzhen Gongjin Electronics Co.,Ltd
+2CABA4|Cisco
+2CAD13|SHENZHEN ZHILU TECHNOLOGY CO.,LTD
+2CB05D|Netgear
+2CB0DF|Soliton Technologies Pvt Ltd
+2CB43A|Apple
+2CB693|Radware
+2CB69D|RED Digital Cinema
+2CBE08|Apple
+2CBE97|Ingenieurbuero Bickele und Buehler GmbH
+2CC260|Ravello Systems
+2CC548|IAdea Corporation
+2CC5D3|Ruckus Wireless
+2CCC15|Nokia Corporation
+2CCD27|Precor Inc
+2CCD43|Summit Technology Group
+2CCD69|Aqavi.com
+2CD05A|Liteon Technology Corporation
+2CD141|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+2CD1DA|Sanjole, Inc.
+2CD2E7|Nokia Corporation
+2CD444|Fujitsu Limited
+2CDD0C|Discovergy GmbH
+2CE2A8|DeviceDesign
+2CE412|SAGEMCOM SAS
+2CE6CC|Ruckus Wireless
+2CE871|Alert Metalguard ApS
+2CEDEB|Alpheus Digital Company Limited
+2CEE26|Petroleum Geo-Services
+2CF0EE|Apple
+2CF203|EMKO ELEKTRONIK SAN VE TIC AS
+2CF4C5|Avaya, Inc
+2CF7F1|Seeed Technology Inc.
+2CFAA2|Alcatel-Lucent
+30055C|Brother industries, LTD.
+300B9C|Delta Mobile Systems, Inc.
+300D2A|Zhejiang Wellcom Technology Co.,Ltd.
+300ED5|Hon Hai Precision Ind.Co.Ltd
+300EE3|Aquantia Corporation
+3010B3|Liteon Technology Corporation
+3010E4|Apple
+30142D|Piciorgros GmbH
+30144A|Wistron Neweb Corp.
+301518|Ubiquitous Communication Co. ltd.
+30168D|ProLon
+3017C8|Sony Ericsson Mobile Communications AB
+3018CF|DEOS control systems GmbH
+301966|Samsung
+301A28|Mako Networks Ltd
+30215B|Shenzhen Ostar Display Electronic Co.,Ltd
+302DE8|JDA, LLC (JDA Systems)
+303294|W-IE-NE-R Plein & Baus GmbH
+3032D4|Hanilstm Co., Ltd.
+303335|Boosty
+3037A6|Cisco
+303855|Nokia Corporation
+303926|Sony Ericsson Mobile Communications AB
+303955|Shenzhen Jinhengjia Electronic Co., Ltd.
+3039F2|ADB Broadband Italia
+303A64|Intel Corporate
+303D08|GLINTT TES S.A.
+303EAD|Sonavox Canada Inc
+304174|ALTEC LANSING LLC
+304225|BURG-WACHTER KG
+304449|PLATH GmbH
+30469A|Netgear
+30493B|Nanjing Z-Com Wireless Co.,Ltd
+304C7E|Panasonic Electric Works Automation Controls Techno Co.,Ltd.
+304EC3|Tianjin Techua Technology Co., Ltd.
+3051F8|BYK-Gardner GmbH
+30525A|NST Co., LTD
+3055ED|Trex Network LLC
+3057AC|IRLAB LTD.
+30595B|streamnow AG
+3059B7|Microsoft
+305D38|Beissbarth
+306023|ARRIS Group, Inc.
+306112|PAV GmbH
+306118|Paradom Inc.
+3065EC|Wistron (ChongQing)
+30688C|Reach Technology Inc.
+30694B|RIM
+306CBE|Skymotion Technology (HK) Limited
+306E5C|Validus Technologies
+3071B2|Hangzhou Prevail Optoelectronic Equipment Co.,LTD.
+307350|Inpeco SA
+307512|Sony Mobile Communications AB
+30766F|LG Electronics
+3077CB|Maike Industry(Shenzhen)CO.,LTD
+30786B|TIANJIN Golden Pentagon Electronics Co., Ltd.
+3078C2|Innowireless, Co. Ltd.
+307C30|RIM
+307ECB|SFR
+3085A9|Asustek Computer Inc
+308730|Shenzhen Huawei Communication Technologies Co., Ltd
+308999|Guangdong East Power Co.,
+3089D3|HONGKONG UCLOUDLINK NETWORK TECHNOLOGY LIMITED
+308CFB|Dropcam
+3090AB|Apple
+30918F|Technicolor
+3092F6|SHANGHAI SUNMON COMMUNICATION TECHNOGY CO.,LTD
+309BAD|BBK Electronics Corp., Ltd.,
+30A8DB|Sony Mobile Communications AB
+30AABD|Shanghai Reallytek Information Technology Co.,Ltd
+30AE7B|Deqing Dusun Electron CO., LTD
+30AEF6|Radio Mobile Access
+30B216|Hytec Geraetebau GmbH
+30B3A2|Shenzhen Heguang Measurement & Control Technology Co.,Ltd
+30B5C2|TP-LINK TECHNOLOGIES CO.,LTD.
+30B5F1|Aitexin Technology Co., Ltd
+30C750|MIC Technology Group
+30C7AE|Samsung
+30C82A|Wi-Next s.r.l.
+30CDA7|Samsung
+30D17E|HUAWEI TECHNOLOGIES CO.,LTD
+30D357|Logosol, Inc.
+30D46A|Autosales Incorporated
+30D587|Samsung
+30D6C9|Samsung
+30DE86|Cedac Software S.r.l.
+30E48E|Vodafone UK
+30E4DB|Cisco
+30EB25|INTEK DIGITAL
+30EFD1|Alstom Strongwish (Shenzhen) Co., Ltd.
+30F31D|zte corporation
+30F335|HUAWEI TECHNOLOGIES CO.,LTD
+30F33A|+plugg srl
+30F42F|ESP
+30F70D|Cisco
+30F7C5|Apple
+30F7D7|Thread Technology Co., Ltd
+30F9ED|Sony Corporation
+30FAB7|Tunai Creative
+30FD11|MACROTECH (USA) INC.
+3400A3|HUAWEI TECHNOLOGIES CO.,LTD
+340286|Intel Corporate
+34029B|CloudBerry Technologies Private Limited
+3407FB|Ericsson AB
+340804|D-Link Corporation
+340A22|TOP-ACCESS ELECTRONICS CO LTD
+340AFF|Qingdao Hisense Communications Co.,Ltd
+340B40|MIOS ELETTRONICA SRL
+341298|Apple
+3413A8|Mediplan Limited
+3413E8|Intel Corporate
+34159E|Apple
+3417EB|Dell Inc
+341A4C|SHENZHEN WEIBU ELECTRONICS CO.,LTD.
+341B22|Grandbeing Technology Co., Ltd
+342109|Jensen Scandinavia AS
+342387|Hon Hai Precision Ind. Co.,Ltd.
+3423BA|Samsung
+34255D|Shenzhen Loadcom Technology Co.,Ltd
+3428F0|ATN International Limited
+3429EA|MCD ELECTRONICS SP. Z O.O.
+342F6E|Anywire corporation
+343111|Samsung
+3431C4|AVM GmbH
+34363B|Apple
+3438AF|Inlab Software GmbH
+343D98|Fujian JinQianMao Electronic Technology Co.,Ltd.
+3440B5|IBM
+34466F|HiTEM Engineering
+344B3D|Fiberhome Telecommunication Tech.Co.,Ltd.
+344B50|ZTE Corporation
+344CA4|amazipoint technology Ltd.
+344DEA|zte corporation
+344DF7|LG Electronics
+344F3F|IO-Power Technology Co., Ltd.
+344F5C|R&amp;M AG
+344F69|EKINOPS SAS
+3451AA|JID GLOBAL
+3451C9|Apple
+345B11|EVI HEAT AB
+345C40|Cargt Holdings LLC
+345D10|Wytek
+346178|The Boeing Company
+346288|Cisco
+3464A9|Hewlett Packard
+34684A|Teraworks Co., Ltd.
+346895|Hon Hai Precision Ind. Co.,Ltd.
+346BD3|Huawei Technologies Co., Ltd
+346C0F|Pramod Telecom Pvt. Ltd
+346E8A|Ecosense
+346F90|Cisco
+346F92|White Rodgers Division
+3475C7|Avaya, Inc
+3476C5|I-O DATA DEVICE, INC.
+347877|O-NET Communications(Shenzhen) Limited
+347A60|Pace plc
+347E39|Nokia Danmark A/S
+348137|UNICARD SA
+3481C4|AVM GmbH
+3482DE|Kayo Technology, Inc.
+348302|iFORCOM Co., Ltd
+348446|Ericsson AB
+34862A|Heinz Lackmann GmbH & Co KG
+34873D|Quectel Wireless Solution Co.,Ltd.
+34885D|Logitech Far East
+348AAE|SAGEMCOM SAS
+3495DB|Logitec Corporation
+3497FB|ADVANCED RF TECHNOLOGIES INC
+34996F|VPI Engineering
+3499D7|Universal Flow Monitors, Inc.
+349A0D|ZBD Displays Ltd
+349B5B|Maquet GmbH
+349D90|Heinzmann GmbH & CO. KG
+349E34|Evervictory Electronic Co.Ltd
+34A183|AWare, Inc
+34A395|Apple
+34A3BF|Terewave. Inc.
+34A55D|TECHNOSOFT INTERNATIONAL SRL
+34A5E1|Sensorist ApS
+34A68C|Shine Profit Development Limited
+34A709|Trevil srl
+34A7BA|Fischer International Systems Corporation
+34A843|KYOCERA Display Corporation
+34A84E|Cisco
+34AA8B|Samsung
+34AA99|Alcatel-Lucent
+34AAEE|Mikrovisatos Servisas UAB
+34ADE4|Shanghai Chint Power Systems Co., Ltd.
+34AF2C|Nintendo Co., Ltd.
+34B1F7|Texas Instruments
+34B571|PLDS
+34B7FD|Guangzhou Younghead Electronic Technology Co.,Ltd
+34BA51|Se-Kure Controls, Inc.
+34BA9A|Asiatelco Technologies Co.
+34BB1F|Research In Motion
+34BB26|Motorola
+34BCA6|Beijing Ding Qing Technology, Ltd.
+34BDC8|Cisco
+34BDF9|Shanghai WDK Industrial Co.,Ltd.
+34BDFA|Cisco
+34BE00|Samsung
+34BF90|Fiberhome Telecommunication Tech.Co.,Ltd.
+34C059|Apple
+34C3AC|Samsung
+34C5D0|Hagleitner Hygiene International GmbH
+34C69A|Enecsys Ltd
+34C731|ALPS Co,. Ltd.
+34C803|Nokia Corporation
+34C99D|EIDOLON COMMUNICATIONS TECHNOLOGY CO. LTD.
+34CC28|Nexpring Co. LTD.,
+34CD6D|CommSky Technologies
+34CDBE|Huawei Technologies Co., Ltd
+34CE94|Parsec (Pty) Ltd
+34D09B|MobilMAX Technology Inc.
+34D2C4|RENA GmbH Print Systeme
+34D7B4|Tributary Systems, Inc.
+34DBFD|Cisco
+34DE1A|Intel Corporate
+34DE34|zte corporation
+34DF2A|Fujikon Industrial Co.,Limited
+34E0CF|zte corporation
+34E0D7|DONGGUAN QISHENG ELECTRONICS INDUSTRIAL CO., LTD
+34E2FD|Apple
+34E42A|Automatic Bar Controls Inc.
+34E6AD|Intel Corporate
+34E6D7|Dell Inc.
+34EF44|2Wire
+34EF8B|NTT Communications Corporation
+34F0CA|Shenzhen Linghangyuan Digital Technology Co.,Ltd.
+34F39B|WizLAN Ltd.
+34F62D|SHARP Corporation
+34F6D2|Panasonic Taiwan Co.,Ltd.
+34F968|ATEK Products, LLC
+34FA40|Guangzhou Robustel Technologies Co., Limited
+34FC6F|ALCEA
+34FCEF|LG Electronics
+380197|Toshiba Samsung Storage Technolgoy Korea Corporation
+3806B4|A.D.C. GmbH
+3808FD|Silca Spa
+3809A4|Firefly Integrations
+380A0A|Sky-City Communication and Electronics Limited Company
+380A94|Samsung
+380B40|Samsung
+380DD4|Primax Electronics LTD.
+380E7B|V.P.S. Thai Co., Ltd
+380F4A|Apple
+380FE4|Dedicated Network Partners Oy
+3816D1|Samsung
+381766|PROMZAKAZ LTD.
+38192F|Nokia Corporation
+381C1A|Cisco
+381C4A|SIMCom Wireless Solutions Co.,Ltd.
+38229D|Pirelli Tyre S.p.A.
+3822D6|H3C Technologies Co., Limited
+38262B|UTran Technology
+3826CD|ANDTEK
+3828EA|Fujian Netcom Technology Co., LTD
+382B78|ECO PLUGS ENTERPRISE CO., LTD
+382C4A|ASUSTek COMPUTER INC.
+382DD1|Samsung
+3831AC|WEG
+383BC8|2wire
+383F10|DBL Technology Ltd.
+384233|Wildeboer Bauteile GmbH
+3842A6|Ingenieurbuero Stahlkopf
+384369|Patrol Products Consortium LLC
+38458C|MyCloud Technology corporation
+384608|ZTE Corporation
+38484C|Apple
+384B76|AIRTAME ApS
+384FF0|Azurewave Technologies, Inc.
+38521A|Alcatel-Lucent 7705
+38580C|Panaccess Systems GmbH
+3859F8|MindMade sp. z o.o.
+3859F9|Hon Hai Precision Ind. Co.,Ltd.
+385AA8|Beijing Zhongdun Security Technology Development Co.
+385FC3|Yu Jeong System, Co.Ltd
+386077|PEGATRON CORPORATION
+3863BB|Hewlett Packard
+3863F6|3NOD MULTIMEDIA(SHENZHEN)CO.,LTD
+386645|OOSIC Technology CO.,Ltd
+386793|Asia Optical Co., Inc.
+386BBB|ARRIS Group, Inc.
+386C9B|Ivy Biomedical
+386E21|Wasion Group Ltd.
+3872C0|COMTREND
+387B47|AKELA, Inc.
+388345|TP-LINK TECHNOLOGIES CO., LTD.
+3889DC|Opticon Sensors Europe B.V.
+388AB7|ITC Networks
+388EE7|Fanhattan LLC
+3891FB|Xenox Holding BV
+389496|Samsung
+389592|Beijing Tendyron Corporation
+389F83|OTN Systems N.V.
+38A53C|Veenstra Instruments
+38A5B6|SHENZHEN MEGMEET ELECTRICAL CO.,LTD
+38A851|Moog, Ing
+38A86B|Orga BV
+38A95F|Actifio Inc
+38AA3C|Samsung
+38B12D|Sonotronic Nagel GmbH
+38B1DB|Hon Hai Precision Ind. Co.,Ltd.
+38B5BD|E.G.O. Elektro-Ger
+38B74D|Fijowave Limited
+38BB23|OzVision America LLC
+38BB3C|Avaya, Inc
+38BC1A|Meizu technology co.,ltd
+38BF2F|Espec Corp.
+38BF33|NEC CASIO Mobile Communications
+38C096|ALPS ELECTRIC CO.,LTD.
+38C70A|WiFiSong
+38C7BA|CS Services Co.,Ltd.
+38C85C|Cisco
+38C9A9|SMART High Reliability Solutions, Inc.
+38CA97|Contour Design LLC
+38D135|EasyIO Corporation Sdn. Bhd.
+38D82F|zte corporation
+38DBBB|Sunbow Telecom Co., Ltd.
+38DE60|Mohlenhoff GmbH
+38E08E|Mitsubishi Electric Corporation
+38E595|Shenzhen Gongjin Electronics Co.,Ltd
+38E7D8|HTC Corporation
+38E8DF|b gmbh medien + datenbanken
+38E98C|Reco S.p.A.
+38EAA7|Hewlett Packard
+38EC11|Novatek Microelectronics Corp.
+38ECE4|Samsung
+38EE9D|Anedo Ltd.
+38F098|Vapor Stone Rail Systems
+38F33F|TATSUNO CORPORATION
+38F597|home2net GmbH
+38F708|National Resource Management, Inc.
+38F889|Huawei Technologies Co., Ltd
+38F8B7|V2COM PARTICIPACOES S.A.
+38FACA|Skyworth Digital Technology(Shenzhen) Co.,Ltd
+38FEC5|Ellips B.V.
+3C02B1|Creation Technologies LP
+3C04BF|PRAVIS SYSTEMS Co.Ltd.,
+3C05AB|Product Creation Studio
+3C0754|Apple
+3C0771|Sony Corporation
+3C081E|Beijing Yupont Electric Power Technology Co.,Ltd
+3C08F6|Cisco
+3C096D|Powerhouse Dynamics
+3C0C48|Servergy, Inc.
+3C0E23|Cisco
+3C0FC1|KBC Networks
+3C1040|daesung network
+3C106F|ALBAHITH TECHNOLOGIES
+3C15C2|Apple
+3C15EA|TESCOM CO., LTD.
+3C189F|Nokia Corporation
+3C18A0|Luxshare Precision Industry Co.,Ltd.
+3C1915|GFI Chrono Time
+3C197D|Ericsson AB
+3C1A0F|ClearSky Data
+3C1A57|Cardiopulmonary Corp
+3C1A79|Huayuan Technology CO.,LTD
+3C1CBE|JADAK LLC
+3C1E04|D-Link International
+3C1E13|HANGZHOU SUNRISE TECHNOLOGY CO., LTD
+3C25D7|Nokia Corporation
+3C26D5|Sotera Wireless
+3C2763|SLE quality engineering GmbH & Co. KG
+3C2C94|HangZhou Delan Technology Co.,Ltd
+3C2DB7|Texas Instruments
+3C2F3A|SFORZATO Corp.
+3C300C|Dewar Electronics Pty Ltd
+3C3178|Qolsys Inc.
+3C363D|Nokia Corporation
+3C36E4|Arris Group, Inc.
+3C3888|ConnectQuest, llc
+3C39C3|JW Electronics Co., Ltd.
+3C39E7|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+3C3A73|Avaya, Inc
+3C404F|Guangdong Pisen Electronics Co. Ltd.
+3C438E|ARRIS Group, Inc.
+3C46D8|TP-LINK TECHNOLOGIES CO.,LTD.
+3C4711|HUAWEI TECHNOLOGIES CO.,LTD
+3C4937|ASSMANN Electronic GmbH
+3C4A92|Hewlett-Packard Company
+3C4C69|Infinity System S.L.
+3C4E47|Etronic A/S
+3C57BD|Kessler Crane Inc.
+3C57D5|FiveCo
+3C5A37|Samsung
+3C5AB4|Google
+3C5EC3|Cisco
+3C5F01|Synerchip Co., Ltd.
+3C6104|Juniper Networks
+3C6200|Samsung
+3C6278|SHENZHEN JETNET TECHNOLOGY CO.,LTD.
+3C672C|Sciovid Inc.
+3C6A7D|Niigata Power Systems Co., Ltd.
+3C6A9D|Dexatek Technology LTD.
+3C6E63|Mitron OY
+3C6F45|Fiberpro Inc.
+3C6FF7|EnTek Systems, Inc.
+3C7059|MakerBot Industries
+3C7437|RIM
+3C754A|ARRIS Group, Inc.
+3C77E6|Hon Hai Precision Ind. Co.,Ltd.
+3C7DB1|Texas Instruments
+3C81D8|SAGEMCOM SAS
+3C8375|Microsoft
+3C83B5|Advance Vision Electronics Co. Ltd.
+3C86A8|Sangshin elecom .co,, LTD
+3C89A6|KAPELSE
+3C8AB0|Juniper Networks
+3C8AE5|Tensun Information Technology(Hangzhou) Co.,LTD
+3C8BFE|Samsung
+3C8C40|Hangzhou H3C Technologies Co., Limited
+3C912B|Vexata Inc
+3C9157|Hangzhou Yulong Conmunication Co.,Ltd
+3C9174|ALONG COMMUNICATION TECHNOLOGY
+3C94D5|Juniper Networks
+3C970E|Wistron InfoComm(Kunshan)Co.,Ltd.
+3C977E|IPS Technology Limited
+3C98BF|Quest Controls, Inc.
+3C99F7|Lansentechnology AB
+3C9F81|Shenzhen CATIC Bit Communications Technology Co.,Ltd
+3CA10D|Samsung
+3CA315|Bless Information & Communications Co., Ltd
+3CA31A|Oilfind International LLC
+3CA72B|MRV Communications (Networks) LTD
+3CA82A|Hewlett Packard
+3CA9F4|Intel Corporate
+3CAA3F|iKey, Ltd.
+3CAB8E|Apple
+3CAE69|ESA Elektroschaltanlagen Grimma GmbH
+3CB15B|Avaya, Inc
+3CB17F|Wattwatchers Pty Ld
+3CB792|Hitachi Maxell, Ltd., Optronics Division
+3CB87A|ZZZZ 
+3CB9A6|Belden Deutschland GmbH
+3CBDD8|LG Electronics
+3CC0C6|d&b audiotechnik GmbH
+3CC12C|AES Corporation
+3CC1F6|Melange Systems Pvt. Ltd.
+3CC243|Nokia Corporation
+3CC2E1|XINHUA CONTROL ENGINEERING CO.,LTD
+3CC99E|Huiyang Technology Co., Ltd
+3CCA87|Iders Incorporated
+3CCB7C|TCT mobile ltd
+3CCD5A|Technische Alternative GmbH
+3CCD93|LG Electronics
+3CCE15|Mercedes-Benz USA, LLC
+3CCE73|Cisco
+3CD0F8|Apple
+3CD16E|Telepower Communication Co., Ltd
+3CD4D6|WirelessWERX, Inc
+3CD7DA|SK Mtek microelectronics(shenzhen)limited
+3CD92B|Hewlett-Packard Company
+3CD9CE|Eclipse WiFi
+3CDA2A|zte corporation
+3CDF1E|Cisco
+3CDFA9|ARRIS Group, Inc.
+3CDFBD|Huawei Technologies Co., Ltd
+3CE072|Apple
+3CE5A6|Hangzhou H3C Technologies Co., Ltd.
+3CE5B4|KIDASEN INDUSTRIA E COMERCIO DE ANTENAS LTDA
+3CE624|LG Display
+3CEA4F|2Wire
+3CEAFB|NSE AG
+3CF392|Virtualtek. Co. Ltd
+3CF52C|DSPECIALISTS GmbH
+3CF72A|Nokia Corporation
+3CF748|Shenzhen Linsn Technology Development Co.,Ltd
+3CF808|HUAWEI TECHNOLOGIES CO.,LTD
+3CFB96|Emcraft Systems LLC
+3CFDFE|Intel Corporate
+400107|Arista Corp
+4001C6|3COM EUROPE LTD
+40040C|A&T
+4007C0|Railtec Systems GmbH
+400E67|Tremol Ltd.
+400E85|Samsung
+4011DC|Sonance
+4012E4|Compass-EOS
+4013D9|Global ES
+401597|Protect America, Inc.
+40167E|ASUSTek COMPUTER INC.
+40169F|TP-LINK TECHNOLOGIES CO., LTD.
+4016FA|EKM Metering
+4018B1|Aerohive Networks Inc.
+4018D7|Smartronix, Inc.
+401D59|Biometric Associates, LP
+4022ED|Digital Projection Ltd
+4025C2|Intel Corporate
+40270B|Mobileeco Co., Ltd
+402814|RFI Engineering
+402BA1|Sony Ericsson Mobile Communications AB
+402CF4|Universal Global Scientific Industrial Co., Ltd.
+403004|Apple
+403067|Conlog (Pty) Ltd
+40336C|Godrej & Boyce Mfg. co. ltd
+4037AD|Macro Image Technology, Inc.
+403CFC|Apple
+404022|ZIV
+40406B|Icomera
+4045DA|Spreadtrum Communications (Shanghai) Co., Ltd.
+404A03|ZyXEL Communications Corporation
+404A18|Addrek Smart Solutions
+404D8E|Shenzhen Huawei Communication Technologies Co., Ltd
+404EEB|Higher Way Electronic Co., Ltd.
+4050E0|Milton Security Group LLC
+40516C|Grandex International Corporation
+40520D|Pico Technology
+405539|Cisco
+40560C|In Home Displays Ltd
+405A9B|ANOVO
+405FBE|RIM
+405FC2|Texas Instruments
+40605A|Hawkeye Tech Co. Ltd
+406186|MICRO-STAR INT'L CO.,LTD
+40618E|Stella-Green Co
+4062B6|Tele system communication
+40667A|mediola - connected living AG
+406826|Thales UK Limited
+406AAB|RIM
+406C8F|Apple
+406F2A|Research In Motion
+407009|ARRIS Group, Inc.
+40704A|Power Idea Technology Limited
+407074|Life Technology (China) Co., Ltd
+407496|aFUN TECHNOLOGY INC.
+40786A|Motorola
+407875|IMBEL - Industria de Material Belico do Brasil
+407A80|Nokia Corporation
+407B1B|Mettle Networks Inc.
+407FE0|Glory Star Technics (ShenZhen) Limited
+408256|Continental Automotive GmbH
+4083DE|Zebra Technologies Inc
+408493|Clavister AB
+4088E0|Beijing Ereneben Information Technology Limited Shenzhen Branch
+408A9A|TITENG CO., Ltd.
+408B07|Actiontec Electronics, Inc
+408BF6|Shenzhen TCL New Technology Co; Ltd.
+408D5C|GIGA-BYTE TECHNOLOGY CO.,LTD.
+409558|Aisino Corporation
+4097D1|BK Electronics cc
+40984C|Casacom Solutions AG
+40984E|Texas Instruments
+40987B|Aisino Corporation
+409B0D|Shenzhen Yourf Kwan Industrial Co., Ltd
+409FC7|BAEKCHUN I&C Co., Ltd.
+40A5EF|Shenzhen Four Seas Global Link Network Technology Co., Ltd.
+40A677|Juniper Networks
+40A6A4|PassivSystems Ltd
+40A6D9|Apple
+40A6E8|Cisco
+40A8F0|Hewlett Packard
+40AC8D|Data Management, Inc.
+40B0FA|LG Electronics
+40B2C8|Nortel Networks
+40B395|Apple
+40B3CD|Chiyoda Electronics Co.,Ltd.
+40B3FC|Logital Co. Limited
+40B4F0|Juniper Networks
+40B6B1|SUNGSAM CO,.Ltd
+40B7F3|ARRIS Group, Inc.
+40B837|Sony Mobile Communications AB
+40B89A|Hon Hai Precision Ind. Co.,Ltd.
+40BA61|Arima Communications Corp.
+40BC73|Cronoplast  S.L.
+40BC8B|itelio GmbH
+40BD9E|Physio-Control, Inc
+40BF17|Digistar Telecom. SA
+40C245|Shenzhen Hexicom Technology Co., Ltd.
+40C4D6|ChongQing Camyu Technology Development Co.,Ltd.
+40C62A|Shanghai Jing Ren Electronic Technology Co., Ltd.
+40C7C9|Naviit Inc.
+40CBA8|Huawei Technologies Co., Ltd
+40CD3A|Z3 Technology
+40D28A|Nintendo Co., Ltd.
+40D32D|Apple
+40D40E|Biodata Ltd
+40D559|MICRO S.E.R.I.
+40D855|IEEE REGISTRATION AUTHORITY - Please see IAB public listing for more information.
+40E230|AzureWave Technologies, Inc.
+40E730|DEY Storage Systems, Inc.
+40E793|Shenzhen Siviton Technology Co.,Ltd
+40EACE|FOUNDER BROADBAND NETWORK SERVICE CO.,LTD
+40ECF8|Siemens AG
+40EF4C|Fihonest communication co., Ltd
+40F02F|Liteon Technology Corporation
+40F14C|ISE Europe SPRL
+40F201|SAGEMCOM
+40F2E9|IBM
+40F308|Murata Manufactuaring Co.,Ltd.
+40F407|Nintendo Co., Ltd.
+40F4EC|Cisco
+40F52E|Leica Microsystems (Schweiz) AG
+40FC89|ARRIS Group, Inc.
+4403A7|Cisco
+440CFD|NetMan Co., Ltd.
+4411C2|Telegartner Karl Gartner GmbH
+441319|WKK TECHNOLOGY LTD.
+44184F|Fitview
+4419B6|Hangzhou Hikvision Digital Technology Co.,Ltd.
+441E91|ARVIDA Intelligent Electronics Technology  Co.,Ltd.
+441EA1|Hewlett-Packard Company
+4423AA|Farmage Co., Ltd.
+4425BB|Bamboo Entertainment Corporation
+442938|NietZsche enterprise Co.Ltd.
+442A60|Apple
+442AFF|E3 Technology, Inc.
+442B03|Cisco
+443192|Hewlett Packard
+44322A|Avaya, Inc
+4432C8|Technicolor USA Inc.
+44334C|Shenzhen Bilian electronic CO.,LTD
+44348F|MXT INDUSTRIAL LTDA
+44356F|Neterix
+443719|2 Save Energy Ltd
+44376F|Young Electric Sign Co
+4437E6|Hon Hai Precision Ind.Co.Ltd
+443839|Cumulus Networks, inc
+4439C4|Universal Global Scientific Industrial Co.,Ltd
+443C9C|Pintsch Tiefenbach GmbH
+443D21|Nuvolt
+443EB2|DEOTRON Co., LTD.
+444891|HDMI Licensing, LLC
+444A65|Silverflare Ltd.
+444C0C|Apple
+444E1A|Samsung
+444F5E|Pan Studios Co.,Ltd.
+4451DB|Raytheon BBN Technologies
+4454C0|Thompson Aerospace
+4455B1|HUAWEI TECHNOLOGIES CO.,LTD
+44568D|PNC Technologies  Co., Ltd.
+4456B7|Spawn Labs, Inc
+445829|Cisco
+44599F|Criticare Systems, Inc
+445ECD|Razer Inc
+445EF3|Tonalite Holding B.V.
+445F7A|Shihlin Electric & Engineering Corp.
+446132|ecobee inc
+44619C|FONsystem co. ltd.
+44666E|IP-LINE
+446755|Orbit Irrigation
+4468AB|JUIN COMPANY, LIMITED
+446C24|Reallin Electronic Co.,Ltd
+446D57|Liteon Technology Corporation
+446D6C|Samsung
+44700B|IFFU
+447098|MING HONG TECHNOLOGY (SHEN ZHEN) LIMITED
+44746C|Sony Mobile Communications AB
+447BC4|DualShine Technology(SZ)Co.,Ltd
+447C7F|Innolight Technology Corporation
+447DA5|VTION INFORMATION TECHNOLOGY (FUJIAN) CO.,LTD
+447E76|Trek Technology (S) Pte Ltd
+447E95|Alpha and Omega, Inc
+4480EB|Motorola
+448312|Star-Net
+448500|Intel Corporate
+4486C1|Siemens Low Voltage & Products
+4487FC|ELITEGROUP COMPUTER SYSTEM CO., LTD.
+4488CB|Camco Technologies NV
+448A5B|Micro-Star INT'L CO., LTD.
+448C52|KTIS CO., Ltd
+448E12|DT Research, Inc.
+448E81|VIG
+4491DB|Shanghai Huaqin Telecom Technology Co.,Ltd
+4494FC|Netgear
+4495FA|Qingdao Santong Digital Technology Co.Ltd
+44962B|Aidon Oy
+449B78|The Now Factory
+449CB5|Alcomp, Inc
+44A42D|TCT Mobile Limited
+44A689|PROMAX ELECTRONICA SA
+44A6E5|THINKING TECHNOLOGY CO.,LTD
+44A7CF|Murata Manufacturing Co., Ltd.
+44A842|Dell Inc.
+44A8C2|SEWOO TECH CO., LTD
+44AA27|udworks Co., Ltd.
+44AAE8|Nanotec Electronic GmbH & Co. KG
+44ADD9|Cisco
+44B382|Kuang-chi Institute of Advanced Technology
+44C15C|Texas Instruments
+44C233|Guangzhou Comet Technology Development Co.Ltd
+44C306|SIFROM Inc.
+44C39B|OOO RUBEZH NPO
+44C4A9|Opticom Communication, LLC
+44C56F|NGN Easy Satfinder (Tianjin) Electronic Co., Ltd
+44C69B|Wuhan Feng Tian Information Network CO.,LTD
+44C9A2|Greenwald Industries
+44CE7D|SFR
+44D15E|Shanghai Kingto Information Technology Ltd
+44D244|Seiko Epson Corporation
+44D2CA|Anvia TV Oy
+44D3CA|Cisco
+44D4E0|Sony Mobile Communications AB
+44D63D|Talari Networks
+44D832|Azurewave Technologies, Inc.
+44D884|Apple
+44D9E7|Ubiquiti Networks
+44DC91|PLANEX COMMUNICATIONS INC.
+44DCCB|SEMINDIA SYSTEMS PVT LTD
+44E08E|Cisco
+44E137|ARRIS Group, Inc.
+44E49A|OMNITRONICS PTY LTD
+44E4D9|Cisco
+44E8A5|Myreka Technologies Sdn. Bhd.
+44E9DD|SAGEMCOM SAS
+44ED57|Longicorn, inc.
+44EE30|Budelmann Elektronik GmbH
+44F436|zte corporation
+44F459|Samsung
+44F477|Juniper Networks
+44F849|Union Pacific Railroad
+44FB42|Apple
+48022A|B-Link Electronic Limited
+480362|DESAY ELECTRONICS(HUIZHOU)CO.,LTD
+48066A|Tempered Networks, Inc.
+480C49|NAKAYO TELECOMMUNICATIONS,INC
+480FCF|Hewlett Packard
+481249|Luxcom Technologies Inc.
+4813F3|BBK Electronics Corp., Ltd.
+48174C|MicroPower technologies
+481842|Shanghai Winaas Co. Equipment Co. Ltd.
+481A84|Pointer Telocation Ltd
+481BD2|Intron Scientific co., ltd.
+481D70|Cisco
+4826E8|Tek-Air Systems, Inc.
+48282F|ZTE Corporation
+482CEA|Motorola
+4833DD|ZENNIO AVANCE Y TECNOLOGIA, S.L.
+48343D|IEP GmbH
+483D32|Syscor Controls &amp; Automation
+48437C|Apple
+484487|Cisco
+4844F7|Samsung
+4846F1|Uros Oy
+4846FB|HUAWEI TECHNOLOGIES CO.,LTD
+485073|Microsoft
+4851B7|Intel Corporate
+485261|SOREEL
+485415|NET RULES TECNOLOGIA EIRELI
+48555F|Fiberhome Telecommunication Tech.Co.,Ltd.
+4857DD|Facebook
+485929|LG Electronics
+485A3F|WISOL
+485AB6|Hon Hai Precision Ind. Co.,Ltd.
+485B39|ASUSTek COMPUTER INC.
+485D36|Verizon
+485D60|Azurewave Technologies, Inc.
+4860BC|Apple
+4861A3|Concern "Axion" JSC
+486276|HUAWEI TECHNOLOGIES CO.,LTD
+486B2C|BBK Electronics Corp., Ltd.,
+486B91|Fleetwood Group Inc.
+486E73|Pica8, Inc.
+486EFB|Davit System Technology Co., Ltd.
+486FD2|StorSimple Inc
+487119|SGB GROUP LTD.
+48746E|Apple
+488244|Life Fitness / Div. of Brunswick
+4886E8|Microsoft
+488E42|DIGALOG GmbH
+489153|Weinmann Gerate fur Medizin GmbH + Co. KG
+4891F6|Shenzhen Reach software technology CO.,LTD
+489BE2|SCI Innovations Ltd
+489D18|Flashbay Limited
+489D24|Research In Motion
+48A22D|Shenzhen Huaxuchang Telecom Technology Co.,Ltd
+48A2B7|Kodofon JSC
+48A6D2|GJsun Optical Science and Tech Co.,Ltd.
+48A9D2|Wistron Neweb Corp.
+48AA5D|Store Electronic Systems
+48B253|Marketaxess Corporation
+48B5A7|Glory Horse Industries Ltd.
+48B8DE|HOMEWINS TECHNOLOGY CO.,LTD.
+48B977|PulseOn Oy
+48B9C2|Teletics Inc.
+48BE2D|Symanitron
+48C093|Xirrus, Inc.
+48C1AC|PLANTRONICS, INC.
+48C862|Simo Wireless,Inc.
+48C8B6|SysTec GmbH
+48CB6E|Cello Electronics (UK) Ltd
+48D0CF|Universal Electronics, Inc.
+48D18E|Metis Communication Co.,Ltd
+48D224|Liteon Technology Corporation
+48D54C|Jeda Networks
+48D705|Apple
+48D7FF|BLANKOM Antennentechnik GmbH
+48D855|Telvent
+48D8FE|ClarIDy Solutions, Inc.
+48DCFB|Nokia Corporation
+48DF1C|Wuhan NEC Fibre Optic Communications industry Co. Ltd
+48E1AF|Vity
+48E9F1|Apple
+48EA63|Zhejiang Uniview Technologies Co., Ltd.
+48EB30|ETERNA TECHNOLOGY, INC.
+48ED80|daesung eltec
+48EE07|Silver Palm Technologies LLC
+48EE0C|D-Link International
+48EE86|UTStarcom (China) Co.,Ltd
+48F230|Ubizcore Co.,LTD
+48F317|ZZZZ 
+48F47D|TechVision Holding  Internation Limited
+48F7F1|Alcatel-Lucent
+48F8B3|Cisco
+48F8E1|Alcatel Lucent WT
+48F925|Maestronic
+48FCB8|Woodstream Corporation
+48FEEA|HOMA B.V.
+4C0082|Cisco
+4C022E|CMR KOREA CO., LTD
+4C0289|LEX COMPUTECH CO., LTD
+4C068A|Basler Electric Company
+4C07C9|COMPUTER OFFICE Co.,Ltd.
+4C09B4|zte corporation
+4C09D4|Arcadyan Technology Corporation
+4C0B3A|TCT Mobile Limited
+4C0BBE|Microsoft
+4C0DEE|JABIL CIRCUIT (SHANGHAI) LTD.
+4C0F6E|Hon Hai Precision Ind. Co.,Ltd.
+4C0FC7|Earda Electronics Co.,Ltd
+4C11BF|ZHEJIANG DAHUA TECHNOLOGY CO.,LTD.
+4C1480|NOREGON SYSTEMS, INC
+4C14A3|TCL Technoly Electronics (Huizhou) Co., Ltd.
+4C16F1|zte corporation
+4C17EB|SAGEMCOM
+4C1A3A|PRIMA Research And Production Enterprise Ltd.
+4C1A95|Novakon Co., Ltd.
+4C1FCC|HUAWEI TECHNOLOGIES CO.,LTD
+4C21D0|Sony Mobile Communications AB
+4C2258|cozybit, Inc.
+4C2578|Nokia Corporation
+4C26E7|Welgate Co., Ltd.
+4C2C80|Beijing Skyway Technologies Co.,Ltd
+4C2C83|Zhejiang KaNong Network Technology Co.,Ltd.
+4C2F9D|ICM Controls
+4C3089|Thales Transportation Systems GmbH
+4C322D|TELEDATA NETWORKS
+4C32D9|M Rutty Holdings Pty. Ltd.
+4C3488|Intel Corporate
+4C3909|HPL Electric & Power Private Limited
+4C3910|Newtek Electronics co., Ltd.
+4C3B74|VOGTEC(H.K.) Co., Ltd
+4C3C16|Samsung
+4C48DA|Beijing Autelan Technology Co.,Ltd
+4C4B68|Mobile Device, Inc.
+4C4E35|Cisco
+4C5427|Linepro Sp. z o.o.
+4C5499|Shenzhen Huawei Communication Technologies Co., Ltd
+4C5585|Hamilton Systems
+4C55B8|Turkcell Teknoloji
+4C55CC|ACKme Networks Pty Ltd
+4C5DCD|Oy Finnish Electric Vehicle Technologies Ltd
+4C5E0C|Routerboard.com
+4C5FD2|Alcatel-Lucent
+4C60D5|airPointe of New Hampshire
+4C60DE|Netgear
+4C6255|SANMINA-SCI SYSTEM DE MEXICO S.A. DE C.V.
+4C63EB|Application Solutions (Electronics and Vision) Ltd
+4C64D9|Guangdong Leawin Group Co., Ltd
+4C6E6E|Comnect Technology CO.,LTD
+4C72B9|Pegatron Corporation
+4C7367|Genius Bytes Software Solutions GmbH
+4C73A5|KOVE
+4C7403|Mundo Reader (bq)
+4C7625|Dell Inc.
+4C774F|Embedded Wireless Labs
+4C7897|Arrowhead Alarm Products Ltd
+4C79BA|Intel Corporate
+4C7C5F|Apple
+4C7F62|Nokia Corporation
+4C804F|Armstrong Monitoring Corp
+4C8093|Intel Corporate
+4C82CF|Echostar Technologies
+4C83DE|Cisco
+4C8B30|Actiontec Electronics, Inc
+4C8B55|Grupo Digicon
+4C8BEF|Huawei Technologies Co., Ltd
+4C8D79|Apple
+4C8FA5|Jastec
+4C9614|Juniper Networks
+4C98EF|Zeo
+4C9E80|KYOKKO ELECTRIC Co., Ltd.
+4C9EE4|Hanyang Navicom Co.,Ltd.
+4C9EFF|ZyXEL Communications Corp
+4CA515|Baikal Electronics JSC
+4CA56D|Samsung
+4CA74B|Alcatel Lucent
+4CA928|Insensi
+4CAA16|AzureWave Technologies (Shanghai) Inc.
+4CAB33|KST technology
+4CAC0A|ZTE Corporation
+4CAE31|ShengHai Electronics (Shenzhen) Ltd
+4CB16C|HUAWEI TECHNOLOGIES CO.,LTD
+4CB199|Apple
+4CB4EA|HRD (S) PTE., LTD.
+4CB76D|Novi Security
+4CB81C|SAM Electronics GmbH
+4CB9C8|CONET CO., LTD.
+4CBAA3|Bison Electronics Inc.
+4CBB58|Chicony Electronics Co., Ltd.
+4CBC42|Shenzhen Hangsheng Electronics Co.,Ltd.
+4CBCA5|Samsung
+4CC452|Shang Hai Tyd. Electon Technology Ltd.
+4CC602|Radios, Inc.
+4CC94F|Alcatel-Lucent
+4CCA53|Skyera, Inc.
+4CCBF5|zte corporation
+4CCC34|Motorola
+4CD08A|HUMAX.CO.,LTD
+4CD637|Qsono Electronics Co., Ltd
+4CD7B6|Helmer Scientific
+4CD9C4|Magneti Marelli Automotive Electronics (Guangzhou) Co. Ltd
+4CDF3D|TEAM ENGINEERS ADVANCE TECHNOLOGIES INDIA PVT LTD
+4CE1BB|Zhuhai HiFocus Technology Co., Ltd.
+4CE2F1|sclak srl
+4CE676|Buffalo Inc.
+4CE933|RailComm, LLC
+4CEB42|Intel Corporate
+4CEDDE|Askey Computer Corp
+4CEEB0|SHC Netzwerktechnik GmbH
+4CF02E|Vifa Denmark A/S
+4CF2BF|Cambridge Industries(Group) Co.,Ltd.
+4CF45B|Blue Clover Devices
+4CF5A0|Scalable Network Technologies Inc
+4CF737|SamJi Electronics Co., Ltd
+50008C|Hong Kong Telecommunications (HKT) Limited
+5001BB|Samsung
+50053D|CyWee Group Ltd
+500604|Cisco
+500B32|Foxda Technology Industrial(ShenZhen)Co.,LTD
+500E6D|TrafficCast International
+5011EB|SilverNet Ltd
+5014B5|Richfit Information Technology Co., Ltd
+5017FF|Cisco
+501AC5|Microsoft
+501CBF|Cisco
+50206B|Emerson Climate Technologies Transportation Solutions
+502267|PixeLINK
+50252B|Nethra Imaging Incorporated
+502690|Fujitsu Limited
+5027C7|TECHNART Co.,Ltd
+50294D|NANJING IOT SENSOR TECHNOLOGY CO,LTD
+502A7E|Smart electronic GmbH
+502A8B|Telekom Research and Development Sdn Bhd
+502D1D|Nokia Corporation
+502DA2|Intel Corporate
+502DF4|Phytec Messtechnik GmbH
+502E5C|HTC Corporation
+502ECE|Asahi Electronics Co.,Ltd
+503275|Samsung
+503955|Cisco
+503CC4|Lenovo Mobile Communication Technology Ltd.
+503DE5|Cisco
+503F56|Syncmold Enterprise Corp
+50465D|ASUSTek COMPUTER INC.
+5048EB|BEIJING HAIHEJINSHENG NETWORK TECHNOLOGY CO. LTD.
+504A5E|Masimo Corporation
+504A6E|Netgear
+504F94|Loxone Electronics GmbH
+50502A|Egardia
+505065|TAKT Corporation
+505527|LG Electronics
+505663|Texas Instruments
+5056A8|Jolla Ltd
+5056BF|Samsung
+5057A8|Cisco
+505800|WyTec International, Inc.
+505AC6|GUANGDONG SUPER TELECOM CO.,LTD.
+506028|Xirrus Inc.
+506184|Avaya, Inc
+5061D6|Indu-Sol GmbH
+506313|Hon Hai Precision Ind. Co.,Ltd.
+506441|Greenlee
+5065F3|Hewlett Packard
+506787|iTellus
+5067AE|Cisco
+5067F0|ZyXEL Communications Corporation
+506A03|Netgear
+506F9A|Wi-Fi Alliance
+5070E5|He Shan World Fair Electronics Technology Limited
+507224|Texas Instruments
+50724D|BEG Brueck Electronic GmbH
+507691|Tekpea, Inc.
+5076A6|Ecil Informatica Ind. Com. Ltda
+50795B|Interexport Telecomunicaciones S.A.
+507D02|BIODIT
+507E5D|Arcadyan Technology Corporation
+508569|Samsung
+508789|Cisco
+5087B8|Nuvyyo Inc
+508A42|Uptmate Technology Co., LTD
+508ACB|SHENZHEN MAXMADE TECHNOLOGY CO., LTD.
+508C77|DIRMEIER Schanktechnik GmbH &Co KG
+508D6F|CHAHOO Limited
+50934F|Gradual Tecnologia Ltda.
+509772|Westinghouse Digital
+509871|Inventum Technologies Private Limited
+509F27|Huawei Technologies Co., Ltd
+50A054|Actineon
+50A0BF|Alba Fiber Systems Inc.
+50A4C8|Samsung
+50A6E3|David Clark Company
+50A715|Aboundi, Inc.
+50A733|Ruckus Wireless
+50ABBF|Hoseo Telecom
+50ADD5|Dynalec Corporation
+50AF73|Shenzhen Bitland Information Technology Co., Ltd.
+50B695|Micropoint Biotechnologies,Inc.
+50B7C3|Samsung
+50B888|wi2be Tecnologia S/A
+50B8A2|ImTech Technologies LLC,
+50BD5F|TP-LINK TECHNOLOGIES CO.,LTD.
+50C006|Carmanah Signs
+50C271|SECURETECH INC
+50C58D|Juniper Networks
+50C7BF|TP-LINK TECHNOLOGIES CO.,LTD.
+50C971|GN Netcom A/S
+50C9A0|SKIPPER Electronics AS
+50CCF8|Samsung
+50CD32|NanJing Chaoran Science & Technology Co.,Ltd.
+50CE75|Measy Electronics Ltd
+50D274|Steffes Corporation
+50D6D7|Takahata Precision
+50E0C7|TurControlSystme AG
+50E549|GIGA-BYTE TECHNOLOGY CO.,LTD.
+50EAD6|Apple
+50EB1A|Brocade Communications Systems, Inc.
+50ED78|Changzhou Yongse Infotech Co.,Ltd
+50ED94|Egatel SL
+50F003|Open Stack, Inc.
+50F0D3|Samsung
+50F43C|Leeo Inc
+50F520|Samsung
+50F61A|Kunshan JADE Technologies co., Ltd.
+50FAAB|L-tek d.o.o.
+50FC30|Treehouse Labs
+50FC9F|Samsung
+50FEF2|Sify Technologies Ltd
+5403F5|EBN Technology Corp.
+540496|Gigawave LTD
+5404A6|ASUSTek COMPUTER INC.
+540536|Vivago Oy
+54055F|Alcatel Lucent
+54098D|deister electronic GmbH
+54112F|Sulzer Pump Solutions Finland Oy
+54115F|Atamo Pty Ltd
+541473|Wingtech Group (HongKong) Limited
+541B5D|Techno-Innov
+541DFB|Freestyle Energy Ltd
+541FD5|Advantage Electronics
+542018|Tely Labs
+542160|Resolution Products
+5422F8|zte corporation
+542696|Apple
+54271E|AzureWave Technonloies, Inc.
+542A9C|LSY Defense, LLC.
+542AA2|Alpha Networks Inc.
+542CEA|PROTECTRON
+542F89|Euclid Laboratories, Inc.
+543131|Raster Vision Ltd
+543530|Hon Hai Precision Ind. Co.,Ltd.
+5435DF|Symeo GmbH
+54369B|1Verge Network Technology (Beijing) Co Ltd
+543968|Edgewater Networks Inc
+5439DF|HUAWEI TECHNOLOGIES CO.,LTD
+543D37|Ruckus Wireless
+5440AD|Samsung
+544249|Sony Corporation
+544408|Nokia Corporation
+54466B|Shenzhen CZTIC Electronic Technology Co., Ltd
+544A00|Cisco
+544A05|wenglor sensoric gmbh
+544A16|Texas Instruments
+545146|AMG Systems Ltd.
+5453ED|Sony Corporation
+545414|Digital RF Corea, Inc
+545EBD|NL Technologies
+545FA9|Teracom Limited
+546009|Google
+546172|ZODIAC AEROSPACE SAS
+5461EA|Zaplox AB
+5464D9|Sagemcom SAS
+5465DE|ARRIS Group, Inc.
+54724F|Apple
+547398|Toyo Electronics Corporation
+5474E6|Webtech Wireless
+5475D0|Cisco
+54781A|Cisco
+547975|Nokia Corporation
+547C69|Cisco
+547F54|INGENICO
+547FA8|TELCO systems, s.r.o.
+547FEE|Cisco
+5481AD|Eagle Research Corporation
+54847B|Digital Devices GmbH
+54880E|Samsung
+548922|Zelfy Inc
+548998|HUAWEI TECHNOLOGIES CO.,LTD
+5492BE|Samsung
+549359|SHENZHEN TWOWING TECHNOLOGIES CO.,LTD.
+549478|Silvershore Technology Partners
+549A11|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+549A16|Uzushio Electric Co.,Ltd.
+549B12|Samsung
+549D85|EnerAccess inc
+549F13|Apple
+549F35|Dell Inc.
+54A04F|t-mac Technologies Ltd
+54A050|ASUSTek COMPUTER INC.
+54A274|Cisco
+54A31B|Shenzhen Linkworld Technology Co,.LTD
+54A51B|Shenzhen Huawei Communication Technologies Co., Ltd
+54A54B|NSC Communications Siberia Ltd
+54A619|Alcatel-Lucent Shanghai Bell Co., Ltd
+54A9D4|Minibar Systems
+54AE27|Apple
+54B620|SUHDOL E&C Co.Ltd.
+54B753|Hunan Fenghui Yinjia Science And Technology Co.,Ltd
+54B80A|D-Link International
+54BEF7|PEGATRON CORPORATION
+54C80F|TP-LINK TECHNOLOGIES CO.,LTD.
+54CD10|Panasonic Mobile Communications Co.,Ltd.
+54CDA7|Fujian Shenzhou Electronic Co.,Ltd
+54CDEE|ShenZhen Apexis Electronic Co.,Ltd
+54D0ED|AXIM Communications
+54D163|MAX-TECH,INC
+54D1B0|Universal Laser Systems, Inc
+54D46F|Cisco
+54DF00|Ulterius Technologies, LLC
+54DF63|Intrakey technologies GmbH
+54E032|Juniper Networks
+54E140|INGENICO
+54E2C8|Dongguan Aoyuan Electronics Technology Co., Ltd
+54E2E0|Pace plc
+54E3B0|JVL Industri Elektronik
+54E43A|Apple
+54E4BD|FN-LINK TECHNOLOGY LIMITED
+54E63F|ShenZhen LingKeWeiEr Technology Co., Ltd.
+54E6FC|TP-LINK TECHNOLOGIES CO., LTD.
+54EAA8|Apple
+54EE75|Wistron InfoComm(Kunshan)Co.,Ltd.
+54EF92|Shenzhen Elink Technology Co., LTD
+54F5B6|ORIENTAL PACIFIC INTERNATIONAL LIMITED
+54F666|Berthold Technologies GmbH and Co.KG
+54F876|ABB AG
+54FA3E|Samsung
+54FB58|WISEWARE, Lda
+54FDBF|Scheidt & Bachmann GmbH
+54FFCF|Mopria Alliance
+5804CB|Tianjin Huisun Technology Co.,Ltd.
+580528|LABRIS NETWORKS
+580556|Elettronica GF S.r.L.
+5808FA|Fiber Optic & telecommunication INC.
+580943|ZZZZ 
+5809E5|Kivic Inc.
+580A20|Cisco
+58108C|Intelbras
+581243|AcSiP Technology Corp.
+581626|Avaya, Inc
+58170C|Sony Ericsson Mobile Communications AB
+581CBD|Affinegy
+581D91|Advanced Mobile Telecom co.,ltd.
+581F28|Huawei Technologies Co., Ltd
+581F67|Open-m technology limited
+581FAA|Apple
+581FEF|Tuttnaer LTD
+582136|KMB systems, s.r.o.
+58238C|Technicolor CH USA
+582AF7|Huawei Technologies Co., Ltd
+582EFE|Lighting Science Group
+582F42|Universal Electric Corporation
+58343B|Glovast Technology Ltd.
+5835D9|Cisco
+583CC6|Omneality Ltd.
+583F54|LG Electronics
+5842E4|Sigma International General Medical Apparatus, LLC.
+58468F|Koncar Electronics and Informatics
+5846E1|Baxter Healthcare
+584704| Shenzhen Webridge Technology Co.,Ltd
+5848C0|COFLEC
+58493B|Palo Alto Networks
+5849BA|Chitai Electronic Corp.
+584C19|Chongqing Guohong Technology Development Company Limited
+584CEE|Digital One Technologies, Limited
+585076|Linear Equipamentos Eletronicos SA
+5850AB|TLS Corporation
+5850E6|Best Buy Corporation
+5855CA|Apple
+5856E8|ARRIS Group, Inc.
+58570D|Danfoss Solar Inverters
+58639A|TPL SYSTEMES
+5865E6|INFOMARK CO., LTD.
+5866BA|Hangzhou H3C Technologies Co., Limited
+58671A|BARNES&NOBLE.COM
+58677F|Clare Controls Inc.
+58696C|Fujian Ruijie Networks co, ltd
+5869F9|Fusion Transactive Ltd.
+586AB1|Hangzhou H3C Technologies Co., Limited
+586D8F|Cisco
+586ED6|ASSIGNED - PRIVATE REGISTRATION 
+5870C6|Shanghai Xiaoyi Technology Co., Ltd.
+587521|CJSC RTSoft
+587675|Beijing ECHO Technologies Co.,Ltd
+5876C5|DIGI I'S LTD
+587A4D|Stonesoft Corporation
+587BE9|AirPro Technology India Pvt. Ltd
+587E61|Hisense Electric Co., Ltd
+587F66|Huawei Technologies Co., Ltd
+587FB7|SONAR INDUSTRIAL CO., LTD.
+587FC8|S2M
+5884E4|IP500 Alliance e.V.
+58856E|QSC AG
+58874C|LITE-ON CLEAN ENERGY TECHNOLOGY CORP.
+5887E2|Shenzhen Coship Electronics Co., Ltd.
+588D09|Cisco
+5891CF|Intel Corporate
+58920D|Kinetic Avionics Limited
+589396|Ruckus Wireless
+58946B|Intel Corporate
+5894CF|Vertex Standard LMR, Inc.
+58971E|Cisco
+589835|Technicolor
+58986F|Revolution Display
+589B0B|Shineway Technologies, Inc.
+589CFC|FreeBSD Foundation
+58A2B5|LG Electronics
+58A76F|iD corporation
+58A839|Intel Corporate
+58B035|Apple
+58B0D4|ZuniData Systems Inc.
+58B961|SOLEM Electronique
+58B9E1|Crystalfontz America, Inc.
+58BC27|Cisco
+58BDA3|Nintendo Co., Ltd.
+58BDF9|Sigrand
+58BFEA|Cisco
+58C232|NEC Corporation
+58C38B|Samsung
+58CF4B|Lufkin Industries
+58D071|BW Broadcast
+58D08F|IEEE 1904.1 Working Group
+58D6D3|Dairy Cheq Inc
+58DB8D|Fast Co., Ltd.
+58E02C|Micro Technic A/S
+58E326|Compass Technologies Inc.
+58E476|CENTRON COMMUNICATIONS TECHNOLOGIES FUJIAN CO.,LTD
+58E636|EVRsafe Technologies
+58E747|Deltanet AG
+58E808|AUTONICS CORPORATION
+58EB14|Proteus Digital Health
+58ECE1|Newport Corporation
+58EECE|Icon Time Systems
+58F387|HCCP
+58F39C|Cisco
+58F67B|Xia Men UnionCore Technology LTD.
+58F6BF|Kyoto University
+58F98E|SECUDOS GmbH
+58FCDB|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+58FD20|Bravida Sakerhet AB
+5C026A|Applied Vision Corporation
+5C076F|Thought Creator
+5C0A5B|Samsung
+5C0CBB|CELIZION Inc.
+5C0E8B|Zebra Technologies Inc
+5C1193|Seal One AG
+5C1437|Thyssenkrupp Aufzugswerke GmbH
+5C1515|ADVAN
+5C15E1|AIDC TECHNOLOGY (S) PTE LTD
+5C16C7|Big Switch Networks
+5C1737|I-View Now, LLC.
+5C17D3|LGE
+5C18B5|Talon Communications
+5C20D0|Asoni Communication Co., Ltd.
+5C22C4|DAE EUN ELETRONICS CO., LTD
+5C2479|Baltech AG
+5C254C|Avire Global Pte Ltd
+5C260A|Dell Inc.
+5C2AEF|Open Access Pty Ltd
+5C2BF5|Vivint
+5C2E59|Samsung
+5C2ED2|ABC(XiSheng) Electronics Co.,Ltd
+5C313E|Texas Instruments
+5C3327|Spazio Italia srl
+5C335C|Swissphone Telecom AG
+5C338E|Alpha Networkc Inc.
+5C353B|Compal Broadband Networks Inc.
+5C35DA|There Corporation Oy
+5C36B8|TCL King Electrical Appliances (Huizhou) Ltd.
+5C38E0|Shanghai Super Electronics Technology Co.,LTD
+5C3B35|Gehirn Inc.
+5C3C27|Samsung
+5C4058|Jefferson Audio Video Systems, Inc.
+5C41E7|Wiatec International Ltd.
+5C43D2|HAZEMEYER
+5C4527|Juniper Networks
+5C4A26|Enguity Technology Corp
+5C4CA9|Shenzhen Huawei Communication Technologies Co., Ltd
+5C5015|Cisco
+5C514F|Intel Corporate
+5C56ED|3pleplay Electronics Private Limited
+5C571A|ARRIS Group, Inc.
+5C57C8|Nokia Corporation
+5C5948|Apple
+5C5B35|Mist Systems, Inc.
+5C5BC2|YIK Corporation
+5C5EAB|Juniper Networks
+5C63BF|TP-LINK TECHNOLOGIES CO., LTD.
+5C6984|NUVICO
+5C6A7D|KENTKART EGE ELEKTRONIK SAN. VE TIC. LTD. STI.
+5C6B32|Texas Instruments
+5C6D20|Hon Hai Precision Ind. Co.,Ltd.
+5C6F4F|S.A. SISTEL
+5C7757|Haivision Network Video
+5C7D5E|Huawei Technologies Co., Ltd
+5C8486|Brightsource Industries Israel LTD
+5C864A|Secret Labs LLC
+5C8778|Cybertelbridge co.,ltd
+5C899A|TP-LINK TECHNOLOGIES CO.,LTD
+5C89D4|Beijing Banner Electric Co.,Ltd
+5C8A38|Hewlett Packard
+5C8D4E|Apple
+5C8FE0|ARRIS Group, Inc.
+5C93A2|Liteon Technology Corporation
+5C95AE|Apple
+5C966A|RTNET
+5C969D|Apple
+5C97F3|Apple
+5C9AD8|Fujitsu Limited
+5CA178|TableTop Media (dba Ziosk)
+5CA39D|Samsung
+5CA3EB|Lokel s.r.o.
+5CA48A|Cisco
+5CAAFD|Sonos, Inc.
+5CAC4C|Hon Hai Precision Ind. Co.,Ltd.
+5CB395|HUAWEI TECHNOLOGIES CO.,LTD
+5CB43E|HUAWEI TECHNOLOGIES CO.,LTD
+5CB524|Sony Ericsson Mobile Communications AB
+5CB6CC|NovaComm Technologies Inc.
+5CB8CB|Allis Communications
+5CB901|Hewlett Packard
+5CBD9E|HONGKONG MIRACLE EAGLE TECHNOLOGY(GROUP) LIMITED
+5CC213|Fr. Sauter AG
+5CC5D4|Intel Corporate
+5CC6D0|Skyworth Digital technology(shenzhen)co.ltd.
+5CC9D3|PALLADIUM ENERGY ELETRONICA DA AMAZONIA LTDA
+5CCA32|Theben AG
+5CCCFF|Techroutes Network Pvt Ltd
+5CCEAD|CDYNE Corporation
+5CD135|Xtreme Power Systems
+5CD2E4|Intel Corporate
+5CD41B|UCZOON Technology Co., LTD
+5CD4AB|Zektor
+5CD61F|Qardio, Inc
+5CD998|D-Link Corporation
+5CDAD4|Murata Manufacturing Co., Ltd.
+5CDC96|Arcadyan Technology Corporation
+5CDD70|Hangzhou H3C Technologies Co., Limited
+5CE0C5|Intel Corporate
+5CE0CA|FeiTian United (Beijing) System Technology Co., Ltd.
+5CE0F6|NIC.br- Nucleo de Informacao e Coordenacao do Ponto BR
+5CE223|Delphin Technology AG
+5CE286|Nortel Networks
+5CE2F4|AcSiP Technology Corp.
+5CE7BF|New Singularity International Technical Development Co.,Ltd
+5CE8EB|Samsung
+5CEB4E|R. STAHL HMI Systems GmbH
+5CEB68|Cheerstar Technology Co., Ltd
+5CEE79|Global Digitech Co LTD
+5CF207|Speco Technologies
+5CF370|CC&C Technologies, Inc
+5CF3FC|IBM Corp
+5CF4AB|ZyXEL Communications Corp
+5CF50D|Institute of microelectronic applications
+5CF5DA|Apple
+5CF6DC|Samsung
+5CF7C3|SYNTECH (HK) TECHNOLOGY LIMITED
+5CF8A1|Murata Manufactuaring Co.,Ltd.
+5CF938|Apple
+5CF96A|Huawei Technologies Co., Ltd
+5CF9DD|Dell Inc
+5CF9F0|Atomos Engineering P/L
+5CFC66|Cisco
+5CFF35|Wistron Corporation
+5CFFFF|Shenzhen Kezhonglong Optoelectronic Technology Co., Ltd
+600292|PEGATRON CORPORATION
+6002B4|Wistron Neweb Corp.
+600308|Apple
+600347|Billion Electric Co. Ltd.
+600417|POSBANK CO.,LTD
+600F77|SilverPlus, Inc
+601199|Siama Systems Inc
+601283|Soluciones Tecnologicas para la Salud y el Bienestar SA
+60128B|CANON INC.
+6015C7|IdaTech
+60190C|RRAMAC
+601929|VOLTRONIC POWER TECHNOLOGY(SHENZHEN) CORP.
+601970|HUIZHOU QIAOXING ELECTRONICS TECHNOLOGY CO., LTD.
+601D0F|Midnite Solar
+601E02|EltexAlatau
+602103|STCUBE.INC
+6021C0|Murata Manufactuaring Co.,Ltd.
+6024C1|Jiangsu Zhongxun Electronic Technology Co., Ltd
+602A54|CardioTek B.V.
+602AD0|Cisco
+6032F0|Mplus technology
+60334B|Apple
+603553|Buwon Technology
+603696|The Sapling Company
+6036DD|Intel Corporate
+60380E|Alps Electric Co.,
+60391F|ABB Ltd
+603FC5|COX CO., LTD
+6044F5|Easy Digital Ltd.
+60455E|Liptel s.r.o.
+6045BD|Microsoft
+604616|XIAMEN VANN INTELLIGENT CO., LTD
+6047D4|FORICS Electronic Technology Co., Ltd.
+604826|Newbridge Technologies Int. Ltd.
+604A1C|SUYIN Corporation
+6050C1|Kinetek Sports
+60512C|TCT mobile limited
+6052D0|FACTS Engineering
+605464|Eyedro Green Solutions Inc.
+605718|Intel Corporate
+605BB4|AzureWave Technologies, Inc.
+60601F|SZ DJI TECHNOLOGY CO.,LTD
+6063FD|Transcend Communication Beijing Co.,Ltd.
+6064A1|RADiflow Ltd.
+606720|Intel Corporate
+606944|Apple
+60699B|isepos GmbH
+606BBD|Samsung
+606C66|Intel Corporate
+606DC7|Hon Hai Precision Ind. Co.,Ltd.
+60735C|Cisco
+60748D|Atmaca Elektronik
+607688|Velodyne
+6077E2|Samsung
+60812B|Custom Control Concepts
+6081F9|Helium Systems, Inc
+6083B2|GkWare e.K.
+60843B|Soladigm, Inc.
+608645|Avery Weigh-Tronix, LLC
+60893C|Thermo Fisher Scientific P.O.A.
+6089B1|Key Digital Systems
+6089B7|KAEL MUHENDISLIK ELEKTRONIK TICARET SANAYI LIMITED SIRKETI
+608C2B|Hanson Technology
+608D17|Sentrus Government Systems Division, Inc
+608F5C|Samsung
+609084|DSSD Inc
+609217|Apple
+6099D1|Vuzix / Lenovo
+609AA4|GVI SECURITY INC.
+609C9F|Brocade Communications Systems, Inc.
+609E64|Vivonic GmbH
+609F9D|CloudSwitch
+60A10A|Samsung
+60A44C|ASUSTek COMPUTER INC.
+60A8FE|Nokia Solutions and Networks
+60A9B0|Merchandising Technologies, Inc
+60AF6D|Samsung
+60B185|ATH system
+60B3C4|Elber Srl
+60B606|Phorus
+60B617|Fiberhome Telecommunication Tech.Co.,Ltd.
+60B933|Deutron Electronics Corp.
+60B982|RO.VE.R. Laboratories S.p.A.
+60BB0C|Beijing HuaqinWorld Technology Co,Ltd
+60BC4C|EWM Hightec Welding GmbH
+60BD91|Move Innovation
+60BEB5|Motorola
+60C1CB|Fujian Great Power PLC Equipment Co.,Ltd
+60C397|2Wire Inc
+60C547|Apple
+60C5A8|Beijing LT Honway Technology Co.,Ltd
+60C798|Verifone, Inc.
+60C980|Trymus
+60CBFB|AirScape Inc.
+60CDA9|Abloomy
+60CDC5|Taiwan Carol Electronics., Ltd
+60D0A9|Samsung
+60D1AA|Vishal Telecommunications Pvt Ltd
+60D2B9|REALAND BIO CO., LTD.
+60D30A|Quatius Limited
+60D819|Hon Hai Precision Ind. Co.,Ltd.
+60D9A0|Lenovo Mobile Communication Technology Ltd.
+60D9C7|Apple
+60DA23|Estech Co.,Ltd
+60DB2A|HNS
+60DE44|HUAWEI TECHNOLOGIES CO.,LTD
+60E00E|SHINSEI ELECTRONICS CO LTD
+60E327|TP-LINK TECHNOLOGIES CO.,LTD.
+60E6BC|Sino-Telecom Technology Co.,Ltd.
+60E701|Huawei Technologies Co., Ltd
+60E956|Ayla Networks, Inc
+60EB69|Quanta computer Inc.
+60F13D|JABLOCOM s.r.o.
+60F189|Murata Manufacturing Co., Ltd.
+60F281|TRANWO TECHNOLOGY CO., LTD.
+60F2EF|VisionVera International Co., Ltd.
+60F3DA|Logic Way GmbH
+60F494|Hon Hai Precision Ind. Co.,Ltd.
+60F59C|CRU-Dataport
+60F673|TERUMO CORPORATION
+60F81D|Apple
+60FACD|Apple
+60FB42|Apple
+60FE1E|China Palms Telecom.Ltd
+60FE20|2 Wire
+60FEC5|Apple
+60FEF9|Thomas & Betts
+60FFDD|C.E. ELECTRONICS, INC
+64002D|Powerlinq Co., LTD
+64006A|Dell Inc.
+6400F1|Cisco
+6405BE|NEW LIGHT LED
+64094C|Beijing Superbee Wireless Technology Co.,Ltd
+640980|Xiaomi
+640B4A|Digital Telecom Technology Limited
+640E36|TAZTAG
+640E94|Pluribus Networks, Inc.
+640F28|2wire
+641084|HEXIUM Technical Development Co., Ltd.
+641225|Cisco
+64167F|Polycom
+64168D|Cisco
+6416F0|Shehzhen Huawei Communication Technologies Co., Ltd.
+641A22|Heliospectra/Woodhill Investments
+641C67|DIGIBRAS INDUSTRIA DO BRASILS/A
+641E81|Dowslake Microsystems
+64200C|Apple
+642184|Nippon Denki Kagaku Co.,LTD
+642216|Shandong Taixin Electronic co., Ltd
+642400|Xorcom Ltd.
+642737|Hon Hai Precision Ind. Co.,Ltd.
+642DB7|SEUNGIL ELECTRONICS
+643150|Hewlett-Packard Company
+64317E|Dexin Corporation
+643409|BITwave Pte Ltd
+643AB1|SICHUAN TIANYI COMHEART TELECOMCO.,LTD
+643E8C|HUAWEI TECHNOLOGIES CO.,LTD
+643F5F|Exablaze
+644214|Swisscom Energy Solutions AG
+644346|GuangDong Quick Network Computer CO.,LTD
+644BC3|Shanghai WOASiS Telecommunications Ltd., Co.
+644BF0|CalDigit, Inc
+644D70|dSPACE GmbH
+644F74|LENUS Co., Ltd.
+644FB0|Hyunjin.com
+645106|Hewlett Packard
+64517E|LONG BEN (DONGGUAN) ELECTRONIC TECHNOLOGY CO.,LTD.
+645299|The Chamberlain Group, Inc
+64535D|Frauscher Sensortechnik
+645422|Equinox Payments
+645563|Intelight Inc.
+64557F|NSFOCUS Information Technology Co., Ltd.
+6455B1|ARRIS Group, Inc.
+645601|TP-LINK TECHNOLOGIES CO.,LTD
+6459F8|Vodafone Omnitel B.V.
+645A04|Chicony Electronics Co., Ltd.
+645DD7|Shenzhen Lifesense Medical Electronics Co., Ltd.
+645EBE|Yahoo! JAPAN
+645FFF|Nicolet Neuro
+646223|Cellient Co., Ltd.
+64649B|juniper networks
+6465C0|Nuvon, Inc
+6466B3|TP-LINK TECHNOLOGIES CO., LTD.
+646707|Beijing Omnific Technology, Ltd.
+64680C|COMTREND
+6469BC|Hytera Communications Co .,ltd
+646A52|Avaya, Inc
+646CB2|Samsung
+646E6C|Radio Datacom LLC
+646EEA|Iskratel d.o.o.
+647002|TP-LINK TECHNOLOGIES CO., LTD.
+6472D8|GooWi Technology Co.,Limited
+6473E2|Arbiter Systems, Inc.
+647657|Innovative Security Designs
+6476BA|Apple
+647791|Samsung
+647BD4|Texas Instruments
+647C34|Ubee Interactive Corp.
+647D81|YOKOTA INDUSTRIAL CO,.LTD
+647FDA|TEKTELIC Communications Inc.
+64808B|VG Controls, Inc.
+648099|Intel Corporate
+648125|Alphatron Marine BV
+648788|Juniper Networks
+6487D7|Pirelli Tyre S.p.A.
+6488FF|Sichuan Changhong Electric Ltd.
+64899A|LG Electronics
+648D9E|IVT Electronic Co.,Ltd
+64995D|LGE
+649968|Elentec
+6499A0|AG Elektronik AB
+649ABE|Apple
+649B24|V Technology Co., Ltd.
+649C81|Qualcomm iSkoot, Inc.
+649C8E|Texas Instruments
+649EF3|Cisco
+649FF7|Kone OYj
+64A0E7|Cisco
+64A232|OOO Samlight
+64A341|Wonderlan (Beijing) Technology Co., Ltd.
+64A3CB|Apple
+64A769|HTC Corporation
+64A7DD|Avaya, Inc
+64A837|Juni Korea Co., Ltd
+64AE0C|Cisco
+64AE88|Polytec GmbH
+64B21D|Chengdu Phycom Tech Co., Ltd.
+64B310|Samsung
+64B370|PowerComm Solutions LLC
+64B473|Xiaomi
+64B64A|ViVOtech, Inc.
+64B853|Samsung
+64B9E8|Apple
+64BABD|SDJ Technologies, Inc.
+64BC11|CombiQ AB
+64C5AA|South African Broadcasting Corporation
+64C667|Barnes&Noble
+64C6AF|AXERRA Networks Ltd
+64C944|LARK Technologies, Inc
+64D02D|Next Generation Integration (NGI)
+64D1A3|Sitecom Europe BV
+64D241|Keith & Koep GmbH
+64D4BD|ALPS ELECTRIC CO.,LTD.
+64D4DA|Intel Corporate
+64D814|Cisco
+64D912|Solidica, Inc.
+64D954|TAICANG AND W ELECTRONICS CO LTD
+64D989|Cisco
+64DB18|OpenPattern
+64DB81|Syszone Co., Ltd.
+64DC01|Static Systems Group PLC
+64DE1C|Kingnetic Pte Ltd
+64E161|DEP Corp.
+64E599|EFM Networks
+64E625|Woxu Wireless Co., Ltd
+64E682|Apple
+64E84F|Serialway Communication Technology Co. Ltd
+64E892|Morio Denki Co., Ltd.
+64E8E6|global moisture management system
+64E950|Cisco
+64EAC5|SiboTech Automation Co., Ltd.
+64EB8C|Seiko Epson Corporation
+64ED57|ARRIS Group, Inc.
+64ED62|WOORI SYSTEMS Co., Ltd
+64F242|Gerdes Aktiengesellschaft
+64F50E|Kinion Technology Company Limited
+64F69D|Cisco
+64F970|Kenade Electronics Technology Co.,LTD.
+64F987|Avvasi Inc.
+64FB81|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+64FC8C|Zonar Systems
+680571|Samsung
+6805CA|Intel Corporate
+680927|Apple
+680AD7|Yancheng Kecheng Optoelectronic Technology Co., Ltd
+68122D|Special Instrument Development Co., Ltd.
+681590|SAGEMCOM SAS
+6815D3|Zaklady Elektroniki i Mechaniki Precyzyjnej R&G S.A.
+681605|Systems And Electronic Development FZCO
+681729|Intel Corporate
+68193F|Digital Airways
+681AB2|zte corporation
+681CA2|Rosewill Inc.
+681D64|Sunwave Communications Co., Ltd
+681E8B|InfoSight Corporation
+681FD8|Advanced Telemetry
+68234B|Nihon Dengyo Kousaku
+6828BA|Dejai
+6828F6|Vubiq Networks, Inc.
+682DDC|Wuhan Changjiang Electro-Communication Equipment CO.,LTD
+6836B5|DriveScale, Inc.
+683B1E|Countwise LTD
+683C7D|Magic Intelligence Technology Limited
+683EEC|ERECA
+684352|Bhuu Limited
+684898|Samsung
+684B88|Galtronics Telemetry Inc.
+684CA8|Shenzhen Herotel Tech. Co., Ltd.
+6851B7|PowerCloud Systems, Inc.
+6854ED|Alcatel-Lucent - Nuage
+6854F5|enLighted Inc
+68597F|Alcatel Lucent
+685B35|Apple
+685B36|POWERTECH INDUSTRIAL CO., LTD.
+685D43|Intel Corporate
+685E6B|PowerRay Co., Ltd.
+686359|Advanced Digital Broadcast SA
+68644B|Apple
+68692E|Zycoo Co.,Ltd
+6869F2|ComAp s.r.o.
+686E23|Wi3 Inc.
+686E48|Prophet Electronic Technology Corp.,Ltd
+687251|Ubiquiti Networks
+6872DC|CETORY.TV Company Limited
+68764F|Sony Mobile Communications AB
+687848|Westunitis Co., Ltd.
+68784C|Nortel Networks
+687924|ELS-GmbH & Co. KG
+6879ED|SHARP Corporation
+687CC8|Measurement Systems S. de R.L.
+687CD5|Y Soft Corporation, a.s.
+687F74|Cisco
+68831A|Pandora Mobility Corporation
+688470|eSSys Co.,Ltd
+688540|IGI Mobile, Inc.
+68856A|OuterLink Corporation
+6886A7|Cisco
+6886E7|Orbotix, Inc.
+68876B|INQ Mobile Limited
+688AB5|EDP Servicos
+688F84|HUAWEI TECHNOLOGIES CO.,LTD
+689234|Ruckus Wireless
+689423|Hon Hai Precision Ind. Co.,Ltd.
+68967B|Apple
+68974B|Shenzhen Costar Electronics Co. Ltd.
+6897E8|Society of Motion Picture &amp; Television Engineers
+6899CD|Cisco
+689C5E|AcSiP Technology Corp.
+689C70|Apple
+689CE2|Cisco
+689E19|Texas Instruments
+68A0F6|Huawei Technologies Co., Ltd
+68A1B7|Honghao Mingchuan Technology (Beijing) CO.,Ltd.
+68A378|FREEBOX SAS
+68A3C4|Liteon Technology Corporation
+68A40E|BSH Bosch and Siemens Home Appliances GmbH
+68A86D|Apple
+68AAD2|DATECS LTD.,
+68AB8A|RF IDeas
+68AE20|Apple
+68AF13|Futura Mobility
+68B094|INESA ELECTRON CO.,LTD
+68B43A|WaterFurnace International, Inc.
+68B599|Hewlett-Packard Company
+68B6FC|Hitron Technologies. Inc
+68B8D9|Act KDE, Inc.
+68B983|b-plus GmbH
+68BC0C|Cisco
+68BDAB|Cisco
+68C90B|Texas Instruments
+68CA00|Octopus Systems Limited
+68CC9C|Mine Site Technologies
+68CD0F|U Tek Company Limited
+68CE4E|L-3 Communications Infrared Products
+68D1FD|Shenzhen Trimax Technology Co.,Ltd
+68D247|Portalis LC
+68D925|ProSys Development Services
+68D93C|Apple
+68DB67|Nantong Coship Electronics Co., Ltd
+68DB96|OPWILL Technologies CO .,LTD
+68DCE8|PacketStorm Communications
+68DFDD|Xiaomi
+68E41F|Unglaube Identech GmbH
+68EBAE|Samsung
+68EBC5|Angstrem Telecom
+68EC62|YODO Technology Corp. Ltd.
+68ED43|Research In Motion
+68EDA4|Shenzhen Seavo Technology Co.,Ltd
+68EE96|Cisco
+68EFBD|Cisco
+68F06D|ALONG INDUSTRIAL CO., LIMITED
+68F0BC|Shenzhen LiWiFi Technology Co., Ltd
+68F125|Data Controls Inc.
+68F728|LCFC(HeFei) Electronics Technology co., ltd
+68F895|Redflow Limited
+68FB95|Generalplus Technology Inc.
+68FCB3|Next Level Security Systems, Inc.
+6C0273|Shenzhen Jin Yun Video Equipment Co., Ltd.
+6C0460|RBH Access Technologies Inc.
+6C09D6|Digiquest Electronics LTD
+6C0B84|Universal Global Scientific Industrial Co.,Ltd.
+6C0E0D|Sony Ericsson Mobile Communications AB
+6C0F6A|JDC Tech Co., Ltd.
+6C14F7|Erhardt+Leimer GmbH
+6C15F9|Nautronix Limited
+6C1811|Decatur Electronics
+6C198F|D-Link International
+6C1E70|Guangzhou YBDS IT Co.,Ltd
+6C2056|Cisco
+6C22AB|Ainsworth Game Technology
+6C23B9|Sony Ericsson Mobile Communications AB
+6C25B9|BBK Electronics Corp., Ltd.,
+6C2995|Intel Corporate
+6C2C06|OOO NPP Systemotechnika-NN
+6C2E33|Accelink Technologies Co.,Ltd.
+6C2E72|B&B EXPORTING LIMITED
+6C2E85|SAGEMCOM
+6C2F2C|Samsung
+6C32DE|Indieon Technologies Pvt. Ltd.
+6C33A9|Magicjack LP
+6C391D|Beijing ZhongHuaHun Network Information center
+6C3A84|Shenzhen Aero-Startech. Co.Ltd
+6C3BE5|Hewlett Packard
+6C3C53|SoundHawk Corp
+6C3E6D|Apple
+6C3E9C|KE Knestel Elektronik GmbH
+6C4008|Apple
+6C40C6|Nimbus Data Systems, Inc.
+6C416A|Cisco
+6C4418|Zappware
+6C4598|Antex Electronic Corp.
+6C4B7F|Vossloh-Schwabe Deutschland GmbH
+6C504D|Cisco
+6C5779|Aclima, Inc.
+6C5940|SHENZHEN MERCURY COMMUNICATION TECHNOLOGIES CO.,LTD.
+6C5A34|Shenzhen Haitianxiong Electronic Co., Ltd.
+6C5AB5|TCL Technoly Electronics (Huizhou) Co., Ltd.
+6C5CDE|SunReports, Inc.
+6C5D63|ShenZhen Rapoo Technology Co., Ltd.
+6C5E7A|Ubiquitous Internet Telecom Co., Ltd
+6C5F1C|Lenovo Mobile Communication Technology Ltd.
+6C6126|Rinicom Holdings
+6C626D|Micro-Star INT'L CO., LTD
+6C641A|Penguin Computing
+6C6EFE|Core Logic Inc.
+6C6F18|Stereotaxis, Inc.
+6C7039|Novar GmbH
+6C709F|Apple
+6C71D9|AzureWave Technologies, Inc
+6C7660|KYOCERA Corporation
+6C81FE|Mitsuba Corporation
+6C8336|Samsung
+6C8366|Nanjing SAC Power Grid Automation Co., Ltd.
+6C8686|Technonia
+6C8814|Intel Corporate
+6C8B2F|zte corporation
+6C8CDB|Otus Technologies Ltd
+6C8D65|Wireless Glue Networks, Inc.
+6C90B1|SanLogic Inc
+6C92BF|Inspur Electronic Information Industry Co.,Ltd.
+6C94F8|Apple
+6C98EB|Ocedo GmbH
+6C9989|Cisco
+6C9AC9|Valentine Research, Inc.
+6C9B02|Nokia Corporation
+6C9CE9|Nimble Storage
+6C9CED|Cisco
+6CA100|Intel Corporate
+6CA682|EDAM information & communications
+6CA75F|zte corporation
+6CA780|Nokia Corporation
+6CA7FA|YOUNGBO ENGINEERING INC.
+6CA849|Avaya, Inc
+6CA906|Telefield Ltd
+6CA96F|TransPacket AS
+6CAAB3|Ruckus Wireless
+6CAB4D|Digital Payment Technologies
+6CAC60|Venetex Corp
+6CAD3F|Hubbell Building Automation, Inc.
+6CADEF|KZ Broadband Technologies, Ltd.
+6CADF8|Azurewave Technologies, Inc.
+6CAE8B|IBM Corporation
+6CB0CE|Netgear
+6CB311|Shenzhen Lianrui Electronics Co.,Ltd
+6CB350|Anhui comhigher tech co.,ltd
+6CB56B|HUMAX.CO.,LTD
+6CB7F4|Samsung
+6CBEE9|Alcatel-Lucent-IPD
+6CBFB5|Noon Technology Co., Ltd
+6CC1D2|ARRIS Group, Inc.
+6CC217|Hewlett Packard
+6CC26B|Apple
+6CCA08|ARRIS Group, Inc.
+6CD032|LG Electronics
+6CD146|Smartek d.o.o.
+6CD1B0|WING SING ELECTRONICS HONG KONG LIMITED
+6CD68A|LG Electronics
+6CDC6A|Promethean Limited
+6CE01E|Modcam AB
+6CE0B0|SOUND4
+6CE4CE|Villiger Security Solutions AG
+6CE873|TP-LINK TECHNOLOGIES CO., LTD.
+6CE907|Nokia Corporation
+6CE983|Gastron Co., LTD.
+6CECA1|SHENZHEN CLOU ELECTRONICS CO. LTD.
+6CECEB|Texas Instruments
+6CF049|GIGA-BYTE TECHNOLOGY CO.,LTD.
+6CF373|Samsung
+6CF37F|Aruba Networks
+6CF5E8|Mooredoll Inc.
+6CF97C|Nanoptix Inc.
+6CFA58|Avaya, Inc
+6CFA89|Cisco
+6CFAA7|AMPAK Technology Inc.
+6CFDB9|Proware Technologies Co Ltd.
+6CFFBE|MPB Communications Inc.
+700136|FATEK Automation Corporation
+700258|01DB-METRAVIB
+700514|LG Electronics
+700BC0|Dewav Technology Company
+700FC7|SHENZHEN IKINLOOP TECHNOLOGY CO.,LTD.
+700FEC|Poindus Systems Corp.
+70105C|Cisco
+701124|Apple
+701404|Limited Liability Company
+7014A6|Apple
+70188B|Hon Hai Precision Ind. Co.,Ltd.
+701A04|Liteon Tech Corp.
+701AED|ADVAS CO., LTD.
+701D7F|Comtech Technology Co., Ltd.
+702393|fos4X GmbH
+702526|Alcatel-Lucent
+702559|CyberTAN Technology, Inc.
+702A7D|EpSpot AB
+702B1D|E-Domus International Limited
+702C1F|Wisol
+702DD1|Newings Communication CO., LTD.
+702F4B|PolyVision Inc.
+702F97|Aava Mobile Oy
+703018|Avaya, Inc
+70305D|Ubiquoss Inc
+70305E|Nanjing Zhongke Menglian Information Technology Co.,LTD
+703187|ACX GmbH
+7032D5|Athena Wireless Communications Inc
+703811|Invensys Rail
+7038B4|Low Tech Solutions
+7038EE|Avaya, Inc
+703AD8|Shenzhen Afoundry Electronic Co., Ltd
+703C39|SEAWING Kft
+703EAC|Apple
+7041B7|Edwards Lifesciences LLC
+704642|CHYNG HONG ELECTRONIC CO., LTD.
+704AAE|Xstream Flow (Pty) Ltd
+704AE4|Rinstrum Pty Ltd
+704CED|TMRG, Inc.
+704E01|KWANGWON TECH CO., LTD.
+704E66|SHENZHEN FAST TECHNOLOGIES CO.,LTD
+7052C5|Avaya, Inc.
+70533F|Alfa Instrumentos Eletronicos Ltda.
+7054D2|PEGATRON CORPORATION
+7054F5|HUAWEI TECHNOLOGIES CO.,LTD
+705681|Apple
+705812|Panasonic AVC Networks Company
+705957|Medallion Instrumentation Systems
+705986|OOO TTV
+705AB6|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+705B2E|M2Communication Inc.
+705CAD|Konami Gaming Inc
+705EAA|Action Target, Inc.
+7060DE|LaVision GmbH
+706173|Calantec GmbH
+7062B8|D-Link International
+706417|ORBIS TECNOLOGIA ELECTRICA S.A.
+706582|Suzhou Hanming Technologies Co., Ltd.
+706879|Saijo Denki International Co., Ltd.
+706F81|ZZZZ 
+70704C|Purple Communications, Inc
+7071B3|Brain Corporation
+7071BC|PEGATRON CORPORATION
+70720D|Lenovo Mobile Communication Technology Ltd.
+70723C|Huawei Technologies Co., Ltd
+7072CF|EdgeCore Networks
+7073CB|Apple
+707630|Pace plc.
+7076DD|Oxyguard International A/S
+7076F0|LevelOne Communications (India) Private Limited
+7076FF|KERLINK
+707781|Hon Hai Precision Ind. Co.,Ltd.
+707BE8|HUAWEI TECHNOLOGIES CO.,LTD
+707C18|ADATA Technology Co., Ltd
+707E43|ARRIS Group, Inc.
+707EDE|NASTEC LTD.
+708105|Cisco
+70820E|as electronics GmbH
+70828E|OleumTech Corporation
+7085C6|Pace plc.
+708B78|citygrow technology co., ltd
+708D09|Nokia Corporation
+709383|Intelligent Optical Network High Tech CO.,LTD.
+7093F8|Space Monkey, Inc.
+709756|Happyelectronics Co.,Ltd
+709A0B|Italian Institute of Technology
+709BA5|Shenzhen Y&D Electronics Co.,LTD.
+709BFC|Bryton Inc.
+709C8F|Nero AG
+709E29|Sony Computer Entertainment Inc.
+709E86|X6D Limited
+709F2D|zte corporation
+70A191|Trendsetter Medical, LLC
+70A41C|Advanced Wireless Dynamics S.L.
+70A66A|Prox Dynamics AS
+70A8E3|HUAWEI TECHNOLOGIES CO.,LTD
+70AAB2|Research In Motion
+70AD54|Malvern Instruments Ltd
+70AF25|Nishiyama Industry Co.,LTD.
+70B035|Shenzhen Zowee Technology Co., Ltd
+70B08C|Shenou Communication Equipment Co.,Ltd
+70B14E|Pace plc
+70B265|Hiltron s.r.l.
+70B3D5|IEEE REGISTRATION AUTHORITY  - Please see OUI36 public listing for more information.
+70B599|Embedded Technologies s.r.o.
+70B921|FiberHome Telecommunication Technologies CO.,LTD
+70BAEF|Hangzhou H3C Technologies Co., Limited
+70C6AC|Bosch Automotive Aftermarket
+70C76F|INNO S
+70CA9B|Cisco
+70CD60|Apple
+70D4F2|RIM
+70D57E|Scalar Corporation
+70D5E7|Wellcore Corporation
+70D6B6|Metrum Technologies
+70D880|Upos System sp. z o.o.
+70D931|Cambridge Industries Group Co Ltd.
+70DA9C|TECSEN
+70DDA1|Tellabs
+70DEE2|Apple
+70E027|HONGYU COMMUNICATION TECHNOLOGY LIMITED
+70E139|3view Ltd
+70E24C|SAE IT-systems GmbH & Co. KG
+70E284|Wistron InfoComm(Zhongshan) Corporation
+70E72C|Apple
+70E843|Beijing C&W Optical Communication Technology Co.,Ltd.
+70EE50|Netatmo
+70F176|Data Modul AG
+70F196|Actiontec Electronics, Inc
+70F1A1|Liteon Technology Corporation
+70F1E5|Xetawave LLC
+70F395|Universal Global Scientific Industrial Co., Ltd.
+70F927|Samsung
+70F96D|Hangzhou H3C Technologies Co., Limited
+70FC8C|OneAccess SA
+70FF5C|Cheerzing Communication(Xiamen)Technology Co.,Ltd
+70FF76|Texas Instruments
+7403BD|Buffalo Inc.
+74042B|Lenovo Mobile Communication (Wuhan) Company Limited
+740ABC|JSJS Designs (Europe) Limited
+740EDB|Optowiz Co., Ltd
+741489|SRT Wireless
+7415E2|Tri-Sen Systems Corporation
+7419F8|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+741E93|Fiberhome Telecommunication Tech.Co.,Ltd.
+74258A|Hangzhou H3C Technologies Co., Limited
+7426AC|Cisco
+74273C|ChangYang Technology (Nanjing) Co., LTD
+7427EA|Elitegroup Computer Systems Co., Ltd.
+7429AF|Hon Hai Precision Ind. Co.,Ltd.
+742B0F|Infinidat Ltd.
+742B62|Fujitsu Limited
+742D0A|Norfolk Elektronik AG
+742EFC|DirectPacket Research, Inc,
+742F68|Azurewave Technologies, Inc.
+743170|Arcadyan Technology Corporation
+743256|NT-ware Systemprg GmbH
+74372F|Tongfang Shenzhen Cloudcomputing Technology Co.,Ltd
+743889|ANNAX Anzeigesysteme GmbH
+743ECB|Gentrice tech
+744401|Netgear
+74458A|Samsung
+7446A0|Hewlett Packard
+744BE9|EXPLORER HYPERTECH CO.,LTD
+744D79|Arrive Systems Inc.
+7451BA|Xiaomi
+745327|COMMSEN CO., LIMITED
+74547D|Cisco
+745612|ARRIS Group, Inc.
+745798|TRUMPF Laser GmbH + Co. KG
+745C9F|TCT mobile ltd.
+745E1C|PIONEER CORPORATION
+745F00|Samsung
+745FAE|TSL PPL
+7463DF|VTS GmbH
+7465D1|Atlinks
+746630|T:mi Ytti
+746A3A|Aperi Corporation
+746A89|Rezolt Corporation
+746A8F|VS Vision Systems GmbH
+746B82|MOVEK
+746F3D|Contec GmbH
+7472F2|Chipsip Technology Co., Ltd.
+747548|Amazon Technologies Inc.
+747818|ServiceAssure
+747B7A|ETH Inc.
+747DB6|Aliwei Communications, Inc
+747E1A|Red Embedded Design Limited
+747E2D|Beijing Thomson CITIC Digital Technology Co. LTD.
+748114|Apple
+74852A|PEGATRON CORPORATION
+74867A|Dell Inc
+74882A|HUAWEI TECHNOLOGIES CO.,LTD
+74888B|ADB Broadband Italia
+748E08|Bestek Corp.
+748EF8|Brocade Communications Systems, Inc.
+748F1B|MasterImage 3D
+748F4D|MEN Mikro Elektronik GmbH
+749050|Renesas Electronics Corporation
+74911A|Ruckus Wireless
+7491BD|Four systems Co.,Ltd.
+7493A4|Zebra Technologies Corp.
+74943D|AgJunction
+749637|Todaair Electronic Co., Ltd
+749975|IBM Corporation
+749C52|Huizhou Desay SV Automotive Co., Ltd.
+749CE3|Art2Wave Canada Inc.
+749DDC|2Wire
+74A02F|Cisco
+74A063|HUAWEI TECHNOLOGIES CO.,LTD
+74A2E6|Cisco
+74A34A|ZIMI CORPORATION
+74A4A7|QRS Music Technologies, Inc.
+74A4B5|Powerleader Science and Technology Co. Ltd.
+74A722|LG Electronics
+74ADB7|China Mobile Group Device Co.,Ltd.
+74AE76|iNovo Broadband, Inc.
+74B00C|Network Video Technologies, Inc
+74B9EB|Fujian JinQianMao Electronic Technology Co.,Ltd
+74BADB|Longconn Electornics(shenzhen)Co.,Ltd
+74BE08|ATEK Products, LLC
+74BFA1|HYUNTECK
+74C246|Amazon Technologies Inc.
+74C621|Zhejiang Hite Renewable Energy Co.,LTD
+74C99A|Ericsson AB
+74CA25|Calxeda, Inc.
+74CD0C|Smith Myers Communications Ltd.
+74CE56|Packet Force Technology Limited Company
+74D02B|ASUSTek COMPUTER INC.
+74D0DC|ERICSSON AB
+74D435|GIGA-BYTE TECHNOLOGY CO.,LTD.
+74D675|WYMA Tecnologia
+74D6EA|Texas Instruments
+74D850|Evrisko Systems
+74DA38|Edimax Technology Co. Ltd.
+74DBD1|Ebay Inc
+74DE2B|Liteon Technology Corporation
+74E06E|Ergophone GmbH
+74E14A|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+74E1B6|Apple
+74E277|Vizmonet Pte Ltd
+74E28C|Microsoft
+74E2F5|Apple
+74E424|APISTE CORPORATION
+74E50B|Intel Corporate
+74E537|RADSPIN
+74E543|Liteon Technology Corporation
+74E6E2|Dell Inc.
+74E7C6|ARRIS Group, Inc.
+74EA3A|TP-LINK Technologies Co.,Ltd.
+74ECF1|Acumen
+74F06D|AzureWave Technologies, Inc.
+74F07D|BnCOM Co.,Ltd
+74F102|Beijing HCHCOM Technology Co., Ltd
+74F413|Maxwell Forest
+74F612|ARRIS Group, Inc.
+74F726|Neuron Robotics
+74F85D|Berkeley Nucleonics Corp
+74FDA0|Compupal (Group) Corporation
+74FE48|ADVANTECH CO., LTD.
+74FF7D|Wren Sound Systems, LLC
+78028F|Adaptive Spectrum and Signal Alignment (ASSIA), Inc.
+780738|Z.U.K. Elzab S.A.
+781185|NBS Payment Solutions Inc.
+7812B8|ORANTEK LIMITED
+781881|AzureWave Technologies, Inc.
+78192E|NASCENT Technology
+7819F7|Juniper Networks
+781C5A|SHARP Corporation
+781DBA|HUAWEI TECHNOLOGIES CO.,LTD
+781DFD|Jabil Inc
+781FDB|Samsung
+78223D|Affirmed Networks
+7824AF|ASUSTek COMPUTER INC.
+782544|Omnima Limited
+7825AD|Samsung
+782BCB|Dell Inc
+782EEF|Nokia Corporation
+78303B|Stephen Technologies Co.,Limited
+7830E1|UltraClenz, LLC
+78312B|zte corporation
+7831C1|Apple
+78324F|Millennium Group, Inc.
+783A84|Apple
+783CE3|Kai-EE
+783D5B|TELNET Redes Inteligentes S.A.
+783E53|BSkyB Ltd
+783F15|EasySYNC Ltd.
+7840E4|Samsung
+784405|FUJITU(HONG KONG) ELECTRONIC Co.,LTD.
+784476|Zioncom technology co.,ltd
+784561|CyberTAN Technology Inc.
+7845C4|Dell Inc
+7846C4|DAEHAP HYPER-TECH
+78471D|Samsung
+784859|Hewlett Packard
+78491D|The Will-Burt Company
+784B08|f.robotics acquisitions ltd
+784B87|Murata Manufacturing Co.,Ltd.
+78510C|LiveU Ltd.
+78521A|Samsung
+785262|Shenzhen Hojy Software Co., Ltd.
+78542E|D-Link International
+785517|SankyuElectronics
+785712|Mobile Integration Workgroup
+7858F3|Vachen Co.,Ltd
+78593E|RAFI GmbH & Co.KG
+78595E|Samsung
+785968|Hon Hai Precision Ind.Co.,Ltd.
+785C72|Hioso Technology Co., Ltd.
+785F4C|Argox Information Co., Ltd.
+78617C|MITSUMI ELECTRIC CO.,LTD
+7866AE|ZTEC Instruments, Inc.
+786A89|Huawei Technologies Co., Ltd
+786C1C|Apple
+78719C|ARRIS Group, Inc.
+787E61|Apple
+787F62|GiK mbH
+78818F|Server Racks Australia Pty Ltd
+78843C|Sony Corporation
+7884EE|INDRA ESPACIO S.A.
+788973|CMC
+788C54|Eltek Technologies LTD
+788DF7|Hitron Technologies. Inc
+78923E|Nokia Corporation
+78929C|Intel Corporate
+789684|ARRIS Group, Inc.
+7898FD|Q9 Networks Inc.
+78995C|Nationz Technologies Inc
+789966|Musilab Electronics (DongGuan)Co.,Ltd.
+78998F|MEDILINE ITALIA SRL
+789CE7|Shenzhen Aikede Technology Co., Ltd
+789ED0|Samsung
+789F4C|HOERBIGER Elektronik GmbH
+789F70|Apple
+789F87|Siemens AG I IA PP PRM
+78A051|iiNet Labs Pty Ltd
+78A106|TP-LINK TECHNOLOGIES CO.,LTD.
+78A183|Advidia
+78A2A0|Nintendo Co., Ltd.
+78A351|SHENZHEN ZHIBOTONG ELECTRONICS CO.,LTD
+78A3E4|Apple
+78A504|Texas Instruments
+78A5DD|Shenzhen Smarteye Digital Electronics Co., Ltd
+78A683|Precidata
+78A6BD|DAEYEON Control&Instrument Co,.Ltd
+78A714|Amphenol
+78A873|Samsung
+78AB60|ABB Australia
+78ABBB|Samsung
+78ACBF|Igneous Systems
+78ACC0|Hewlett-Packard Company
+78AE0C|Far South Networks
+78B3B9|ShangHai sunup lighting CO.,LTD
+78B3CE|Elo touch solutions
+78B5D2|Ever Treasure Industrial Limited
+78B6C1|AOBO Telecom Co.,Ltd
+78B81A|INTER SALES A/S
+78BAD0|Shinybow Technology Co. Ltd.
+78BAF9|Cisco
+78BDBC|Samsung
+78BEB6|Enhanced Vision
+78BEBD|STULZ GmbH
+78C40E|H&D Wireless
+78C4AB|Shenzhen Runsil Technology Co.,Ltd
+78C5E5|Texas Instruments
+78C6BB|Innovasic, Inc.
+78CA04|Nokia Corporation
+78CA39|Apple
+78CA5E|ELNO
+78CB33|DHC Software Co.,Ltd
+78CD8E|SMC Networks Inc
+78D004|Neousys Technology Inc.
+78D129|Vicos
+78D34F|Pace-O-Matic, Inc.
+78D38D|HONGKONG YUNLINK TECHNOLOGY LIMITED
+78D5B5|NAVIELEKTRO KY
+78D66F|Aristocrat Technologies Australia Pty. Ltd.
+78D6F0|Samsung
+78D752|HUAWEI TECHNOLOGIES CO.,LTD
+78D99F|NuCom HK Ltd.
+78DA6E|Cisco
+78DAB3|GBO Technology
+78DD08|Hon Hai Precision Ind. Co.,Ltd.
+78DDD6|c-scape
+78DEE4|Texas Instruments
+78E3B5|Hewlett-Packard Company
+78E400|Hon Hai Precision Ind. Co.,Ltd.
+78E7D1|Hewlett-Packard Company
+78E8B6|zte corporation
+78E980|RainUs Co.,Ltd
+78EB14|SHENZHEN FAST TECHNOLOGIES CO.,LTD
+78EC22|Shanghai Qihui Telecom Technology Co., LTD
+78EC74|Kyland-USA
+78EF4C|Unetconvergence Co., Ltd.
+78F5E5|BEGA Gantenbrink-Leuchten KG
+78F5FD|Huawei Technologies Co., Ltd
+78F7BE|Samsung
+78F7D0|Silverbrook Research
+78FC14|B Communications Pty Ltd
+78FD94|Apple
+78FE3D|Juniper Networks
+78FE41|Socus networks
+78FEE2|Shanghai Diveo Technology Co., Ltd
+78FF57|Intel Corporate
+7C0187|Curtis Instruments, Inc.
+7C02BC|Hansung Electronics Co. LTD
+7C034C|SAGEMCOM
+7C03D8|SAGEMCOM SAS
+7C0507|PEGATRON CORPORATION
+7C051E|RAFAEL LTD.
+7C0623|Ultra Electronics, CIS
+7C08D9|Shanghai B-Star Technology Co
+7C092B|Bekey A/S
+7C0A50|J-MEX Inc.
+7C0ECE|Cisco
+7C11BE|Apple
+7C11CD|QianTang Technology
+7C1476|Damall Technologies SAS
+7C160D|Saia-Burgess Controls AG
+7C1A03|8Locations Co., Ltd.
+7C1AFC|Dalian Co-Edifice Video Technology Co., Ltd
+7C1DD9|Xiaomi
+7C1E52|Microsoft
+7C1EB3|2N TELEKOMUNIKACE a.s.
+7C2048|KoamTac
+7C2064|Alcatel Lucent IPD
+7C2587|chaowifi.com
+7C2CF3|Secure Electrans Ltd
+7C2E0D|Blackmagic Design
+7C2F80|Gigaset Communications GmbH
+7C336E|MEG Electronics Inc.
+7C386C|Real Time Logic
+7C3920|SSOMA SECURITY
+7C3BD5|Imago Group
+7C3CB6|Shenzhen Homecare Technology Co.,Ltd.
+7C3E9D|PATECH
+7C438F|E-Band Communications Corp.
+7C444C|Entertainment Solutions, S.L.
+7C49B9|Plexus Manufacturing Sdn Bhd
+7C4A82|Portsmith LLC
+7C4AA8|MindTree Wireless PVT Ltd
+7C4B78|Red Sun Synthesis Pte Ltd
+7C4C58|Scale Computing, Inc.
+7C4CA5|BSkyB Ltd
+7C4FB5|Arcadyan Technology Corporation
+7C534A|Metamako
+7C55E7|YSI, Inc.
+7C5CF8|Intel Corporate
+7C6097|HUAWEI TECHNOLOGIES CO.,LTD
+7C6193|HTC Corporation
+7C669D|Texas Instruments
+7C69F6|Cisco
+7C6AB3|IBC TECHNOLOGIES INC.
+7C6AC3|GatesAir, Inc
+7C6ADB|SafeTone Technology Co.,Ltd
+7C6B33|Tenyu Tech Co. Ltd.
+7C6B52|Tigaro Wireless
+7C6C39|PIXSYS SRL
+7C6C8F|AMS NEVE LTD
+7C6D62|Apple
+7C6DF8|Apple
+7C6F06|Caterpillar Trimble Control Technologies
+7C6FF8|ShenZhen ACTO Digital Video Technology Co.,Ltd.
+7C70BC|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+7C72E4|Unikey Technologies
+7C7673|ENMAS GmbH
+7C7A53|Phytrex Technology Corp.
+7C7A91|Intel Corporate
+7C7BE4|Z'SEDAI KENKYUSHO CORPORATION
+7C7D41|Jinmuyu Electronics Co., Ltd.
+7C822D|Nortec
+7C8274|Shenzhen Hikeen Technology CO.,LTD
+7C8306|Glen Dimplex Nordic as
+7C8D91|Shanghai Hongzhuo Information Technology co., LTD
+7C8EE4|Texas Instruments
+7C94B2|Philips Healthcare PCCI
+7C95F3|Cisco
+7C9763|Openmatics s.r.o.
+7C9A9B|VSE valencia smart energy
+7CA15D|GN ReSound A/S
+7CA29B|D.SignT GmbH & Co. KG
+7CA61D|MHL, LLC
+7CACB2|Bosch Software Innovations GmbH
+7CAD74|Cisco
+7CB03E|OSRAM GmbH
+7CB177|Satelco AG
+7CB21B|Cisco
+7CB232|Hui Zhou Gaoshengda Technology Co.,LTD
+7CB542|ACES Technology
+7CB733|ASKEY COMPUTER CORP
+7CB77B|Paradigm Electronics Inc
+7CBB6F|Cosco Electronics Co., Ltd.
+7CBD06|AE REFUsol
+7CBF88|Mobilicom LTD
+7CBFB1|ARRIS Group, Inc.
+7CC3A1|Apple
+7CC4EF|Devialet
+7CC537|Apple
+7CC709|Shenzhen RF-LINK Elec&Technology.,Ltd
+7CC8AB|Acro Associates, Inc.
+7CC8D0|TIANJIN YAAN TECHNOLOGY CO., LTD.
+7CC8D7|Damalisk
+7CCB0D|Antaira Technologies, LLC
+7CCCB8|Intel Corporate
+7CCD11|MS-Magnet
+7CCD3C|Guangzhou Juzing Technology Co., Ltd
+7CCFCF|Shanghai SEARI Intelligent System Co., Ltd
+7CD1C3|Apple
+7CD30A|INVENTEC Corporation
+7CD762|Freestyle Technology Pty Ltd
+7CD844|Enmotus Inc
+7CD9FE|New Cosmos Electric Co., Ltd.
+7CDA84|Dongnian Networks Inc.
+7CDD11|Chongqing MAS SCI&TECH.Co.,Ltd
+7CDD20|IOXOS Technologies S.A.
+7CDD90|Shenzhen Ogemray Technology Co., Ltd.
+7CE044|NEON Inc
+7CE1FF|Computer Performance, Inc. DBA Digital Loggers, Inc.
+7CE524|Quirky, Inc.
+7CE56B|ESEN Optoelectronics Technology Co.,Ltd.
+7CE9D3|Hon Hai Precision Ind. Co.,Ltd.
+7CEBEA|ASCT
+7CEC79|Texas Instruments
+7CED8D|Microsoft
+7CEF18|Creative Product Design Pty. Ltd.
+7CEF8A|Inhon International Ltd.
+7CF05F|Apple
+7CF098|Bee Beans Technologies, Inc.
+7CF0BA|Linkwell Telesystems Pvt Ltd
+7CF429|NUUO Inc.
+7CF854|Samsung
+7CF90E|Samsung
+7CFADF|Apple
+7CFE28|Salutron Inc.
+7CFE4E|Shenzhen Safe vision Technology Co.,LTD
+7CFF62|Huizhou Super Electron Technology Co.,Ltd.
+80000B|Intel Corporate
+800010|ATT BELL LABORATORIES
+80006E|Apple
+800184|HTC Corporation
+8005DF|Montage Technology Group Limited
+8007A2|Esson Technology Inc.
+800902|Keysight Technologies, Inc.
+800A06|COMTEC co.,ltd
+800B51|Chengdu XGimi Technology Co.,Ltd
+800E24|ForgetBox
+801440|Sunlit System Technology Corp
+8014A8|Guangzhou V-SOLUTION Electronic Technology Co., Ltd.
+8016B7|Brunel University
+80177D|Nortel Networks
+8018A7|Samsung
+801934|Intel Corporate
+801967|Shanghai Reallytek Information Technology  Co.,Ltd
+801DAA|Avaya Inc
+801F02|Edimax Technology Co. Ltd.
+8020AF|Trade FIDES, a.s.
+802275|Beijing Beny Wave Technology Co Ltd
+802AA8|Ubiquiti Networks
+802AFA|Germaneers GmbH
+802DE1|Solarbridge Technologies
+802E14|azeti Networks AG
+802FDE|Zurich Instruments AG
+803457|OT Systems Limited
+803773|Netgear
+8038BC|Huawei Technologies Co., Ltd
+8038FD|LeapFrog Enterprises, Inc.
+8039E5|PATLITE CORPORATION
+803B2A|ABB Xiamen Low Voltage Equipment Co.,Ltd.
+803B9A|ghe-ces electronic ag
+803F5D|Winstars Technology Ltd
+803FD6|bytes at work AG
+80414E|BBK Electronics Corp., Ltd.,
+80427C|Adolf Tedsen GmbH & Co. KG
+804731|Packet Design, Inc.
+8048A5|SICHUAN TIANYI COMHEART TELECOM CO.,LTD
+804971|Apple
+804B20|Ventilation Control
+804E81|Samsung
+804F58|ThinkEco, Inc.
+80501B|Nokia Corporation
+805067|W & D TECHNOLOGY CORPORATION
+8056F2|Hon Hai Precision Ind. Co.,Ltd.
+805719|Samsung
+8058C5|NovaTec Kommunikationstechnik GmbH
+8059FD|Noviga
+806007|RIM
+80618F|Shenzhen sangfei consumer communications co.,ltd
+806459|Nimbus Inc.
+8065E9|BenQ Corporation
+806629|Prescope Technologies CO.,LTD.
+806AB0|Tinno Mobile Technology Corp
+806C1B|Motorola
+806C8B|KAESER KOMPRESSOREN AG
+806CBC|NET New Electronic Technology GmbH
+80711F|Juniper Networks
+80717A|Huawei Technologies Co., Ltd
+807459|K's Co.,Ltd.
+807693|Newag SA
+8079AE|ShanDong Tecsunrise  Co.,Ltd
+807A7F|ABB Genway Xiamen Electrical Equipment CO., LTD
+807B1E|Corsair Components
+807B85|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+807D1B|Neosystem Co. Ltd.
+807DE3|Chongqing Sichuan Instrument Microcircuit Co.LTD.
+8081A5|TONGQING COMMUNICATION EQUIPMENT (SHENZHEN) Co.,Ltd
+808287|ATCOM Technology Co.Ltd.
+808698|Netronics Technologies Inc.
+8086F2|Intel Corporate
+808917|TP-LINK TECHNOLOGIES CO.,LTD
+808B5C|Shenzhen Runhuicheng Technology Co., Ltd
+80912A|Lih Rong electronic Enterprise Co., Ltd.
+8091C0|AgileMesh, Inc.
+80929F|Apple
+809393|Xapt GmbH
+80946C|TOKYO RADAR CORPORATION
+8096B1|ARRIS Group, Inc.
+8096CA|Hon Hai Precision Ind Co.,Ltd
+80971B|Altenergy Power System,Inc.
+809B20|Intel Corporate
+809FAB|Fiberhome Telecommunication Technologies Co.,LTD
+80A1D7|Shanghai DareGlobal Technologies Co.,Ltd
+80A85D|Osterhout Design Group
+80AAA4|USAG
+80AD67|Kasda Networks Inc
+80B219|ELEKTRON TECHNOLOGY UK LIMITED
+80B289|Forworld Electronics Ltd.
+80B32A|Alstom Grid
+80B686|Huawei Technologies Co., Ltd
+80B95C|ELFTECH Co., Ltd.
+80BAAC|TeleAdapt Ltd
+80BAE6|Neets
+80BBEB|Satmap Systems Ltd
+80BE05|Apple
+80C16E|Hewlett Packard
+80C5E6|Microsoft
+80C63F|Remec Broadband Wireless , LLC
+80C6AB|Technicolor USA Inc.
+80C6CA|Endian s.r.l.
+80C862|Openpeak, Inc
+80CEB1|Theissen Training Systems GmbH
+80CF41|Lenovo Mobile Communication Technology Ltd.
+80D019|Embed, Inc
+80D09B|Huawei Technologies Co., Ltd
+80D18B|Hangzhou I'converge Technology Co.,Ltd
+80D21D|AzureWave Technologies, Inc
+80D433|LzLabs GmbH
+80D733|QSR Automations, Inc.
+80DB31|Power Quotient International Co., Ltd.
+80E4DA|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+80E650|Apple
+80EA96|Apple
+80EACA|Dialog Semiconductor Hellas SA
+80EE73|Shuttle Inc.
+80F25E|Kyynel
+80F503|Pace plc
+80F593|IRCO Sistemas de Telecomunicacion S.A.
+80F62E|Hangzhou H3C Technologies Co., Limited
+80F8EB|RayTight
+80FA5B|CLEVO CO.
+80FB06|HUAWEI TECHNOLOGIES CO.,LTD
+80FFA8|UNIDIS
+8400D2|Sony Ericsson Mobile Communications AB
+8401A7|Greyware Automation Products, Inc
+840B2D|Samsung
+840F45|Shanghai GMT Digital Technologies Co., Ltd
+84119E|Samsung
+841715|GP Electronics (HK) Ltd.
+841766|Weifang GoerTek Electronics Co., Ltd
+841826|Osram GmbH
+84183A|Ruckus Wireless
+841888|Juniper Networks
+841B38|Shenzhen Excelsecu Data Technology Co.,Ltd
+841B5E|Netgear
+841E26|KERNEL-I Co.,LTD
+842141|Shenzhen Ginwave Technologies Ltd.
+84248D|Zebra Technologies Inc
+84253F|Silex Technology, Inc
+8425A4|Tariox Limited
+8425DB|Samsung
+842615|ADB Broadband Italia
+84262B|Alcatel-Lucent
+842690|BEIJING THOUGHT SCIENCE CO.,LTD.
+8427CE|Corporation of the Presiding Bishop of The Church of Jesus Christ of Latter-day Saints
+842914|EMPORIA TELECOM Produktions- und VertriebsgesmbH & Co KG
+842999|Apple
+842B2B|Dell Inc.
+842B50|Huria Co.,Ltd.
+842BBC|Modelleisenbahn GmbH
+842E27|Samsung
+842F75|Innokas Group
+8430E5|SkyHawke Technologies, LLC
+8432EA|ANHUI WANZTEN P&T CO., LTD
+843497|Hewlett Packard
+843611|hyungseul publishing networks
+843835|Apple
+843838|Samsung
+843A4B|Intel Corporate
+843F4E|Tri-Tech Manufacturing, Inc.
+844464|ServerU Inc
+844823|WOXTER TECHNOLOGY Co. Ltd
+844915|vArmour Networks, Inc.
+844BB7|Beijing Sankuai Online Technology Co.,Ltd
+844BF5|Hon Hai Precision Ind. Co.,Ltd.
+844F03|Ablelink Electronics Ltd
+845181|Samsung
+8455A5|Samsung
+84569C|Coho Data, Inc.,
+845787|DVR C&C Co., Ltd.
+845C93|Chabrier Services
+845DD7|Shenzhen Netcom Electronics Co.,Ltd
+8461A0|ARRIS Group, Inc.
+846223|Shenzhen Coship Electronics Co., Ltd.
+8462A6|EuroCB (Phils), Inc.
+8463D6|Microsoft
+846AED|Wireless Tsukamoto.,co.LTD
+846EB1|Park Assist LLC
+847207|I&C Technology
+847303|Letv Mobile and Intelligent Information Technology (Beijing) Corporation Ltd.
+84742A|zte corporation
+847616|Addat S.r.o.
+84788B|Apple
+8478AC|Cisco
+847A88|HTC Corporation
+847E40|Texas Instruments
+84802D|Cisco
+8482F4|Beijing Huasun Unicreate Technology Co., Ltd
+848336|Newrun
+848371|Avaya, Inc
+848433|Paradox Engineering SA
+848506|Apple
+84850A|Hella Sonnen- und Wetterschutztechnik GmbH
+8486F3|Greenvity Communications
+848D84|Rajant Corporation
+848DC7|Cisco
+848E0C|Apple
+848E96|Embertec Pty Ltd
+848EDF|Sony Mobile Communications AB
+848F69|Dell Inc.
+849000|Arnold & Richter Cine Technik
+84930C|InCoax Networks Europe AB
+84948C|Hitron Technologies. Inc
+849681|Cathay Communication Co.,Ltd
+8496D8|Pace plc
+8497B8|Memjet Inc.
+849CA6|Arcadyan Technology Corporation
+849DC5|Centera Photonics Inc.
+84A466|Samsung
+84A6C8|Intel Corporate
+84A783|Alcatel Lucent
+84A8E4|Shenzhen Huawei Communication Technologies Co., Ltd
+84A991|Cyber Trans Japan Co.,Ltd.
+84ACA4|Beijing Novel Super Digital TV Technology Co., Ltd
+84AF1F|Beat System Service Co,. Ltd.
+84B153|Apple
+84B59C|Juniper networks
+84B802|Cisco
+84C2E4|Jiangsu Qinheng Co., Ltd.
+84C3E8|Vaillant GmbH
+84C727|Gnodal Ltd
+84C7A9|C3PO S.A.
+84C8B1|Incognito Software Inc.
+84C9B2|D-Link International
+84CFBF|Fairphone
+84D32A|IEEE 1905.1
+84D9C8|Unipattern Co.,
+84DB2F|Sierra Wireless Inc
+84DBAC|Huawei Technologies Co., Ltd
+84DBFC|Alcatel-Lucent
+84DD20|Texas Instruments
+84DDB7|Cilag GmbH International
+84DE3D|Crystal Vision Ltd
+84DF0C|NET2GRID BV
+84DF19|Chuango Security Technology Corporation
+84E058|Pace plc
+84E4D9|Shenzhen NEED technology Ltd.
+84E629|Bluwan SA
+84E714|Liang Herng Enterprise,Co.Ltd.
+84EA99|Vieworks
+84EB18|Texas Instruments
+84ED33|BBMC Co.,Ltd
+84F129|Metrascale Inc.
+84F493|OMS spol. s.r.o.
+84F64C|Cross Point BV
+84FCFE|Apple
+84FE9E|RTC Industries, Inc.
+880355|Arcadyan Technology Corp.
+880905|MTMCommunications
+880F10|Huami Information Technology Co.,Ltd.
+880FB6|Jabil Circuits India Pvt Ltd,-EHTP unit
+881036|Panodic(ShenZhen) Electronics Limted
+88124E|Qualcomm Atheros
+88142B|Protonic Holland
+881544|Meraki, Inc.
+8818AE|Tamron Co., Ltd
+881DFC|Cisco
+881FA1|Apple
+882012|LMI Technologies
+8821E3|Nebusens, S.L.
+882364|Watchnet DVR Inc
+8823FE|TTTech Computertechnik AG
+88252C|Arcadyan Technology Corporation
+882593|TP-LINK TECHNOLOGIES CO.,LTD
+882950|Dalian Netmoon Tech Develop Co.,Ltd
+882E5A|storONE
+88308A|Murata Manufactuaring Co.,Ltd.
+88329B|Samsung
+883314|Texas Instruments
+8833BE|Ivenix, Inc.
+88354C|Transics
+883612|SRC Computers, LLC
+883B8B|Cheering Connection Co. Ltd.
+884157|Shenzhen Atsmart Technology Co.,Ltd.
+8841C1|ORBISAT DA AMAZONIA IND E AEROL SA
+8841FC|AirTies Wireless Netowrks
+8843E1|Cisco
+8844F6|Nokia Corporation
+88462A|Telechips Inc.
+884B39|Siemens AG, Healthcare Sector
+8851FB|Hewlett Packard
+88532E|Intel Corporate
+885395|Apple
+8853D4|Huawei Technologies Co., Ltd
+88576D|XTA Electronics Ltd
+885A92|Cisco
+885BDD|Aerohive Networks Inc.
+885C47|Alcatel Lucent
+88615A|Siano Mobile Silicon Ltd.
+8863DF|Apple
+88685C|Shenzhen ChuangDao & Perpetual Eternal Technology Co.,Ltd
+886B76|CHINA HOPEFUL GROUP HOPEFUL ELECTRIC CO.,LTD
+887033|Hangzhou Silan Microelectronic Inc
+88708C|Lenovo Mobile Communication Technology Ltd.
+8870EF|SC Professional Trading Co., Ltd.
+887384|Toshiba
+887398|K2E Tekpoint
+887556|Cisco
+88789C|Game Technologies SA
+888603|HUAWEI TECHNOLOGIES CO.,LTD
+8886A0|Simton Technologies, Ltd.
+888717|CANON INC.
+8887DD|DarbeeVision Inc.
+888914|All Components Incorporated
+888964|GSI Electronics Inc.
+888B5D|Storage Appliance Corporation
+888C19|Brady Corp Asia Pacific Ltd
+88908D|Cisco
+889166|Viewcooper Corp.
+8891DD|Racktivity
+889471|Brocade Communications Systems, Inc.
+8894F9|Gemicom Technology, Inc.
+8895B9|Unified Packet Systems Crop
+889676|TTC MARCONI s.r.o.
+8897DF|Entrypass Corporation Sdn. Bhd.
+889821|TERAON
+889B39|Samsung
+889CA6|BTB Korea INC
+889FFA|Hon Hai Precision Ind. Co.,Ltd.
+88A25E|juniper networks
+88A2D7|HUAWEI TECHNOLOGIES CO.,LTD
+88A3CC|Amatis Controls
+88A5BD|QPCOM INC.
+88A73C|Ragentek Technology Group
+88ACC1|Generiton Co., Ltd.
+88AE1D|COMPAL INFORMATION(KUNSHAN)CO.,LTD
+88B168|Delta Control GmbH
+88B1E1|AirTight Networks, Inc.
+88B627|Gembird Europe BV
+88BA7F|Qfiednet Co., Ltd.
+88BFD5|Simple Audio Ltd
+88C36E|Beijing Ereneben lnformation Technology Limited
+88C626|Logitech - Ultimate Ears
+88C663|Apple
+88C9D0|LG Electronics
+88CB87|Apple
+88CEFA|Huawei Technologies Co., Ltd
+88D37B|FirmTek, LLC
+88D7BC|DEP Company
+88D962|Canopus Systems US LLC
+88DC96|SENAO Networks, Inc.
+88DD79|Voltaire
+88E0A0|Shenzhen VisionSTOR Technologies Co., Ltd
+88E0F3|Juniper Networks
+88E161|Art Beijing Science and Technology Development Co., Ltd.
+88E3AB|Huawei Technologies Co., Ltd
+88E603|Avotek corporation
+88E712|Whirlpool Corporation
+88E7A6|iKnowledge Integration Corp.
+88E8F8|YONG TAI ELECTRONIC (DONGGUAN) LTD.
+88E917|Tamaggo
+88ED1C|Cudo Communication Co., Ltd.
+88F031|Cisco
+88F077|Cisco
+88F488|cellon communications technology(shenzhen)Co.,Ltd.
+88F490|Jetmobile Pte Ltd
+88F7C7|Technicolor USA Inc.
+88FD15|LINEEYE CO., LTD
+88FED6|ShangHai WangYong Software Co., Ltd.
+8C006D|Apple
+8C04FF|Technicolor USA Inc.
+8C0551|Koubachi AG
+8C078C|FLOW DATA INC
+8C088B|Remote Solution
+8C09F4|ARRIS Group, Inc.
+8C0C90|Ruckus Wireless
+8C0CA3|Amper
+8C0EE3|GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD.
+8C11CB|ABUS Security-Center GmbH & Co. KG
+8C18D9|Shenzhen RF Technology Co., Ltd
+8C1F94|RF Surgical System Inc.
+8C210A|TP-LINK TECHNOLOGIES CO., LTD.
+8C271D|QuantHouse
+8C278A|Vocollect Inc
+8C2937|Apple
+8C2DAA|Apple
+8C2F39|IBA Dosimetry GmbH
+8C3330|EmFirst Co., Ltd.
+8C3357|HiteVision Digital Media Technology Co.,Ltd.
+8C34FD|Huawei Technologies Co., Ltd
+8C3AE3|LG Electronics
+8C3C07|Skiva Technologies, Inc.
+8C3C4A|NAKAYO TELECOMMUNICATIONS,INC.
+8C41F2|RDA Technologies Ltd.
+8C4435|Shanghai BroadMobi Communication Technology Co., Ltd.
+8C4AEE|GIGA TMS INC
+8C4B59|3D Imaging & Simulations Corp
+8C4CDC|PLANEX COMMUNICATIONS INC.
+8C4DB9|Unmonday Ltd
+8C4DEA|Cerio Corporation
+8C5105|Shenzhen ireadygo Information Technology CO.,LTD.
+8C53F7|A&D ENGINEERING CO., LTD.
+8C541D|LGE
+8C569D|Imaging Solutions Group
+8C56C5|Nintendo Co., Ltd.
+8C57FD|LVX Western
+8C5877|Apple
+8C598B|C Technologies AB
+8C5AF0|Exeltech Solar Products
+8C5CA1|d-broad,INC
+8C5D60|UCI Corporation Co.,Ltd.
+8C5FDF|Beijing Railway Signal Factory
+8C604F|Cisco
+8C640B|Beyond Devices d.o.o.
+8C6422|Sony Ericsson Mobile Communications AB
+8C6878|Nortek-AS
+8C6AE4|Viogem Limited
+8C705A|Intel Corporate
+8C71F8|Samsung
+8C736E|Fujitsu Limited
+8C76C1|Goden Tech Limited
+8C7712|Samsung
+8C7716|LONGCHEER TELECOMMUNICATION LIMITED
+8C7967|zte corporation
+8C7B9D|Apple
+8C7C92|Apple
+8C7CB5|Hon Hai Precision Ind. Co.,Ltd.
+8C7CFF|Brocade Communications Systems, Inc.
+8C7EB3|Lytro, Inc.
+8C7F3B|ARRIS Group, Inc.
+8C82A8|Insigma Technology Co.,Ltd
+8C8401|ZZZZ 
+8C873B|Leica Camera AG
+8C89A5|Micro-Star INT'L CO., LTD
+8C8A6E|ESTUN AUTOMATION TECHNOLOY CO., LTD
+8C8B83|Texas Instruments
+8C8E76|taskit GmbH
+8C90D3|Alcatel Lucent
+8C9109|Toyoshima Electric Technoeogy(Suzhou) Co.,Ltd.
+8C9236|Aus.Linx Technology Co., Ltd.
+8C94CF|Encell Technology, Inc.
+8CA048|Beijing NeTopChip Technology Co.,LTD
+8CA982|Intel Corporate
+8CAE4C|Plugable Technologies
+8CAE89|Y-cam Solutions Ltd
+8CB094|Airtech I&C Co., Ltd
+8CB64F|Cisco
+8CB7F7|Shenzhen UniStrong Science & Technology Co., Ltd
+8CB82C|IPitomy Communications
+8CB864|AcSiP Technology Corp.
+8CBEBE|Xiaomi
+8CBF9D|Shanghai Xinyou Information Technology Ltd. Co.
+8CBFA6|Samsung
+8CC121|Panasonic Corporation AVC Networks Company
+8CC5E1|ShenZhen Konka Telecommunication Technology Co.,Ltd
+8CC7AA|Radinet Communications Inc.
+8CC7D0|zhejiang ebang communication co.,ltd
+8CC8CD|Samsung
+8CCDA2|ACTP, Inc.
+8CCDE8|Nintendo Co., Ltd.
+8CCF5C|BEFEGA GmbH
+8CD17B|CG Mobile
+8CD3A2|VisSim AS
+8CD628|Ikor Metering
+8CDB25|ESG Solutions
+8CDCD4|Hewlett Packard
+8CDD8D|Wifly-City System Inc.
+8CDE52|ISSC Technologies Corp.
+8CDE99|Comlab Inc.
+8CDF9D|NEC Corporation
+8CE081|zte corporation
+8CE748|ZZZZ 
+8CE78C|DK Networks
+8CE7B3|Sonardyne International Ltd
+8CEEC6|Precepscion Pty. Ltd.
+8CF228|SHENZHEN MERCURY COMMUNICATION TECHNOLOGIES CO.,LTD.
+8CF813|ORANGE POLSKA
+8CF945|Power Automation pte Ltd
+8CF9C9|MESADA Technology Co.,Ltd.
+8CFABA|Apple
+8CFDF0|QUALCOMM Incorporated
+90004E|Hon Hai Precision Ind. Co.,Ltd.
+9000DB|Samsung
+90013B|SAGEMCOM
+90028A|Shenzhen Shidean Legrand Electronic Products Co.,Ltd
+9002A9|ZHEJIANG DAHUA TECHNOLOGY CO.,LTD
+9003B7|PARROT
+900917|Far-sighted mobile
+900A39|Wiio, Inc.
+900A3A|PSG Plastic Service GmbH
+900CB4|Alinket Electronic Technology Co., Ltd
+900D66|Digimore Electronics Co., Ltd
+900DCB|ARRIS Group, Inc.
+90179B|Nanomegas
+9017AC|HUAWEI TECHNOLOGIES CO.,LTD
+90185E|Apex Tool Group GmbH & Co OHG
+90187C|Samsung
+9018AE|Shanghai Meridian Technologies, Co. Ltd.
+901900|SCS SA
+901ACA|ARRIS Group, Inc.
+901B0E|Fujitsu Technology Solutions GmbH
+901D27|zte corporation
+901EDD|GREAT COMPUTER CORPORATION
+90203A|BYD Precision Manufacture Co.,Ltd
+902083|General Engine Management Systems Ltd.
+902106|BSkyB Ltd
+902155|HTC Corporation
+902181|Shanghai Huaqin Telecom Technology Co.,Ltd
+9027E4|Apple
+902B34|GIGA-BYTE TECHNOLOGY CO.,LTD.
+902CC7|C-MAX Asia Limited
+902E1C|Intel Corporate
+902E87|LabJack
+9031CD|Onyx Healthcare Inc.
+90342B|Gatekeeper Systems, Inc.
+9034FC|Hon Hai Precision Ind. Co.,Ltd.
+90356E|Vodafone Omnitel N.V.
+9038DF|Changzhou Tiannengbo System Co. Ltd.
+903AA0|Alcatel-Lucent
+903C92|Apple
+903CAE|Yunnan KSEC Digital Technology Co.,Ltd.
+903D5A|Shenzhen Wision Technology Holding Limited
+903D6B|Zicon Technology Corp.
+903EAB|ARRIS Group, Inc.
+904506|Tokyo Boeki Medisys Inc.
+9046B7|Vadaro Pte Ltd
+904716|RORZE CORPORATION
+90489A|Hon Hai Precision Ind. Co.,Ltd.
+9049FA|Intel Corporate
+904CE5|Hon Hai Precision Ind. Co.,Ltd.
+904E2B|Huawei Technologies Co., Ltd
+90507B|Advanced PANMOBIL Systems GmbH & Co. KG
+90513F|Elettronica Santerno SpA
+905446|TES ELECTRONIC SOLUTIONS
+9055AE|Ericsson, EAB/RWI/K
+905682|Lenbrook Industries Limited
+905692|Autotalks Ltd.
+9059AF|Texas Instruments
+905F2E|TCT Mobile Limited
+905F8D|modas GmbH
+90610C|Fida International (S) Pte Ltd
+906717|Alphion India Private Limited
+90671C|Huawei Technologies Co., Ltd
+9067B5|Alcatel-Lucent
+9067F3|Alcatel Lucent
+9068C3|Motorola
+906CAC|Fortinet, Inc.
+906DC8|DLG Automacao Industrial Ltda
+906EBB|Hon Hai Precision Ind. Co.,Ltd.
+907025|Garea Microsys Co.,Ltd.
+907240|Apple
+907990|Benchmark Electronics Romania SRL
+907A0A|Gebr. Bode GmbH & Co KG
+907A28|Beijing Morncloud Information And Technology Co. Ltd.
+907AF1|SNUPI Technologies
+907EBA|UTEK TECHNOLOGY (SHENZHEN) CO.,LTD
+907F61|Chicony Electronics Co., Ltd.
+908260|IEEE 1904.1 Working Group
+90837A|General Electric Water & Process Technologies
+90840D|Apple
+9088A2|IONICS TECHNOLOGY ME LTDA
+908C09|Total Phase
+908C44|H.K ZONGMU TECHNOLOGY CO., LTD.
+908C63|GZ Weedong Networks Technology Co. , Ltd
+908D1D|GH Technologies
+908D6C|Apple
+908FCF|UNO System Co., Ltd
+90903C|TRISON TECHNOLOGY CORPORATION
+909060|RSI VIDEO TECHNOLOGIES
+9092B4|Diehl BGT Defence GmbH & Co. KG
+9094E4|D-Link International
+909864|Impex-Sat GmbH&amp;Co KG
+909916|ELVEES NeoTek OJSC
+909DE0|Newland Design + Assoc. Inc.
+909F33|EFM Networks
+909F43|Accutron Instruments Inc.
+90A210|United Telecoms Ltd
+90A2DA|GHEO SA
+90A4DE|Wistron Neweb Corp.
+90A783|JSW PACIFIC CORPORATION
+90A7C1|Pakedge Device and Software Inc.
+90AC3F|BrightSign LLC
+90AE1B|TP-LINK TECHNOLOGIES CO.,LTD.
+90B11C|Dell Inc.
+90B134|ARRIS Group, Inc.
+90B21F|Apple
+90B686|Murata Manufacturing Co., Ltd.
+90B8D0|Joyent, Inc.
+90B931|Apple
+90B97D|Johnson Outdoors Marine Electronics d/b/a Minnkota
+90C115|Sony Ericsson Mobile Communications AB
+90C35F|Nanjing Jiahao Technology Co., Ltd.
+90C682|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+90C792|ARRIS Group, Inc.
+90CC24|Synaptics, Inc
+90CF15|Nokia Corporation
+90CF6F|Dlogixs Co Ltd
+90CF7D|Qingdao Hisense Electric Co.,Ltd.
+90D11B|Palomar Medical Technologies
+90D74F|Bookeen
+90D7EB|Texas Instruments
+90D852|Comtec Co., Ltd.
+90D92C|HUG-WITSCHI AG
+90DA4E|AVANU
+90DA6A|FOCUS H&S Co., Ltd.
+90DB46|E-LEAD ELECTRONIC CO., LTD
+90DFB7|s.m.s smart microwave sensors GmbH
+90E0F0|IEEE 1722a Working Group
+90E2BA|Intel Corporate
+90E6BA|ASUSTek COMPUTER INC.
+90E7C4|HTC Corporation
+90EA60|SPI Lasers Ltd
+90EF68|ZyXEL Communications Corporation
+90F1AA|Samsung
+90F1B0|Hangzhou Anheng Info&Tech CO.,LTD
+90F278|Radius Gateway
+90F3B7|Kirisun Communications Co., Ltd.
+90F4C1|Rand McNally
+90F652|TP-LINK TECHNOLOGIES CO., LTD.
+90F72F|Phillips Machine & Welding Co., Inc.
+90FB5B|Avaya, Inc
+90FBA6|Hon Hai Precision Ind.Co.Ltd
+90FD61|Apple
+90FF79|Metro Ethernet Forum
+940070|Nokia Corporation
+940149|AutoHotBox
+9401C2|Samsung
+94049C|HUAWEI TECHNOLOGIES CO.,LTD
+9405B6|Liling FullRiver Electronics & Technology Ltd
+940937|HUMAX Co., Ltd.
+940B2D|NetView Technologies(Shenzhen) Co., Ltd
+940BD5|Himax Technologies, Inc
+940C6D|TP-LINK Technologies Co.,Ltd.
+94103E|Belkin International Inc.
+9411DA|ITF Froschl GmbH
+941673|Point Core SARL
+941D1C|TLab West Systems AB
+942053|Nokia Corporation
+942197|Stalmart Technology Limited
+94236E|Shenzhen Junlan Electronic Ltd
+942E17|Schneider Electric Canada Inc
+942E63|Finsecur
+94319B|Alphatronics BV
+9433DD|Taco Electronic Solutions, Inc.
+94350A|Samsung
+9436E0|Sichuan Bihong Broadcast &amp; Television New Technologies Co.,Ltd
+9439E5|Hon Hai Precision Ind. Co.,Ltd.
+943AF0|Nokia Corporation
+943BB1|KAONMEDIA
+9440A2|Anywave Communication Technologies, Inc.
+944444|LG Innotek
+944452|Belkin International Inc.
+944696|BaudTec Corporation
+944A09|BitWise Controls
+944A0C|Sercomm Corporation
+945047|Rechnerbetriebsgruppe
+945103|Samsung
+9451BF|Hyundai ESG
+945493|Rigado, LLC
+94592D|EKE Building Technology Systems Ltd
+945B7E|TRILOBIT LTDA.
+946124|Pason Systems
+946269|Arris Group, Inc.
+9463D1|Samsung
+94659C|Intel Corporate
+9470D2|WINFIRM TECHNOLOGY
+9471AC|TCT Mobile Limited
+94756E|QinetiQ North America
+94772B|Huawei Technologies Co., Ltd
+947C3E|Polewall Norge AS
+9481A4|Azuray Technologies
+94857A|Evantage Industries Corp
+9486D4|Surveillance Pro Corporation
+94877C|ARRIS Group, Inc.
+948854|Texas Instruments
+948B03|EAGET Innovation and Technology Co., Ltd.
+948D50|Beamex Oy Ab
+948E89|INDUSTRIAS UNIDAS SA DE CV
+948FEE|Hughes Telematics, Inc.
+949426|Apple
+9498A2|Shanghai LISTEN TECH.LTD
+949BFD|Trans New Technology, Inc.
+949C55|Alta Data Technologies
+949F3F|Optek Digital Technology company limited
+949FB4|ChengDu JiaFaAnTai Technology Co.,Ltd
+94A1A2|AMPAK Technology Inc.
+94A7B7|zte corporation
+94A7BC|BodyMedia, Inc.
+94AAB8|Joview(Beijing) Technology Co. Ltd.
+94ACCA|trivum technologies GmbH
+94AE61|Alcatel Lucent
+94AEE3|Belden Hirschmann Industries (Suzhou) Ltd.
+94B40F|Aruba Networks
+94B8C5|RuggedCom Inc.
+94B9B4|Aptos Technology
+94BA31|Visiontec da Amazonia Ltda.
+94BA56|Shenzhen Coship Electronics Co., Ltd.
+94BF1E|eflow Inc. / Smart Device Planning and Development Division
+94BF95|Shenzhen Coship Electronics Co., Ltd
+94C014|Sorter Sp. j. Konrad Grzeszczyk MichaA, Ziomek
+94C038|Tallac Networks
+94C150|2Wire Inc
+94C3E4|SCA Schucker Gmbh & Co KG
+94C4E9|PowerLayer Microsystems HongKong Limited
+94C6EB|NOVA electronics, Inc.
+94C7AF|Raylios Technology
+94C962|Teseq AG
+94CA0F|Honeywell Analytics
+94CCB9|ARRIS Group, Inc.
+94CDAC|Creowave Oy
+94CE2C|Sony Mobile Communications AB
+94CE31|CTS Limited
+94D019|Cydle Corp.
+94D417|GPI KOREA INC.
+94D60E|shenzhen yunmao information technologies co., ltd
+94D723|Shanghai DareGlobal Technologies Co., Ltd
+94D771|Samsung
+94D93C|ENELPS
+94DB49|SITCORP
+94DBC9|Azurewave
+94DD3F|A+V Link Technologies, Corp.
+94DE0E|SmartOptics AS
+94DE80|GIGA-BYTE TECHNOLOGY CO.,LTD.
+94DF4E|Wistron InfoComm(Kunshan)Co.,Ltd.
+94DF58|IJ Electron CO.,Ltd.
+94E0D0|HealthStream Taiwan Inc.
+94E226|D. ORtiz Consulting, LLC
+94E2FD|Boge Kompressoren Otto Boge GmbH & Co. KG
+94E711|Xirka Dama Persada PT
+94E848|FYLDE MICRO LTD
+94E96A|Apple
+94E98C|Alcatel-Lucent
+94EB2C|Google
+94EBCD|Research In Motion Limited
+94F19E|HUIZHOU MAORONG INTELLIGENT TECHNOLOGY CO.,LTD
+94F665|Ruckus Wireless
+94F692|Geminico co., Ltd.
+94F720|Tianjin Deviser Electronics Instrument Co., Ltd
+94FAE8|Shenzhen Eycom Technology Co., Ltd
+94FBB2|Shenzhen Gongjin Electronics Co.,Ltd
+94FD1D|WhereWhen Corp
+94FD2E|Shanghai Uniscope Technologies Co.,Ltd
+94FEF4|SAGEMCOM
+980284|Theobroma Systems GmbH
+9802D8|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+9803A0|ABB n.v. Power Quality Products
+9803D8|Apple
+980C82|Samsung
+980D2E|HTC Corporation
+980EE4|ZZZZ 
+981094|Shenzhen Vsun communication technology Co.,ltd
+9816EC|IC Intracom
+981DFA|Samsung
+98208E|Definium Technologies
+98262A|Applied Research Associates, Inc
+98291D|Jaguar de Mexico, SA de CV
+98293F|Fujian Start Computer Equipment Co.,Ltd
+982CBE|2Wire
+982D56|Resolution Audio
+982F3C|Sichuan Changhong Electric Ltd.
+983000|Beijing KEMACOM Technologies Co., Ltd.
+983071|DAIKYUNG VASCOM
+98349D|Krauss Maffei Technologies GmbH
+983571|Sub10 Systems Ltd
+9835B8|Assembled Products Corporation
+983713|PT.Navicom Indonesia
+983B16|AMPAK Technology Inc
+983F9F|China SSJ (Suzhou) Network Technology Inc.
+984246|SOL INDUSTRY PTE., LTD
+9843DA|INTERTECH
+98473C|SHANGHAI SUNMON COMMUNICATION TECHNOGY CO.,LTD
+984A47|CHG Hospital Beds
+984B4A|ARRIS Group, Inc.
+984BE1|Hewlett-Packard Company
+984C04|Zhangzhou Keneng Electrical Equipment Co Ltd
+984CD3|Mantis Deposition
+984E97|Starlight Marketing (H. K.) Ltd.
+984FEE|Intel Corporate
+9852B1|Samsung
+9857D3|HON HAI-CCPBG  PRECISION IND.CO.,LTD.
+98588A|SYSGRATION Ltd.
+985945|Texas Instruments
+985AEB|Apple
+985C93|SBG Systems SAS
+985D46|PeopleNet Communication
+985E1B|ConversDigital Co., Ltd.
+986022|EMW Co., Ltd.
+9866EA|Industrial Control Communications, Inc.
+986B3D|ARRIS Group, Inc.
+986CF5|zte corporation
+986DC8|TOSHIBA MITSUBISHI-ELECTRIC INDUSTRIAL SYSTEMS CORPORATION
+9873C4|Sage Electronic Engineering LLC
+9876B6|Adafruit
+987770|Pep Digital Technology (Guangzhou) Co., Ltd
+987BF3|Texas Instruments
+987E46|Emizon Networks Limited
+988217|Disruptive Ltd
+988389|Samsung
+9886B1|Flyaudio corporation (China)
+9889ED|Anadem Information Inc.
+988B5D|SAGEM COMMUNICATION
+988BAD|Corintech Ltd.
+988E34|ZHEJIANG BOXSAM ELECTRONIC CO.,LTD
+988E4A|NOXUS(BEIJING) TECHNOLOGY CO.,LTD
+988EDD|TE Connectivity Limerick
+989080|Linkpower Network System Inc Ltd.
+989096|Dell Inc
+9893CC|LG Electronics
+989449|Skyworth Wireless Technology Ltd.
+98A7B0|MCST ZAO
+98AAD7|BLUE WAVE NETWORKING CO LTD
+98B039|Alcatel-Lucent
+98B8E3|Apple
+98BC57|SVA TECHNOLOGIES CO.LTD
+98BC99|Edeltech Co.,Ltd.
+98BE94|IBM
+98C0EB|Global Regency Ltd
+98C845|PacketAccess
+98CDB4|Virident Systems, Inc.
+98D331|Shenzhen Bolutek Technology Co.,Ltd.
+98D686|Chyi Lee industry Co., ltd.
+98D6BB|Apple
+98D6F7|LG Electronics
+98D88C|Nortel Networks
+98DA92|Vuzix Corporation
+98DCD9|UNITEC Co., Ltd.
+98E0D9|Apple
+98E165|Accutome
+98E79A|Foxconn(NanJing) Communication Co.,Ltd.
+98EC65|Cosesy ApS
+98EECB|Wistron InfoComm(ZhongShan)Corporation
+98F0AB|Apple
+98F170|Murata Manufacturing Co., Ltd.
+98F537|zte corporation
+98F5A9|OHSUNG ELECTRONICS CO.,LTD.
+98F8C1|IDT Technology Limited
+98F8DB|Marini Impianti Industriali s.r.l.
+98FAE3|Xiaomi
+98FB12|Grand Electronics (HK) Ltd
+98FC11|Cisco
+98FE03|Ericsson - North America
+98FE94|Apple
+98FF6A|OTEC(Shanghai)Technology Co.,Ltd.
+98FFD0|Lenovo Mobile Communication Technology Ltd.
+9C0111|Shenzhen Newabel Electronic Co., Ltd.
+9C0298|Samsung
+9C039E|Beijing Winchannel Software Technology Co., Ltd
+9C0473|Tecmobile (International) Ltd.
+9C04EB|Apple
+9C066E|Hytera Communications Corporation Limited
+9C0DAC|Tymphany HK Limited
+9C1465|Edata Elektronik San. ve Tic. A.S.
+9C1874|Nokia Danmark A/S
+9C1C12|Aruba Networks
+9C1FDD|Accupix Inc.
+9C207B|Apple
+9C216A|TP-LINK TECHNOLOGIES CO.,LTD.
+9C220E|TASCAN Service GmbH
+9C2840|Discovery Technology,LTD..
+9C28BF|Continental Automotive Czech Republic s.r.o.
+9C28EF|HUAWEI TECHNOLOGIES CO.,LTD
+9C2A70|Hon Hai Precision Ind. Co.,Ltd.
+9C3066|RWE Effizienz GmbH
+9C3178|Foshan Huadian Intelligent Communications Teachnologies Co.,Ltd
+9C31B6|Kulite Semiconductor Products Inc
+9C3583|Nipro Diagnostics, Inc
+9C35EB|Apple
+9C37F4|HUAWEI TECHNOLOGIES CO.,LTD
+9C3AAF|Samsung
+9C3EAA|EnvyLogic Co.,Ltd.
+9C417C|Hame  Technology Co.,  Limited
+9C443D|CHENGDU XUGUANG TECHNOLOGY CO, LTD
+9C44A6|SwiftTest, Inc.
+9C4563|DIMEP Sistemas
+9C4A7B|Nokia Corporation
+9C4CAE|Mesa Labs
+9C4E20|Cisco
+9C4E36|Intel Corporate
+9C4E8E|ALT Systems Ltd
+9C4EBF|BoxCast
+9C53CD|ENGICAM s.r.l.
+9C541C|Shenzhen My-power Technology Co.,Ltd
+9C54CA|Zhengzhou VCOM Science and Technology Co.,Ltd
+9C55B4|I.S.E. S.r.l.
+9C5711|Feitian Xunda(Beijing) Aeronautical Information Technology Co., Ltd.
+9C5B96|NMR Corporation
+9C5C8D|FIREMAX INDUSTRIA E COMERCIO DE PRODUTOS ELETRONICOS  LTDA
+9C5D12|Aerohive Networks Inc
+9C5D95|VTC Electronics Corp.
+9C5E73|Calibre UK Ltd
+9C611D|Omni-ID USA, Inc.
+9C645E|Harman Consumer Group
+9C65B0|Samsung
+9C65F9|AcSiP Technology Corp.
+9C6650|Glodio Technolies Co.,Ltd Tianjin Branch
+9C685B|Octonion SA
+9C6ABE|QEES ApS.
+9C6C15|Microsoft
+9C7514|Wildix srl
+9C77AA|NADASNV
+9C79AC|Suntec Software(Shanghai) Co., Ltd.
+9C7BD2|NEOLAB Convergence
+9C807D|SYSCABLE Korea Inc.
+9C80DF|Arcadyan Technology Corporation
+9C86DA|Phoenix Geophysics Ltd.
+9C8888|Simac Techniek NV
+9C8BF1|The Warehouse Limited
+9C8D1A|INTEG process group inc
+9C8E99|Hewlett-Packard Company
+9C8EDC|Teracom Limited
+9C934E|Xerox Corporation
+9C95F8|SmartDoor Systems, LLC
+9C9726|Technicolor
+9C9811|Guangzhou Sunrise Electronics Development Co., Ltd
+9C9C1D|Starkey Labs Inc.
+9CA10A|SCLE SFE
+9CA134|Nike, Inc.
+9CA3BA|SAKURA Internet Inc.
+9CA577|Osorno Enterprises Inc.
+9CA9E4|zte corporation
+9CAD97|Hon Hai Precision Ind. Co.,Ltd.
+9CADEF|Obihai Technology, Inc.
+9CAFCA|Cisco
+9CB008|Ubiquitous Computing Technology Corporation
+9CB206|PROCENTEC
+9CB654|Hewlett Packard
+9CB6D0|Rivet Networks
+9CB70D|Liteon Technology Corporation
+9CB793|Creatcomm Technology Inc.
+9CBB98|Shen Zhen RND Electronic Co.,LTD
+9CBD9D|SkyDisk, Inc.
+9CBEE0|Biosoundlab Co., Ltd.
+9CC077|PrintCounts, LLC
+9CC0D2|Conductix-Wampfler GmbH
+9CC172|Huawei Technologies Co., Ltd
+9CC7A6|AVM GmbH
+9CC7D1|SHARP Corporation
+9CCAD9|Nokia Corporation
+9CCD82|CHENG UEI PRECISION INDUSTRY CO.,LTD
+9CD21E|Hon Hai Precision Ind. Co.,Ltd.
+9CD24B|zte corporation
+9CD35B|Samsung
+9CD36D|Netgear
+9CD643|D-Link International
+9CD917|Motorola
+9CDF03|Harman/Becker Automotive Systems GmbH
+9CE10E|NCTech Ltd
+9CE1D6|Junger Audio-Studiotechnik GmbH
+9CE230|JULONG CO,.LTD.
+9CE635|Nintendo Co., Ltd.
+9CE6E7|Samsung
+9CE7BD|Winduskorea co., Ltd
+9CEBE8|BizLink (Kunshan) Co.,Ltd
+9CF387|Apple
+9CF61A|UTC Fire and Security
+9CF67D|Ricardo Prague, s.r.o.
+9CF8DB|shenzhen eyunmei technology co,.ltd
+9CF938|AREVA NP GmbH
+9CFBF1|MESOMATIC GmbH & Co.KG
+9CFC01|Apple
+9CFFBE|OTSL Inc.
+A002DC|Amazon Technologies Inc.
+A00363|Robert Bosch Healthcare GmbH
+A00627|NEXPA System
+A00798|Samsung
+A007B6|Advanced Technical Support, Inc.
+A00ABF|Wieson Technologies Co., Ltd.
+A00BBA|Samsung
+A00CA1|SKTB SKiT
+A01290|Avaya, Inc
+A012DB|TABUCHI ELECTRIC CO.,LTD
+A0133B|HiTi Digital, Inc.
+A013CB|Fiberhome Telecommunication Technologies Co.,LTD
+A0143D|PARROT SA
+A0165C|Triteka LTD
+A01828|Apple
+A01859|Shenzhen Yidashi Electronics Co Ltd
+A01917|Bertel S.p.a.
+A01C05|NIMAX TELECOM CO.,LTD.
+A01D48|Hewlett Packard
+A02195|Samsung
+A021B7|Netgear
+A0231B|TeleComp R&D Corp.
+A02BB8|Hewlett Packard
+A02EF3|United Integrated Services Co., Led.
+A0369F|Intel Corporate
+A036F0|Comprehensive Power
+A036FA|Ettus Research LLC
+A03A75|PSS Belgium N.V.
+A03B1B|Inspire Tech
+A04025|Actioncable, Inc.
+A04041|SAMWONFA Co.,Ltd.
+A041A7|NL Ministry of Defense
+A0423F|Tyan Computer Corp
+A0481C|Hewlett Packard
+A04CC1|Helixtech Corp.
+A04E04|Nokia Corporation
+A04FD4|ADB Broadband Italia
+A051C6|Avaya, Inc
+A0554F|Cisco
+A055DE|Pace plc
+A056B2|Harman/Becker Automotive Systems GmbH
+A0593A|V.D.S. Video Display Systems srl
+A05AA4|Grand Products Nevada, Inc.
+A05B21|ENVINET GmbH
+A05DC1|TMCT Co., LTD.
+A05DE7|DIRECTV, Inc.
+A05E6B|MELPER Co., Ltd.
+A06391|Netgear
+A06518|VNPT TECHNOLOGY
+A067BE|Sicon s.r.l.
+A06986|Wellav Technologies Ltd
+A06A00|Verilink Corporation
+A06CEC|RIM
+A06D09|Intelcan Technosystems Inc.
+A06E50|Nanotek Elektronik Sistemler Ltd. Sti.
+A071A9|Nokia Corporation
+A07332|Cashmaster International Limited
+A073FC|Rancore Technologies Private Limited
+A07591|Samsung
+A07771|Vialis BV
+A078BA|Pantech Co., Ltd.
+A0821F|Samsung
+A082C7|P.T.I Co.,LTD
+A0861D|Chengdu Fuhuaxin Technology co., Ltd
+A086C6|Xiaomi
+A086EC|SAEHAN HITEC Co., Ltd
+A08869|Intel Corporate
+A088B4|Intel Corporate
+A089E4|Skyworth Digital Technology(Shenzhen) Co.,Ltd
+A08A87|HuiZhou KaiYue Electronic Co.,Ltd
+A08C15|Gerhard D. Wempe KG
+A08C9B|Xtreme Technologies Corp
+A090DE|VEEDIMS,LLC
+A09347|GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD.
+A09805|OpenVox Communication Co Ltd
+A098ED|Shandong Intelligent Optical Communication Development Co., Ltd.
+A0999B|Apple
+A09A5A|Time Domain
+A09BBD|Total Aviation Solutions Pty Ltd
+A0A130|DLI Taiwan Branch office
+A0A23C|GPMS
+A0A3E2|Actiontec Electronics, Inc
+A0A65C|Supercomputing Systems AG
+A0A763|Polytron Vertrieb GmbH
+A0A8CD|Intel Corporate
+A0AAFD|EraThink Technologies Corp.
+A0ADA1|JMR Electronics, Inc
+A0B100|ShenZhen Cando Electronics Co.,Ltd
+A0B3CC|Hewlett Packard
+A0B437|GENERAL DYNAMICS C4 SYSEMS
+A0B4A5|Samsung
+A0B5DA|HongKong THTF Co., Ltd
+A0B662|Acutvista Innovation Co., Ltd.
+A0B9ED|Skytap
+A0BAB8|Pixon Imaging
+A0BB3E|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+A0BF50|S.C. ADD-PRODUCTION S.R.L.
+A0BFA5|CORESYS
+A0C2DE|Costar Video Systems
+A0C3DE|Triton Electronic Systems Ltd.
+A0C562|Pace plc
+A0C6EC|ShenZhen ANYK Technology Co.,LTD
+A0CEC8|CE LINK LIMITED
+A0CF5B|Cisco
+A0D12A|AXPRO Technology Inc.
+A0D3C1|Hewlett Packard
+A0DA92|Nanjing Glarun Atten Technology Co. Ltd.
+A0DC04|Becker-Antriebe GmbH
+A0DD97|PolarLink Technologies, Ltd
+A0DDE5|SHARP Corporation
+A0DE05|JSC "Irbis-T"
+A0E201|AVTrace Ltd.(China)
+A0E25A|Amicus SK, s.r.o.
+A0E295|DAT System Co.,Ltd
+A0E453|Sony Mobile Communications AB
+A0E4CB|ZyXEL Communications Corporation
+A0E534|Stratec Biomedical AG
+A0E5E9|enimai Inc
+A0E6F8|Texas Instruments Inc
+A0E9DB|Ningbo FreeWings Technologies Co.,Ltd
+A0EB76|AirCUVE Inc.
+A0EC80|zte corporation
+A0ECF9|Cisco
+A0EDCD|Apple
+A0EF84|Seine Image Int'l Co., Ltd
+A0F217|GE Medical System(China) Co., Ltd.
+A0F3C1|TP-LINK TECHNOLOGIES CO., LTD.
+A0F3E4|Alcatel Lucent IPD
+A0F419|Nokia Corporation
+A0F450|HTC Corporation
+A0F459|FN-LINK TECHNOLOGY LIMITED
+A0F6FD|Texas Instruments
+A0F849|Cisco
+A0FC6E|Telegrafia a.s.
+A0FE91|AVAT Automation GmbH
+A40130|ABIsystems Co., LTD
+A4059E|STA Infinity LLP
+A408EA|Murata Manufacturing Co., Ltd.
+A409CB|Alfred Kaercher GmbH &amp; Co KG
+A40BED|Carry Technology Co.,Ltd
+A40CC3|Cisco
+A41242|NEC Platforms, Ltd.
+A4134E|Luxul
+A41566|Wei Fang Goertek Electronics Co.,Ltd
+A41731|Hon Hai Precision Ind. Co.,Ltd.
+A41875|Cisco
+A41BC0|Fastec Imaging Corporation
+A41F72|Dell Inc.
+A4218A|Nortel Networks
+A42305|Open Networking Laboratory
+A424B3|FlatFrog Laboratories AB
+A424DD|Cambrionix Ltd
+A4251B|Avaya, Inc
+A42940|Shenzhen YOUHUA Technology Co., Ltd
+A429B7|bluesky
+A42B8C|Netgear
+A42C08|Masterwork Automodules
+A43135|Apple
+A433D1|Fibrlink Communications Co.,Ltd.
+A434D9|Intel Corporate
+A438FC|Plastic Logic
+A43A69|Vers Inc
+A43BFA|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+A43D78|GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD
+A4466B|EOC Technology
+A446FA|AmTRAN Video Corporation
+A44AD3|ST Electronics(Shanghai) Co.,Ltd
+A44B15|Sun Cupid Technology (HK) LTD
+A44C11|Cisco
+A44E2D|Adaptive Wireless Solutions, LLC
+A44E31|Intel Corporate
+A44F29|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+A45055|busware.de
+A4526F|ADB Broadband Italia
+A45602|fenglian Technology Co.,Ltd.
+A4561B|MCOT Corporation
+A45630|Cisco
+A45A1C|smart-electronic GmbH
+A45C27|Nintendo Co., Ltd.
+A45D36|Hewlett Packard
+A45DA1|ADB Broadband Italia
+A45E60|Apple
+A46032|MRV Communications (Networks) LTD
+A46706|Apple
+A46C2A|Cisco
+A46CC1|LTi REEnergy GmbH
+A46E79|DFT System Co.Ltd
+A470D6|Motorola
+A47733|Google
+A47760|Nokia Corporation
+A479E4|KLINFO Corp
+A47AA4|ARRIS Group, Inc.
+A47ACF|VIBICOM COMMUNICATIONS INC.
+A47B2C|Alcatel-Lucent
+A47B85|ULTIMEDIA Co Ltd,
+A47C14|ChargeStorm AB
+A47C1F|Cobham plc
+A47E39|zte corporation
+A481EE|Nokia Corporation
+A4856B|Q Electronics Ltd
+A4895B|ARK INFOSOLUTIONS PVT LTD
+A48CDB|Lenovo
+A49005|CHINA GREATWALL COMPUTER SHENZHEN CO.,LTD
+A4934C|Cisco
+A497BB|Hitachi Industrial Equipment Systems Co.,Ltd
+A49947|Huawei Technologies Co., Ltd
+A49981|FuJian Elite Power Tech CO.,LTD.
+A49A58|Samsung
+A49B13|Burroughs Payment Systems, Inc.
+A49D49|Ketra, Inc.
+A49EDB|AutoCrib, Inc.
+A49F85|Lyve Minds, Inc
+A49F89|Shanghai Rui Rui Communication Technology Co.Ltd.
+A4A1C2|Ericsson AB (EAB)
+A4A1E4|Innotube, Inc.
+A4A24A|Cisco
+A4A4D3|Bluebank Communication Technology Co.Ltd
+A4A80F|Shenzhen Coship Electronics Co., Ltd.
+A4AD00|Ragsdale Technology
+A4ADB8|Vitec Group, Camera Dynamics Ltd
+A4AE9A|Maestro Wireless Solutions ltd.
+A4B121|Arantia 2010 S.L.
+A4B197|Apple
+A4B1E9|Technicolor
+A4B1EE|H. ZANDER GmbH & Co. KG
+A4B2A7|Adaxys Solutions AG
+A4B36A|JSC SDO Chromatec
+A4B818|PENTA Gesellschaft fur elektronische Industriedatenverarbeitung mbH
+A4B980|Parking BOXX Inc.
+A4BADB|Dell Inc.
+A4BBAF|Lime Instruments
+A4BE61|EutroVision System, Inc.
+A4C0C7|ShenZhen Hitom Communication Technology Co..LTD
+A4C0E1|Nintendo Co., Ltd.
+A4C2AB|Hangzhou LEAD-IT Information & Technology Co.,Ltd
+A4C361|Apple
+A4C494|Intel Corporate
+A4C7DE|Cambridge Industries(Group) Co.,Ltd.
+A4D094|Erwin Peters Systemtechnik GmbH
+A4D18F|Shenzhen Skyee Optical Fiber Communication Technology Ltd.
+A4D1D1|ECOtality North America
+A4D1D2|Apple
+A4D3B5|GLITEL Stropkov, s.r.o.
+A4D856|Gimbal, Inc
+A4DA3F|Bionics Corp.
+A4DB2E|Kingspan Environmental Ltd
+A4DB30|Liteon Technology Corporation
+A4DE50|Total Walther GmbH
+A4E0E6|FILIZOLA S.A. PESAGEM E AUTOMACAO
+A4E32E|Silicon & Software Systems Ltd.
+A4E391|DENY FONTAINE
+A4E4B8|BlackBerry Limited
+A4E731|Nokia Corporation
+A4E7E4|Connex GmbH
+A4E991|SISTEMAS AUDIOVISUALES ITELSIS S.L.
+A4E9A3|Honest Technology Co., Ltd
+A4EBD3|Samsung
+A4ED4E|ARRIS Group, Inc.
+A4EE57|SEIKO EPSON CORPORATION
+A4EF52|Telewave Co., Ltd.
+A4F3C1|Open Source Robotics Foundation, Inc.
+A4F522|CHOFU SEISAKUSHO CO.,LTD
+A4F7D0|LAN Accessories Co., Ltd.
+A4FB8D|Hangzhou Dunchong Technology Co.Ltd
+A4FCCE|Security Expert Ltd.
+A80180|IMAGO Technologies GmbH
+A80600|Samsung
+A80C0D|Cisco
+A81374|Panasonic Corporation AVC Networks Company
+A8154D|TP-LINK TECHNOLOGIES CO.,LTD.
+A816B2|LG Electronics
+A81758|Elektronik System i Umea AB
+A81B18|XTS CORP
+A81B5A|GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD.
+A81B5D|Foxtel Management Pty Ltd
+A81D16|AzureWave Technologies, Inc
+A81FAF|KRYPTON POLSKA
+A82066|Apple
+A824EB|ZAO NPO Introtest
+A826D9|HTC Corporation
+A8294C|Precision Optical Transceivers, Inc.
+A82BD6|Shina System Co., Ltd
+A830AD|Wei Fang Goertek Electronics Co.,Ltd
+A8329A|Digicom Futuristic Technologies Ltd.
+A83944|Actiontec Electronics, Inc
+A84041|Dragino Technology Co., Limited
+A84481|Nokia Corporation
+A845E9|Firich Enterprises CO., LTD.
+A849A5|Lisantech Co., Ltd.
+A854B2|Wistron Neweb Corp.
+A8556A|Pocketnet Technology Inc.
+A8574E|TP-LINK TECHNOLOGIES CO.,LTD.
+A85B78|Apple
+A85BB0|Shenzhen Dehoo Technology Co.,Ltd
+A85BF3|Audivo GmbH
+A861AA|Cloudview Limited
+A862A2|JIWUMEDIA CO., LTD.
+A863DF|DISPLAIRE CORPORATION
+A863F2|Texas Instruments
+A86405|nimbus 9, Inc
+A865B2|DONGGUAN YISHANG ELECTRONIC TECHNOLOGY CO., LIMITED
+A8667F|Apple
+A86A6F|RIM
+A870A5|UniComm Inc.
+A875D6|FreeTek International Co., Ltd.
+A875E2|Aventura Technologies, Inc.
+A8776F|Zonoff
+A87B39|Nokia Corporation
+A87C01|Samsung
+A87E33|Nokia Danmark A/S
+A88038|ShenZhen MovingComm Technology Co., Limited
+A881F1|BMEYE B.V.
+A8827F|CIBN Oriental Network(Beijing) CO.,Ltd
+A886DD|Apple
+A88792|Broadband Antenna Tracking Systems
+A887ED|ARC Wireless LLC
+A88808|Apple
+A88CEE|MicroMade Galka i Drozdz sp.j.
+A88D7B|SunDroid Global limited.
+A88E24|Apple
+A89008|Beijing Yuecheng Technology Co. Ltd.
+A8922C|LG Electronics
+A893E6|JIANGXI JINGGANGSHAN CKING COMMUNICATION TECHNOLOGY CO.,LTD
+A895B0|Aker Subsea Ltd
+A8968A|Apple
+A897DC|IBM
+A898C6|Shinbo Co., Ltd.
+A8995C|aizo ag
+A89B10|inMotion Ltd.
+A89D21|Cisco
+A89DD2|Shanghai DareGlobal Technologies Co., Ltd
+A89FBA|Samsung
+A8A668|zte corporation
+A8AD3D|Alcatel-Lucent Shanghai Bell Co., Ltd
+A8B0AE|LEONI
+A8B1D4|Cisco
+A8B9B3|ESSYS
+A8BBCF|Apple
+A8BD1A|Honey Bee (Hong Kong) Limited
+A8BD3A|UNIONMAN TECHNOLOGY CO.,LTD
+A8C222|TM-Research Inc.
+A8CB95|EAST BEST CO., LTD.
+A8CCC5|Saab AB (publ)
+A8CE90|CVC
+A8D0E3|Systech Electronics Ltd.
+A8D0E5|Juniper Networks
+A8D236|Lightware Visual Engineering
+A8D3C8|Wachendorff Elektronik  GmbH & Co. KG
+A8D409|USA 111 Inc
+A8D88A|Wyconn
+A8E018|Nokia Corporation
+A8E3EE|Sony Computer Entertainment Inc.
+A8E539|Moimstone Co.,Ltd
+A8EF26|Tritonwave
+A8F038|SHEN ZHEN SHI JIN HUA TAI ELECTRONICS CO.,LTD
+A8F274|Samsung
+A8F470|Fujian Newland Communication Science Technologies Co.,Ltd.
+A8F7E0|PLANET Technology Corporation
+A8F94B|Eltex Enterprise Ltd.
+A8FAD8|Apple
+A8FB70|WiseSec L.t.d
+A8FCB7|Consolidated Resource Imaging
+AA0000|DIGITAL EQUIPMENT CORPORATION
+AA0001|DIGITAL EQUIPMENT CORPORATION
+AA0002|DIGITAL EQUIPMENT CORPORATION
+AA0003|DIGITAL EQUIPMENT CORPORATION
+AA0004|DIGITAL EQUIPMENT CORPORATION
+AC0142|Uriel Technologies SIA
+AC02CA|HI Solutions, Inc.
+AC02CF|RW Tecnologia Industria e Comercio Ltda
+AC02EF|Comsis
+AC0613|Senselogix Ltd
+AC0A61|Labor S.r.L.
+AC0DFE|Ekon GmbH - myGEKKO
+AC11D3|Suzhou HOTEK  Video Technology Co. Ltd
+AC1461|ATAW  Co., Ltd.
+AC14D2|wi-daq, inc.
+AC162D|Hewlett Packard
+AC1702|Fibar Group sp. z o.o.
+AC1826|SEIKO EPSON CORPORATION
+AC199F|SUNGROW POWER SUPPLY CO.,LTD.
+AC20AA|DMATEK Co., Ltd.
+AC220B|ASUSTek COMPUTER INC.
+AC293A|Apple
+AC2DA3|TXTR GmbH
+AC2FA8|Humannix Co.,Ltd.
+AC319D|Shenzhen TG-NET Botone Technology Co.,Ltd.
+AC34CB|Shanhai GBCOM Communication Technology Co. Ltd
+AC3613|Samsung
+AC3870|Lenovo Mobile Communication Technology Ltd.
+AC3A7A|Roku
+AC3C0B|Apple
+AC3CB4|Nilan A/S
+AC3D05|Instorescreen Aisa
+AC3D75|HANGZHOU ZHIWAY TECHNOLOGIES CO.,LTD.
+AC3FA4|TAIYO YUDEN CO.,LTD
+AC40EA|C&T Solution Inc.
+AC4122|Eclipse Electronic Systems Inc.
+AC44F2|Revolabs Inc
+AC4723|Genelec
+AC4AFE|Hisense Broadband Multimedia Technology Co.,Ltd.
+AC4BC8|Juniper Networks
+AC4E91|HUAWEI TECHNOLOGIES CO.,LTD
+AC4FFC|SVS-VISTEK GmbH
+AC5036|Pi-Coral Inc
+AC5135|MPI TECH
+AC51EE|Cambridge Communication Systems Ltd
+AC54EC|IEEE P1823 Standards Working Group
+AC562C|LAVA INTERNATIONAL(H.K) LIMITED
+AC583B|Human Assembler, Inc.
+AC5A14|Samsung
+AC5D10|Pace Americas
+AC5E8C|Utillink
+AC6123|Drivven, Inc.
+AC620D|Jabil Circuit (Wuxi) Co. LTD
+AC6706|Ruckus Wireless
+AC6BAC|Jenny Science AG
+AC6E1A|Shenzhen Gongjin Electronics Co.,Ltd
+AC6F4F|Enspert Inc
+AC6FBB|TATUNG Technology Inc.
+AC6FD9|Valueplus Inc.
+AC7236|Lexking Technology Co., Ltd.
+AC7289|Intel Corporate
+AC7A42|iConnectivity
+AC7A4D|ALPS ELECTRIC CO.,LTD.
+AC7BA1|Intel Corporate
+AC7F3E|Apple
+AC80D6|Hexatronic AB
+AC8112|Gemtek Technology Co., Ltd.
+AC81F3|Nokia Corporation
+AC8317|Shenzhen Furtunetel Communication Co., Ltd
+AC83F0|ImmediaTV Corporation
+AC853D|HUAWEI TECHNOLOGIES CO.,LTD
+AC8674|Open Mesh, Inc.
+AC867E|Create New Technology (HK) Limited Company
+AC87A3|Apple
+AC8ACD|ROGER D.Wensker, G.Wensker sp.j.
+AC8D14|Smartrove Inc
+AC932F|Nokia Corporation
+AC9403|Envision Peripherals Inc
+AC9A96|Lantiq Deutschland GmbH
+AC9B0A|Sony Corporation
+AC9B84|Smak Tecnologia e Automacao
+AC9CE4|Alcatel-Lucent Shanghai Bell Co., Ltd
+AC9E17|ASUSTek COMPUTER INC.
+ACA016|Cisco
+ACA213|Shenzhen Bilian electronic CO.,LTD
+ACA22C|Baycity Technologies Ltd
+ACA31E|Aruba Networks
+ACA430|Peerless AV
+ACA919|TrekStor GmbH
+ACA9A0|Audioengine, Ltd.
+ACAB8D|Lyngso Marine A/S
+ACABBF|AthenTek Inc.
+ACB313|ARRIS Group, Inc.
+ACB57D|Liteon Technology Corporation
+ACB74F|METEL s.r.o.
+ACB859|Uniband Electronic Corp,
+ACBD0B|IMAC CO.,LTD
+ACBE75|Ufine Technologies Co.,Ltd.
+ACBEB6|Visualedge Technology Co., Ltd.
+ACC2EC|CLT INT'L IND. CORP.
+ACC595|Graphite Systems
+ACC698|Kohzu Precision Co., Ltd.
+ACC73F|VITSMO CO., LTD.
+ACC935|Ness Corporation
+ACCA54|Telldus Technologies AB
+ACCA8E|ODA Technologies
+ACCAAB|Virtual Electric Inc
+ACCABA|Midokura Co., Ltd.
+ACCB09|Hefcom Metering (Pty) Ltd
+ACCC8E|Axis Communications AB
+ACCE8F|HWA YAO TECHNOLOGIES CO., LTD
+ACCF23|Hi-flying electronics technology Co.,Ltd
+ACCF5C|Apple
+ACD074|Espressif Inc.
+ACD180|Crexendo Business Solutions, Inc.
+ACD1B8|Hon Hai Precision Ind. Co.,Ltd.
+ACD364|ABB SPA, ABB SACE DIV.
+ACD657|Shaanxi Guolian Digital TV Technology Co., Ltd.
+ACD9D6|tci GmbH
+ACDBDA|Shenzhen Geniatech Inc, Ltd
+ACDE48|IEEE Registration Authority 
+ACE010|Liteon Technology Corporation
+ACE069|ISAAC Instruments
+ACE215|Huawei Technologies Co., Ltd
+ACE348|MadgeTech, Inc
+ACE42E|SK hynix
+ACE64B|Shenzhen Baojia Battery Technology Co., Ltd.
+ACE87B|Huawei Technologies Co., Ltd
+ACE87E|Bytemark Computer Consulting Ltd
+ACE97F|IoT Tech Limited
+ACE9AA|Hay Systems Ltd
+ACEA6A|GENIX INFOCOMM CO., LTD.
+ACEE3B|6harmonics Inc
+ACF0B2|Becker Electronics Taiwan Ltd.
+ACF1DF|D-Link International
+ACF2C5|Cisco
+ACF7F3|Xiaomi
+ACF97E|ELESYS INC.
+ACFD93|Weifang GoerTek Electronics Co., Ltd.
+ACFDCE|Intel Corporate
+ACFDEC|Apple
+B000B4|Cisco
+B00594|Liteon Technology Corporation
+B008BF|Vital Connect, Inc.
+B009D3|Avizia
+B01041|Hon Hai Precision Ind. Co.,Ltd.
+B01203|Dynamics Hong Kong Limited
+B01266|Futaba-Kikaku
+B01408|LIGHTSPEED INTERNATIONAL CO.
+B01743|EDISON GLOBAL CIRCUITS LLC
+B01B7C|Ontrol A.S.
+B01C91|Elim Co
+B01F81|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+B024F3|Progeny Systems
+B03495|Apple
+B0358D|Nokia Corporation
+B03829|Siliconware Precision Industries Co., Ltd.
+B03850|Nanjing CAS-ZDC IOT SYSTEM CO.,LTD
+B0435D|NuLEDs, Inc.
+B04515|mira fitness,LLC.
+B04519|TCT mobile ltd
+B04545|YACOUB Automation GmbH
+B046FC|MitraStar Technology Corp.
+B0487A|TP-LINK TECHNOLOGIES CO., LTD.
+B0495F|OMRON HEALTHCARE Co., Ltd.
+B04C05|Fresenius Medical Care Deutschland GmbH
+B050BC|SHENZHEN BASICOM ELECTRONIC CO.,LTD.
+B0518E|Holl technology CO.Ltd.
+B05706|Vallox Oy
+B058C4|Broadcast Microwave Services, Inc
+B05B1F|THERMO FISHER SCIENTIFIC S.P.A.
+B05B67|Huawei Technologies Co., Ltd
+B05CE5|Nokia Corporation
+B061C7|Ericsson-LG Enterprise
+B06563|Shanghai Railway Communication Factory
+B065BD|Apple
+B068B6|Hangzhou OYE Technology Co. Ltd
+B06971|DEI Sales, Inc.
+B06CBF|3ality Digital Systems GmbH
+B0750C|QA Cafe
+B0754D|Alcatel-Lucent
+B075D5|ZTE Corporation
+B077AC|ARRIS Group, Inc.
+B07908|Cummings Engineering
+B0793C|Revolv Inc
+B07994|Motorola
+B07D62|Dipl.-Ing. H. Horstmann GmbH
+B0808C|Laser Light Engines
+B081D8|I-sys Corp
+B083FE|Dell Inc
+B0869E|Chloride S.r.L
+B08807|Strata Worldwide
+B08991|LGE
+B08E1A|URadio Systems Co., Ltd
+B09074|Fulan Electronics Limited
+B09134|Taleo
+B09137|ISis ImageStream Internet Solutions, Inc
+B0966C|Lanbowan Technology Ltd.
+B0973A|E-Fuel Corporation
+B0989F|LG CNS
+B09928|Fujitsu Limited
+B09AE2|STEMMER IMAGING GmbH
+B09BD4|GNH Software India Private Limited
+B09FBA|Apple
+B0A10A|Pivotal Systems Corporation
+B0A37E|Qingdao Haier Electronics Co.,Ltd
+B0A72A|Ensemble Designs, Inc.
+B0A737|Roku, Inc.
+B0A86E|Juniper Networks
+B0AA36|GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD.
+B0AA77|Cisco
+B0ACFA|Fujitsu Limited
+B0ADAA|Avaya, Inc
+B0B2DC|Zyxel Communications Corporation
+B0B32B|Slican Sp. z o.o.
+B0B448|Texas Instruments
+B0B8D5|Nanjing Nengrui Auto Equipment CO.,Ltd
+B0BD6D|Echostreams Innovative Solutions
+B0BDA1|ZAKLAD ELEKTRONICZNY SIMS
+B0BF99|WIZITDONGDO
+B0C287|Technicolor CH USA Inc
+B0C4E7|Samsung
+B0C554|D-Link International
+B0C559|Samsung
+B0C69A|Juniper Networks
+B0C745|Buffalo Inc.
+B0C83F|Jiangsu Cynray IOT Co., Ltd.
+B0C8AD|People Power Company
+B0C95B|Beijing Symtech CO.,LTD
+B0CE18|Zhejiang shenghui lighting co., Ltd
+B0CF4D|MI-Zone Technology Ireland
+B0D09C|Samsung
+B0D2F5|Vello Systems, Inc.
+B0D59D|Shenzhen Zowee Technology Co., Ltd
+B0D7C5|Logipix Ltd
+B0DA00|CERA ELECTRONIQUE
+B0DF3A|Samsung
+B0E03C|TCT mobile ltd
+B0E2E5|Fiberhome Telecommunication Tech.Co.,Ltd.
+B0E39D|CAT SYSTEM CO.,LTD.
+B0E50E|NRG SYSTEMS INC
+B0E754|2Wire
+B0E892|SEIKO EPSON CORPORATION
+B0E97E|Advanced Micro Peripherals
+B0EC71|Samsung
+B0EC8F|GMX SAS
+B0EE45|AzureWave Technologies, Inc.
+B0F1BC|Dhemax Ingenieros Ltda
+B0FAEB|Cisco
+B0FEBD|ZZZZ 
+B4009C|CableWorld Ltd.
+B40142|GCI Science & Technology Co.,LTD
+B40418|Smartchip Integrated Inc.
+B40566|SP Best Corporation Co., LTD.
+B407F9|Samsung
+B40832|TC Communications
+B40AC6|DEXON Systems Ltd.
+B40B44|Smartisan Technology Co., Ltd.
+B40B7A|Brusa Elektronik AG
+B40C25|Palo Alto Networks
+B40E96|HERAN
+B40EDC|LG-Ericsson Co.,Ltd.
+B41489|Cisco
+B41513|HUAWEI TECHNOLOGIES CO.,LTD
+B41780|DTI Group Ltd
+B418D1|Apple
+B41DEF|Internet Laboratories, Inc.
+B4211D|Beijing GuangXin Technology Co., Ltd
+B4218A|Dog Hunter LLC
+B424E7|Codetek Technology Co.,Ltd
+B428F1|E-Prime Co., Ltd.
+B42A39|ORBIT MERRET, spol. s r. o.
+B42C92|Zhejiang Weirong Electronic Co., Ltd
+B42CBE|Direct Payment Solutions Limited
+B43052|Huawei Technologies Co., Ltd
+B431B8|Aviwest
+B4346C|MATSUNICHI DIGITAL TECHNOLOGY (HONG KONG) LIMITED
+B43564|Fujian Tian Cheng Electron Science & Technical Development Co.,Ltd.
+B435F7|Zhejiang Pearmain Electronics Co.ltd.
+B43741|Consert, Inc.
+B43934|Pen Generations, Inc.
+B439D6|ProCurve Networking by HP
+B43A28|Samsung
+B43DB2|Degreane Horizon
+B43E3B|Viableware, Inc
+B4417A|ShenZhen Gongjin Electronics Co.,Ltd
+B4430D|Broadlink Pty Ltd
+B4475E|Avaya, Inc
+B44CC2|NR ELECTRIC CO., LTD
+B451F9|NB Software
+B45253|Seagate Technology
+B4527D|Sony Mobile Communications AB
+B4527E|Sony Mobile Communications AB
+B45570|Borea
+B45861|CRemote, LLC
+B45CA4|Thing-talk Wireless Communication Technologies Corporation Limited
+B461FF|Lumigon A/S
+B46238|Exablox
+B46293|Samsung
+B462AD|raytest GmbH
+B46698|Zealabs srl
+B467E9|Qingdao GoerTek Technology Co., Ltd.
+B46D35|Dalian Seasky Automation Co;Ltd
+B46D83|Intel Corporate
+B47356|Hangzhou Treebear Networking Co., Ltd.
+B4749F|askey computer corp
+B4750E|Belkin International Inc.
+B479A7|Samsung
+B47C29|Shenzhen Guzidi Technology Co.,Ltd
+B47F5E|Foresight Manufacture (S) Pte Ltd
+B48255|Research Products Corporation
+B4827B|AKG Acoustics GmbH
+B482C5|Relay2, Inc.
+B482FE|Askey Computer Corp
+B48547|Amptown System Company GmbH
+B48910|Coster T.E. S.P.A.
+B4944E|WeTelecom Co., Ltd.
+B49842|zte corporation
+B4994C|Texas Instruments
+B499BA|Hewlett-Packard Company
+B49DB4|Axion Technologies Inc.
+B49EAC|Imagik Int'l Corp
+B49EE6|SHENZHEN TECHNOLOGY CO LTD
+B4A4B5|Zen Eye Co.,Ltd
+B4A4E3|Cisco
+B4A5A9|MODI GmbH
+B4A828|Shenzhen Concox Information Technology Co., Ltd
+B4A82B|Histar Digital Electronics Co., Ltd.
+B4A95A|Avaya, Inc
+B4A9FE|GHIA Technology (Shenzhen) LTD
+B4AA4D|Ensequence, Inc.
+B4AB2C|MtM Technology Corporation
+B4AE6F|Circle Reliance, Inc DBA Cranberry Networks
+B4B017|Avaya, Inc
+B4B265|DAEHO I&T
+B4B362|ZTE Corporation
+B4B52F|Hewlett Packard
+B4B542|Hubbell Power Systems, Inc.
+B4B5AF|Minsung Electronics
+B4B676|Intel Corporate
+B4B859|Texa Spa
+B4B88D|Thuh Company
+B4C44E|VXL eTech Pvt Ltd
+B4C799|Zebra Technologies Inc
+B4C810|UMPI Elettronica
+B4CCE9|PROSYST
+B4CEF6|HTC Corporation
+B4CFDB|Shenzhen Jiuzhou Electric Co.,LTD
+B4D8A9|BetterBots
+B4D8DE|iota Computing, Inc.
+B4DD15|ControlThings Oy Ab
+B4DF3B|Chromlech
+B4DFFA|Litemax Electronics Inc.
+B4E0CD|Fusion-io, Inc
+B4E1EB|ZZZZ 
+B4E9B0|Cisco
+B4ED19|Pie Digital, Inc.
+B4ED54|Wohler Technologies
+B4EEB4|ASKEY COMPUTER CORP
+B4EED4|Texas Instruments
+B4EF39|Samsung
+B4F0AB|Apple
+B4F2E8|Pace plc
+B4F323|PETATEL INC.
+B4FC75|SEMA Electronics(HK) CO.,LTD
+B4FE8C|Centro Sicurezza Italia SpA
+B80305|Intel Corporate
+B80415|Bayan Audio
+B808CF|Intel Corporate
+B8098A|Apple
+B80B9D|ROPEX Industrie-Elektronik GmbH
+B81413|Keen High Holding(HK) Ltd.
+B81619|ARRIS Group, Inc.
+B817C2|Apple
+B8186F|ORIENTAL MOTOR CO., LTD.
+B81999|Nesys
+B820E7|Guangzhou Horizontal Information & Network Integration Co. Ltd
+B82410|Magneti Marelli Slovakia s.r.o.
+B8241A|SWEDA INFORMATICA LTDA
+B8266C|ANOV France
+B826D4|Furukawa Industrial S.A. Produtos Eletricos
+B827EB|Raspberry Pi Foundation
+B8288B|Parker Hannifin
+B829F7|Blaster Tech
+B82A72|Dell Inc
+B82ADC|EFR Europaische Funk-Rundsteuerung GmbH
+B82CA0|Honeywell HomMed
+B830A8|Road-Track Telematics Development
+B836D8|Videoswitch
+B83861|Cisco
+B838CA|Kyokko Tsushin System CO.,LTD
+B83A7B|Worldplay (Canada) Inc.
+B83D4E|Shenzhen Cultraview Digital Technology Co.,Ltd Shanghai Branch
+B83E59|Roku, Inc
+B8415F|ASP AG
+B843E4|Vlatacom
+B847C6|SanJet Technology Corp.
+B84FD5|Microsoft
+B85510|Zioncom Electronics (Shenzhen) Ltd.
+B856BD|ITT LLC
+B85810|NUMERA, INC.
+B85A73|Samsung
+B85AF7|Ouya, Inc
+B85AFE|Handaer Communication Technology (Beijing) Co., Ltd
+B85E7B|Samsung
+B86091|Onnet Technologies and Innovations LLC
+B8616F|Accton Wireless Broadband(AWB), Corp.
+B8621F|Cisco
+B863BC|ROBOTIS, Co, Ltd
+B86491|CK Telecom Ltd
+B8653B|Bolymin, Inc.
+B86B23|Toshiba
+B86CE8|Samsung
+B870F4|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+B87424|Viessmann Elektronik GmbH
+B87447|Convergence Technologies
+B875C0|PayPal, Inc.
+B8763F|Hon Hai Precision Ind. Co.,Ltd.
+B877C3|Decagon Devices, Inc.
+B8782E|Apple
+B87879|Roche Diagnostics GmbH
+B8797E|Secure Meters (UK) Limited
+B87AC9|Siemens Ltd.
+B87CF2|Aerohive Networks Inc.
+B8871E|Good Mind Industries Co., Ltd.
+B887A8|Step Ahead Innovations Inc.
+B888E3|COMPAL INFORMATION (KUNSHAN) CO., LTD
+B889CA|ILJIN ELECTRIC Co., Ltd.
+B88A60|Intel Corporate
+B88D12|Apple
+B88E3A|Infinite Technologies JLT
+B88EC6|Stateless Networks
+B88F14|Analytica GmbH
+B8921D|BG T&A
+B894D2|Retail Innovation HTT AB
+B89674|AllDSP GmbH & Co. KG
+B8975A|BIOSTAR Microtech Int'l Corp.
+B898B0|Atlona Inc.
+B898F7|Gionee Communication Equipment Co,Ltd.ShenZhen
+B89919|7signal Solutions, Inc
+B899B0|Cohere Technologies
+B89ACD|ELITE OPTOELECTRONIC(ASIA)CO.,LTD
+B89AED|OceanServer Technology, Inc
+B89BC9|SMC Networks Inc
+B89BE4|ABB Power Systems Power Generation
+B8A386|D-Link International
+B8A3E0|BenRui Technology Co.,Ltd
+B8A8AF|Logic S.p.A.
+B8AC6F|Dell Inc
+B8AD3E|BLUECOM
+B8AE6E|Nintendo Co., Ltd.
+B8AEED|Elitegroup Computer Systems Co., Ltd.
+B8AF67|Hewlett-Packard Company
+B8B1C7|BT&COM CO.,LTD
+B8B3DC|DEREK (SHAOGUAN) LIMITED
+B8B42E|Gionee Communication Equipment Co,Ltd.ShenZhen
+B8B7D7|2GIG Technologies
+B8B81E|Intel Corporate
+B8B94E|Shenzhen iBaby Labs, Inc.
+B8BA68|Xi'an Jizhong Digital Communication Co.,Ltd
+B8BA72|Cynove
+B8BB6D|ENERES Co.,Ltd.
+B8BC1B|Huawei Technologies Co., Ltd
+B8BD79|TrendPoint Systems
+B8BEBF|Cisco
+B8BF83|Intel Corporate
+B8C1A2|Dragon Path Technologies Co., Limited
+B8C3BF|Henan Chengshi NetWork Technology Co. Ltd
+B8C46F|PRIMMCON INDUSTRIES INC
+B8C68E|Samsung
+B8C716|Fiberhome Telecommunication Technologies Co.,LTD
+B8C75D|Apple
+B8C855|Shanghai GBCOM Communication Technology Co.,Ltd.
+B8CA3A|Dell Inc
+B8CD93|Penetek, Inc
+B8CDA7|Maxeler Technologies Ltd.
+B8D06F|GUANGZHOU HKUST FOK YING TUNG RESEARCH INSTITUTE
+B8D49D|M Seven System Ltd.
+B8D812|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+B8D9CE|Samsung
+B8DAF1|Strahlenschutz- Entwicklungs- und Ausruestungsgesellschaft mbH
+B8DAF7|Advanced Photonics, Inc.
+B8DC87|IAI Corporation
+B8DF6B|SpotCam Co., Ltd.
+B8E589|Payter BV
+B8E625|2Wire
+B8E779|9Solutions Oy
+B8E856|Apple
+B8E937|Sonos, Inc.
+B8EE65|Liteon Technology Corporation
+B8EE79|YWire Technologies, Inc.
+B8F080|SPS, INC.
+B8F317|iSun Smasher Communications Private Limited
+B8F4D0|Herrmann Ultraschalltechnik GmbH & Co. Kg
+B8F5E7|WayTools, LLC
+B8F6B1|Apple
+B8F732|Aryaka Networks Inc
+B8F828|Changshu Gaoshida Optoelectronic Technology Co. Ltd.
+B8F934|Sony Ericsson Mobile Communications AB
+B8FD32|Zhejiang ROICX Microelectronics
+B8FF61|Apple
+B8FF6F|Shanghai Typrotech Technology Co.Ltd
+B8FFFE|Texas Instruments
+BC0200|Stewart Audio
+BC0543|AVM GmbH
+BC0DA5|Texas Instruments
+BC0F2B|FORTUNE TECHGROUP CO.,LTD
+BC0F64|Intel Corporate
+BC125E|Beijing  WisVideo  INC.
+BC1401|Hitron Technologies. Inc
+BC1485|Samsung
+BC14EF|ITON Technology Limited
+BC15A6|Taiwan Jantek Electronics,Ltd.
+BC1665|Cisco
+BC16F5|Cisco
+BC1A67|YF Technology Co., Ltd
+BC20A4|Samsung
+BC20BA|Inspur (Shandong) Electronic Information Co., Ltd
+BC25E0|Huawei Technologies Co., Ltd
+BC25F0|3D Display Technologies Co., Ltd.
+BC261D|HONG KONG TECON TECHNOLOGY
+BC2846|NextBIT Computing Pvt. Ltd.
+BC28D6|Rowley Associates Limited
+BC2B6B|Beijing Haier IC Design Co.,Ltd
+BC2BD7|Revogi Innovation Co., Ltd.
+BC2C55|Bear Flag Design, Inc.
+BC2D98|ThinGlobal LLC
+BC305B|Dell Inc.
+BC307D|Wistron Neweb Corp.
+BC3400|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+BC35E5|Hydro Systems Company
+BC38D2|Pandachip Limited
+BC39A6|CSUN System Technology Co.,LTD
+BC3AEA|GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD.
+BC3BAF|Apple
+BC3E13|Accordance Systems Inc.
+BC4100|Codaco Electronic s.r.o.
+BC4377|Hang Zhou Huite Technology Co.,ltd.
+BC4486|Samsung
+BC4760|Samsung
+BC4B79|SensingTek
+BC4CC4|Apple
+BC4DFB|Hitron Technologies. Inc
+BC4E3C|CORE STAFF CO., LTD.
+BC4E5D|ZhongMiao Technology Co., Ltd.
+BC51FE|Swann Communications Pty Ltd
+BC52B4|Alcatel-Lucent
+BC52B7|Apple
+BC54F9|Drogoo Technology Co., Ltd.
+BC5C4C|ELECOM CO.,LTD.
+BC5FF4|ASRock Incorporation
+BC6010|Qingdao Hisense Communications Co.,Ltd
+BC629F|Telenet Systems P. Ltd.
+BC6641|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+BC671C|Cisco
+BC6778|Apple
+BC6784|Environics Oy
+BC6A16|tdvine
+BC6A29|Texas Instruments
+BC6A2F|Henge Docks LLC
+BC6B4D|Alcatel-Lucent
+BC6E64|Sony Mobile Communications AB
+BC6E76|Green Energy Options Ltd
+BC71C1|XTrillion, Inc.
+BC72B1|Samsung
+BC74D7|HangZhou JuRu Technology CO.,LTD
+BC764E|Rackspace US, Inc.
+BC7670|Shenzhen Huawei Communication Technologies Co., Ltd
+BC7737|Intel Corporate
+BC779F|SBM Co., Ltd.
+BC79AD|Samsung
+BC7DD1|Radio Data Comms
+BC811F|Ingate Systems
+BC8199|BASIC Co.,Ltd.
+BC83A7|SHENZHEN CHUANGWEI-RGB ELECTRONICS CO.,LT
+BC851F|Samsung
+BC8556|Hon Hai Precision Ind. Co.,Ltd.
+BC8893|VILLBAU Ltd.
+BC8B55|NPP ELIKS America Inc. DBA T&M Atlantic
+BC8CCD|Samsung
+BC8D0E|Alcatel-Lucent
+BC926B|Apple
+BC9680|Shenzhen Gongjin Electronics Co.,Ltd
+BC9889|Fiberhome Telecommunication Tech.Co.,Ltd.
+BC99BC|FonSee Technology Inc.
+BC9CC5|Beijing Huafei Technology Co., Ltd.
+BC9DA5|DASCOM Europe GmbH
+BCA4E1|Nabto
+BCA9D6|Cyber-Rain, Inc.
+BCAEC5|ASUSTek COMPUTER INC.
+BCB181|SHARP CORPORATION
+BCB1F3|Samsung
+BCB308|HONGKONG RAGENTEK COMMUNICATION TECHNOLOGY CO.,LIMITED
+BCB852|Cybera, Inc.
+BCBAE1|AREC Inc.
+BCBBC9|Kellendonk Elektronik GmbH
+BCBC46|SKS Welding Systems GmbH
+BCC168|DinBox Sverige AB
+BCC23A|Thomson Video Networks
+BCC342|Panasonic System Networks Co., Ltd.
+BCC493|Cisco
+BCC61A|SPECTRA EMBEDDED SYSTEMS
+BCC6DB|Nokia Corporation
+BCC810|Cisco
+BCCAB5|ARRIS Group, Inc.
+BCCD45|VOISMART
+BCCFCC|HTC Corporation
+BCD165|Cisco
+BCD177|TP-LINK TECHNOLOGIES CO.,LTD.
+BCD1D3|Tinno Mobile Technology Corp
+BCD5B6|d2d technologies
+BCD940|ASR Co,.Ltd.
+BCE09D|Eoslink
+BCE59F|WATERWORLD Technology Co.,LTD
+BCE767|Quanzhou  TDX Electronics Co., Ltd
+BCEA2B|CityCom GmbH
+BCEAFA|Hewlett Packard
+BCEB5F|Fujian Beifeng Telecom Technology Co., Ltd.
+BCEC23|SHENZHEN CHUANGWEI-RGB ELECTRONICS CO.,LTD
+BCEE7B|ASUSTek COMPUTER INC.
+BCF1F2|Cisco
+BCF2AF|devolo AG
+BCF5AC|LG Electronics
+BCF61C|Geomodeling Wuxi Technology Co. Ltd.
+BCF685|D-Link International
+BCF811|Xiamen DNAKE Technology Co.,Ltd
+BCFE8C|Altronic, LLC
+BCFFAC|TOPCON CORPORATION
+C005C2|ARRIS Group, Inc.
+C00D7E|Additech, Inc.
+C011A6|Fort-Telecom ltd.
+C01242|Alpha Security Products
+C0143D|Hon Hai Precision Ind. Co.,Ltd.
+C01885|Hon Hai Precision Ind. Co.,Ltd.
+C01ADA|Apple
+C01E9B|Pixavi AS
+C02250|ASSIGNED - PRIVATE REGISTRATION 
+C02506|AVM GmbH
+C0255C|Cisco
+C02567|Nexxt Solutions
+C027B9|Beijing National Railway Research & Design Institute  of Signal & Communication Co., Ltd.
+C02973|Audyssey Laboratories Inc.
+C029F3|XySystem
+C02BFC|iNES. applied informatics GmbH
+C02C7A|Shen Zhen Horn audio Co., Ltd.
+C0335E|Microsoft
+C034B4|Gigastone Corporation
+C03580|A&R TECH
+C035BD|Velocytech Aps
+C035C5|Prosoft Systems LTD
+C03896|Hon Hai Precision Ind. Co.,Ltd.
+C038F9|Nokia Danmark A/S
+C03B8F|Minicom Digital Signage
+C03D46|Shanghai Mochui Network Technology Co., Ltd
+C03E0F|BSkyB Ltd
+C03F0E|Netgear
+C03F2A|Biscotti, Inc.
+C03FD5|Elitegroup Computer Systems Co., LTD
+C041F6|LG Electronics
+C04301|Epec Oy
+C044E3|Shenzhen Sinkna Electronics Co., LTD
+C0493D|MAITRISE TECHNOLOGIQUE
+C04A00|TP-LINK TECHNOLOGIES CO.,LTD.
+C04DF7|SERELEC
+C05627|Belkin International, Inc.
+C056E3|Hangzhou Hikvision Digital Technology Co.,Ltd.
+C057BC|Avaya, Inc
+C058A7|Pico Systems Co., Ltd.
+C05E6F|V. Stonkaus firma "Kodinis Raktas"
+C05E79|SHENZHEN HUAXUN ARK TECHNOLOGIES CO.,LTD
+C06118|TP-LINK TECHNOLOGIES CO.,LTD.
+C0626B|Cisco
+C06394|Apple
+C064C6|Nokia Corporation
+C06599|Samsung
+C067AF|Cisco
+C06C0F|Dobbs Stanford
+C06C6D|MagneMotion, Inc.
+C07009|Huawei Technologies Co., Ltd
+C07BBC|Cisco
+C07E40|SHENZHEN XDK COMMUNICATION EQUIPMENT CO.,LTD
+C08170|Effigis GeoSolutions
+C0830A|2Wire
+C0847A|Apple
+C0885B|SnD Tech Co., Ltd.
+C08ADE|Ruckus Wireless
+C08B6F|S I Sistemas Inteligentes Eletronicos Ltda
+C08C60|Cisco
+C09132|Patriot Memory
+C09134|ProCurve Networking by HP
+C09879|Acer Inc.
+C098E5|University of Michigan
+C09A71|XIAMEN MEITU MOBILE TECHNOLOGY CO.LTD
+C09C92|COBY
+C09D26|Topicon HK Lmd.
+C09F42|Apple
+C0A0BB|D-Link International
+C0A0C7|FAIRFIELD INDUSTRIES
+C0A0DE|Multi Touch Oy
+C0A0E2|Eden Innovations
+C0A26D|Abbott Point of Care
+C0A364|3D Systems Massachusetts
+C0A39E|EarthCam, Inc.
+C0AA68|OSASI Technos Inc.
+C0AC54|SAGEMCOM
+C0B339|Comigo Ltd.
+C0B357|Yoshiki Electronics Industry Ltd.
+C0B8B1|BitBox Ltd
+C0BAE6|Application Solutions (Electronics and Vision) Ltd
+C0BD42|ZPA Smart Energy a.s.
+C0BDD1|Samsung
+C0C1C0|Cisco
+C0C3B6|Automatic Systems
+C0C520|Ruckus Wireless
+C0C569|SHANGHAI LYNUC CNC TECHNOLOGY CO.,LTD
+C0C687|Cisco
+C0C946|MITSUYA LABORATORIES INC.
+C0CB38|Hon Hai Precision Ind. Co.,Ltd.
+C0CECD|Apple
+C0CFA3|Creative Electronics & Software, Inc.
+C0D044|SAGEMCOM
+C0D962|Askey Computer Corp.
+C0DA74|Hangzhou Sunyard Technology Co., Ltd.
+C0DC6A|Qingdao Eastsoft Communication Technology Co.,LTD
+C0DF77|Conrad Electronic SE
+C0E422|Texas Instruments
+C0E54E|DENX Computer Systems GmbH
+C0EAE4|Sonicwall
+C0EEFB|OnePlus Tech (Shenzhen) Ltd
+C0F1C4|Pacidal Corporation Ltd.
+C0F2FB|Apple
+C0F79D|Powercode
+C0F8DA|Hon Hai Precision Ind. Co.,Ltd.
+C0F991|GME Standard Communications P/L
+C0FFD4|Netgear
+C40006|Lipi Data Systems Ltd.
+C40142|MaxMedia Technology Limited
+C4017C|Ruckus Wireless
+C401B1|SeekTech INC
+C401CE|PRESITION (2000) CO., LTD.
+C40415|Netgear
+C40528|Huawei Technologies Co., Ltd
+C4072F|Huawei Technologies Co., Ltd
+C4084A|Alcatel-Lucent
+C40880|Shenzhen UTEPO Tech Co., Ltd.
+C40938|Fujian Star-net Communication Co., Ltd
+C40ACB|Cisco
+C40E45|ACK Networks,Inc.
+C40F09|Hermes electronic GmbH
+C4108A|Ruckus Wireless
+C412F5|D-Link International
+C413E2|Aerohive Networks Inc.
+C4143C|Cisco
+C416FA|Prysm Inc
+C417FE|Hon Hai Precision Ind. Co.,Ltd.
+C4198B|Dominion Voting Systems Corporation
+C419EC|Qualisys AB
+C41ECE|HMI Sources Ltd.
+C421C8|KYOCERA Corporation
+C4237A|WhizNets Inc.
+C4242E|Galvanic Applied Sciences Inc
+C42628|Airo Wireless
+C42795|Technicolor USA Inc.
+C4291D|KLEMSAN ELEKTRIK ELEKTRONIK SAN.VE TIC.AS.
+C42C03|Apple
+C42F90|Hangzhou Hikvision Digital Technology Co.,Ltd.
+C4346B|Hewlett Packard
+C4366C|LG Innotek
+C436DA|Rusteletech Ltd.
+C438D3|TAGATEC CO.,LTD
+C4393A|SMC Networks Inc
+C43A9F|Siconix Inc.
+C43ABE|Sony Mobile Communications AB
+C43C3C|CYBELEC SA
+C43DC7|Netgear
+C44202|Samsung
+C4438F|LG Electronics
+C44567|SAMBON PRECISON and ELECTRONICS
+C445EC|Shanghai Yali Electron Co.,LTD
+C44619|Hon Hai Precision Ind. Co.,Ltd.
+C44838|Satcom Direct, Inc.
+C44AD0|FIREFLIES SYSTEMS
+C44B44|Omniprint Inc.
+C44BD1|Wallys Communications  Teachnologies Co.,Ltd.
+C44E1F|BlueN
+C44EAC|Shenzhen Shiningworth Technology Co., Ltd.
+C45006|Samsung
+C45444|QUANTA COMPUTER INC.
+C455A6|Cadac Holdings Ltd
+C455C2|Bach-Simpson
+C45600|Galleon Embedded Computing
+C456FE|Lava International Ltd.
+C4576E|Samsung
+C458C2|Shenzhen TATFOOK Technology Co., Ltd.
+C45976|Fugoo Coorporation
+C45DD8|HDMI Forum
+C46044|Everex Electronics Limited
+C4626B|ZPT Vigantice
+C462EA|Samsung
+C46354|U-Raku, Inc.
+C46413|Cisco
+C467B5|Libratone A/S
+C4693E|Turbulence Design Inc.
+C46AB7|Xiaomi
+C46BB4|myIDkey
+C46DF1|DataGravity
+C46E1F|TP-LINK TECHNOLOGIES CO.,LTD
+C47130|Fon Technology S.L.
+C471FE|Cisco
+C47295|Cisco
+C4731E|Samsung
+C47B2F|Beijing JoinHope Image Technology Ltd.
+C47BA3|NAVIS Inc.
+C47D46|Fujitsu Limited
+C47D4F|Cisco
+C47DCC|Zebra Technologies Inc
+C47DFE|A.N. Solutions GmbH
+C47F51|Inventek Systems
+C4823F|Fujian Newland Auto-ID Tech. Co,.Ltd.
+C4824E|Changzhou Uchip Electronics Co., LTD.
+C48508|Intel Corporate
+C488E5|Samsung
+C48E8F|Hon Hai Precision Ind. Co.,Ltd.
+C4913A|Shenzhen Sanland Electronic Co., ltd.
+C4924C|KEISOKUKI CENTER CO.,LTD.
+C49300|8Devices
+C49313|100fio networks technology llc
+C49380|Speedytel technology
+C495A2|SHENZHEN WEIJIU INDUSTRY AND TRADE DEVELOPMENT CO., LTD
+C49805|Minieum Networks, Inc
+C49A02|LG Electronics
+C4A81D| D-Link International
+C4AAA1|SUMMIT DEVELOPMENT, spol.s r.o.
+C4AD21|MEDIAEDGE Corporation
+C4B512|General Electric Digital Energy
+C4BA99|I+ME Actia Informatik und Mikro-Elektronik GmbH
+C4BAA3|Beijing Winicssec Technologies Co., Ltd.
+C4BD6A|SKF GmbH
+C4BE84|Texas Instruments.
+C4C0AE|MIDORI ELECTRONIC CO., LTD.
+C4C19F|National Oilwell Varco Instrumentation, Monitoring, and Optimization (NOV IMO)
+C4C755|Beijing HuaqinWorld Technology Co.,Ltd
+C4C919|Energy Imports Ltd
+C4C9EC|Gugaoo   HK Limited
+C4CAD9|Hangzhou H3C Technologies Co., Limited
+C4CD45|Beijing Boomsense Technology CO.,LTD.
+C4D489|JiangSu Joyque Information Industry Co.,Ltd
+C4D655|Tercel technology co.,ltd
+C4D987|Intel Corporate
+C4DA26|NOBLEX SA
+C4E032|IEEE 1904.1 Working Group
+C4E17C|U2S co.
+C4E7BE|SCSpro Co.,Ltd
+C4E92F|AB Sciex
+C4E984|TP-LINK TECHNOLOGIES CO.,LTD.
+C4EA1D|Technicolor
+C4EBE3|RRCN SAS
+C4EDBA|Texas Instruments
+C4EEAE|VSS Monitoring
+C4EEF5|Oclaro, Inc.
+C4F464|Spica international
+C4F57C|Brocade Communications Systems, Inc.
+C4FCE4|DishTV NZ Ltd
+C80084|Cisco
+C80210|LG Innotek
+C80258|ITW GSE ApS
+C802A6|Beijing Newmine Technology
+C80718|TDSi
+C808E9|LG Electronics
+C80AA9|Quanta Computer Inc.
+C80E14|AVM Audiovisuelles Marketing und Computersysteme GmbH
+C80E77|Le Shi Zhi Xin Electronic Technology (Tianjin)  Co.,Ltd
+C80E95|OmniLync Inc.
+C81479|Samsung
+C816BD|HISENSE ELECTRIC CO.,LTD.
+C819F7|Samsung
+C81AFE|DLOGIC GmbH
+C81B6B|Innova Security
+C81E8E|ADV Security (S) Pte Ltd
+C81EE7|Apple
+C81F66|Dell Inc
+C8208E|Storagedata
+C8292A|Barun Electronics
+C82A14|Apple
+C82E94|Halfa Enterprise Co., Ltd.
+C83168|eZEX corporation
+C83232|Hunting Innova
+C8334B|Apple
+C8348E|Intel Corporate
+C835B8|Ericsson, EAB/RWI/K
+C83A35|Tenda Technology Co., Ltd.
+C83B45|JRI-Maxant
+C83D97|Nokia Corporation
+C83E99|Texas Instruments
+C83EA7|KUNBUS GmbH
+C83FB4|ARRIS Group, Inc.
+C84529|IMK Networks Co.,Ltd
+C84544|Shanghai Enlogic Electric Technology Co., Ltd.
+C8458F|Wyler AG
+C848F5|MEDISON Xray Co., Ltd
+C84C75|Cisco
+C85645|Intermas France
+C85663|Sunflex Europe GmbH
+C86000|ASUSTek COMPUTER INC.
+C864C7|zte corporation
+C86C1E|Display Systems Ltd
+C86C87|Zyxel Communications Corp
+C86CB6|Optcom Co., Ltd.
+C86F1D|Apple
+C87248|Aplicom Oy
+C87B5B|zte corporation
+C87CBC|Valink Co., Ltd.
+C87D77|Shenzhen Kingtech Communication Equipment Co.,Ltd
+C87E75|Samsung
+C88439|Sunrise Technologies
+C88447|Beautiful Enterprise Co., Ltd
+C88550|Apple
+C8873B|Net Optics
+C88A83|Dongguan HuaHong Electronics Co.,Ltd
+C88B47|Nolangroup S.P.A con Socio Unico
+C8903E|Pakton Technologies
+C891F9|SAGEMCOM
+C89346|MXCHIP Company Limited
+C89383|Embedded Automation, Inc.
+C894D2|Jiangsu Datang  Electronic Products Co., Ltd
+C8979F|Nokia Corporation
+C89C1D|Cisco
+C89CDC|ELITEGROUP COMPUTER SYSTEM CO., LTD.
+C89F1D|SHENZHEN COMMUNICATION TECHNOLOGIES CO.,LTD
+C89F42|VDII Innovation AB
+C8A030|Texas Instruments
+C8A1B6|Shenzhen Longway Technologies Co., Ltd
+C8A1BA|Neul Ltd
+C8A620|Nebula, Inc
+C8A70A|Verizon Business
+C8A729|SYStronics Co., Ltd.
+C8A823|Samsung
+C8AA21|ARRIS Group, Inc.
+C8AACC|ASSIGNED - PRIVATE REGISTRATION 
+C8AE9C|Shanghai TYD Elecronic Technology Co. Ltd
+C8AF40|marco Systemanalyse und Entwicklung GmbH
+C8B373|Cisco
+C8B5B7|Apple
+C8BA94|Samsung
+C8BBD3|Embrane
+C8BCC8|Apple
+C8BE19|D-Link International
+C8C126|ZPM Industria e Comercio Ltda
+C8C13C|RuggedTek Hangzhou Co., Ltd
+C8C50E|Shenzhen Primestone Network Technologies.Co., Ltd.
+C8C791|Zero1.tv GmbH
+C8CBB8|Hewlett Packard
+C8CD72|SAGEMCOM
+C8D019|Shanghai Tigercel Communication Technology Co.,Ltd
+C8D10B|Nokia Corporation
+C8D15E|Huawei Technologies Co., Ltd
+C8D1D1|AGAiT Technology Corporation
+C8D2C1|Jetlun (Shenzhen) Corporation
+C8D3A3|D-Link International
+C8D429|Muehlbauer AG
+C8D590|FLIGHT DATA SYSTEMS
+C8D5FE|Shenzhen Zowee Technology Co., Ltd
+C8D719|Cisco
+C8D779|Qingdao Haier Telecom Co. Ltd
+C8DDC9|Lenovo Mobile Communication Technology Ltd.
+C8DE51|Integra Networks, Inc.
+C8DF7C|Nokia Corporation
+C8E0EB|Apple
+C8E130|Milkyway Group Ltd
+C8E1A7|Vertu Corporation Limited
+C8E42F|Technical Research Design and Development
+C8E7D8|SHENZHEN MERCURY COMMUNICATION TECHNOLOGIES CO.,LTD.
+C8EE08|TANGTOP TECHNOLOGY CO.,LTD
+C8EE75|Pishion International Co. Ltd
+C8EEA6|Shenzhen SHX Technology Co., Ltd
+C8EF2E|Beijing Gefei Tech. Co., Ltd
+C8F36B|Yamato Scale Co.,Ltd.
+C8F386|Shenzhen Xiaoniao Technology Co.,Ltd
+C8F406|Avaya, Inc
+C8F650|Apple
+C8F68D|S.E.TECHNOLOGIES LIMITED
+C8F704|Building Block Video
+C8F733|Intel Corporate
+C8F981|Seneca s.r.l.
+C8F9F9|Cisco
+C8FB26|Cisco
+C8FE30|Bejing DAYO Mobile Communication Technology Ltd.
+C8FF77|Dyson Limited
+CC0080|BETTINI SRL
+CC03FA|Technicolor CH USA
+CC047C|G-WAY Microwave
+CC04B4|Select Comfort
+CC051B|Samsung
+CC07AB|Samsung
+CC07E4|Lenovo Mobile Communication Technology Ltd.
+CC08E0|Apple
+CC09C8|IMAQLIQ LTD
+CC0CDA|Miljovakt AS
+CC0DEC|Cisco
+CC10A3|Beijing Nan Bao Technology Co., Ltd.
+CC14A6|Yichun MyEnergy Domain, Inc
+CC187B|Manzanita Systems, Inc.
+CC19A8|PT Inovacao e Sistemas SA
+CC1AFA|zte corporation
+CC1EFF|Metrological Group BV
+CC2218|InnoDigital Co., Ltd.
+CC262D|Verifi, LLC
+CC29F5|Apple
+CC2A80|Micro-Biz intelligence solutions Co.,Ltd
+CC2D8C|LG Electronics
+CC3080|VAIO Corporation
+CC33BB|SAGEMCOM SAS
+CC3429|TP-LINK TECHNOLOGIES CO.,LTD.
+CC34D7|GEWISS S.P.A.
+CC3540|Technicolor USA Inc.
+CC398C|Shiningtek
+CC3A61|Samsung
+CC3C3F|SA.S.S. Datentechnik AG
+CC3D82|Intel Corporate
+CC3E5F|Hewlett Packard
+CC3F1D|Intesis Software SL
+CC43E3|Trump s.a.
+CC4703|Intercon Systems Co., Ltd.
+CC4AE1|Fourtec -Fourier Technologies
+CC4BFB|Hellberg Safety AB
+CC4E24|Brocade Communications Systems, Inc.
+CC4EEC|HUMAX Co., Ltd.
+CC501C|KVH Industries, Inc.
+CC5076|Ocom Communications, Inc.
+CC52AF|Universal Global Scientific Industrial Co., Ltd.
+CC53B5|HUAWEI TECHNOLOGIES CO.,LTD
+CC5459|OnTime Networks AS
+CC55AD|RIM
+CC593E|TOUMAZ LTD
+CC5C75|Weightech Com. Imp. Exp. Equip. Pesagem Ltda
+CC5D4E|ZyXEL Communications Corporation
+CC5D57|Information  System Research Institute,Inc.
+CC60BB|Empower RF Systems
+CC65AD|ARRIS Group, Inc.
+CC69B0|Global Traffic Technologies, LLC
+CC6B98|Minetec Wireless Technologies
+CC6BF1|Sound Masking Inc.
+CC6DA0|Roku, Inc.
+CC6DEF|TJK Tietolaite Oy
+CC720F|Viscount Systems Inc.
+CC7498|Filmetrics Inc.
+CC7669|SEETECH
+CC785F|Apple
+CC7A30|CMAX Wireless Co., Ltd.
+CC7B35|zte corporation
+CC7D37|ARRIS Group, Inc.
+CC7EE7|Panasonic AVC Networks Company
+CC856C|SHENZHEN MDK DIGITAL TECHNOLOGY CO.,LTD
+CC89FD|Nokia Corporation
+CC8CE3|Texas Instruments
+CC9093|Hansong Tehnologies
+CC912B|TE Connectivity Touch Solutions
+CC944A|Pfeiffer Vacuum GmbH
+CC95D7|VIZIO, Inc
+CC9635|LVS Co.,Ltd.
+CC96A0|Shenzhen Huawei Communication Technologies Co., Ltd
+CC9E00|Nintendo Co., Ltd.
+CC9F35|Transbit Sp. z o.o.
+CCA0E5|DZG Metering GmbH
+CCA223|Huawei Technologies Co., Ltd
+CCA374|Guangdong Guanglian Electronic Technology Co.Ltd
+CCA462|ARRIS Group, Inc.
+CCA4AF|Shenzhen Sowell Technology Co., LTD
+CCA614|AIFA TECHNOLOGY CORP.
+CCAF78|Hon Hai Precision Ind. Co.,Ltd.
+CCB255|D-Link International
+CCB3F8|FUJITSU ISOTEC LIMITED
+CCB55A|Fraunhofer ITWM
+CCB691|NECMagnusCommunications
+CCB888|AnB Securite s.a.
+CCB8F1|EAGLE KINGDOM TECHNOLOGIES LIMITED
+CCBD35|Steinel GmbH
+CCBDD3|Ultimaker B.V.
+CCBE71|OptiLogix BV
+CCC104|Applied Technical Systems
+CCC3EA|Motorola
+CCC50A|SHENZHEN DAJIAHAO TECHNOLOGY CO.,LTD
+CCC62B|Tri-Systems Corporation
+CCC8D7|CIAS Elettronica srl
+CCCC4E|Sun Fountainhead USA. Corp
+CCCC81|HUAWEI TECHNOLOGIES CO.,LTD
+CCCD64|SM-Electronic GmbH
+CCCE40|Janteq Corp
+CCD29B|Shenzhen Bopengfa Elec&Technology CO.,Ltd
+CCD539|Cisco
+CCD811|Aiconn Technology Corporation
+CCD8C1|Cisco
+CCD9E9|SCR Engineers Ltd.
+CCE17F|juniper networks
+CCE1D5|Buffalo Inc.
+CCE798|My Social Stuff
+CCE7DF|American Magnetics, Inc.
+CCE8AC|SOYEA Technology Co.,Ltd.
+CCEA1C|DCONWORKS  Co., Ltd
+CCEED9|VAHLE DETO GmbH
+CCEF48|Cisco
+CCF3A5|Chi Mei Communication Systems, Inc
+CCF407|EUKREA ELECTROMATIQUE SARL
+CCF538|3isysnetworks
+CCF67A|Ayecka Communication Systems LTD
+CCF841|Lumewave
+CCF8F0|Xi'an HISU Multimedia Technology Co.,Ltd.
+CCF954|Avaya, Inc
+CCF9E8|Samsung
+CCFA00|LG Electronics
+CCFB65|Nintendo Co., Ltd.
+CCFC6D|RIZ TRANSMITTERS
+CCFCB1|Wireless Technology, Inc.
+CCFE3C|Samsung
+D0034B|Apple
+D00492|Fiberhome Telecommunication Technologies Co.,LTD
+D00790|Texas Instruments
+D00AAB|Yokogawa Digital Computer Corporation
+D00EA4|Porsche Cars North America
+D00ED9|TAICANG T AND W ELECTRONICS CO LTD
+D01242|BIOS Corporation
+D0131E|Sunrex Technology Corp
+D0154A|zte corporation
+D0176A|Samsung
+D01AA7|UniPrint
+D01CBB|Beijing Ctimes Digital Technology Co., Ltd.
+D02212|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+D022BE|Samsung
+D023DB|Apple
+D02516|SHENZHEN MERCURY COMMUNICATION TECHNOLOGIES CO.,LTD.
+D02598|Apple
+D02788|Hon Hai Precision Ind.Co.Ltd
+D02C45|littleBits Electronics, Inc.
+D02DB3|Huawei Technologies Co., Ltd
+D03110|Ingenic Semiconductor Co.,Ltd
+D03761|Texas Instruments
+D03972|Texas Instruments
+D039B3|ARRIS Group, Inc.
+D0431E|Dell Inc.
+D046DC|Southwest Research Institute
+D048F3|DATTUS Inc
+D04CC1|SINTRONES Technology Corp.
+D04D2C|Roku, Inc
+D04F7E|Apple
+D05099|ASRock Incorporation
+D05162|Sony Mobile Communications AB
+D052A8|Physical Graph Corporation
+D05349|Liteon Technology Co., Ltd.
+D0542D|Cambridge Industries(Group) Co.,Ltd.
+D0574C|Cisco
+D05785|Pantech Co., Ltd.
+D057A1|Werma Signaltechnik GmbH & Co. KG
+D05875|Active Control Technology Inc.
+D059C3|CeraMicro Technology Corporation
+D059E4|Samsung
+D05A0F|I-BT DIGITAL CO.,LTD
+D05AF1|Shenzhen Pulier Tech CO.,Ltd
+D05BA8|zte corporation
+D05C7A|Sartura d.o.o.
+D05FB8|Texas Instruments
+D05FCE|Hitachi Data Systems
+D062A0|China Essence Technology (Zhumadian) Co., Ltd.
+D0634D|Meiko Maschinenbau GmbH &amp; Co. KG
+D063B4|SolidRun Ltd.
+D0667B|Samsung
+D067E5|Dell Inc
+D0699E|LUMINEX Lighting Control Equipment
+D069D0|Verto Medical Solutions, LLC
+D06A1F|BSE CO.,LTD.
+D06F4A|TOPWELL INTERNATIONAL HOLDINGS LIMITED
+D072DC|Cisco
+D0737F|Mini-Circuits
+D0738E|DONG OH PRECISION CO., LTD.
+D073D5|LIFI LABS MANAGEMENT PTY LTD
+D075BE|Reno A&E
+D07650|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+D07AB5|Huawei Technologies Co., Ltd
+D07DE5|Forward Pay Systems, Inc.
+D07E28|Hewlett Packard
+D07E35|Intel Corporate
+D083D4|XTel ApS
+D084B0|Sagemcom
+D08999|APCON, Inc.
+D08A55|Skullcandy
+D08B7E|Passif Semiconductor
+D08CB5|Texas Instruments
+D08CFF|UPWIS AB
+D0929E|Microsoft
+D093F8|Stonestreet One LLC
+D095C7|Pantech Co., Ltd.
+D09B05|Emtronix
+D09C30|Foster Electric Company, Limited
+D09D0A|LINKCOM
+D09DAB|TCT mobile ltd
+D0A0D6|Chengdu TD Tech Ltd.
+D0A311|Neuberger Gebaudeautomation GmbH
+D0A5A6|Cisco
+D0A637|Apple
+D0AEEC|Alpha Networks Inc.
+D0AFB6|Linktop Technology Co., LTD
+D0B33F|SHENZHEN TINNO MOBILE TECHNOLOGY CO.,LTD.
+D0B498|Robert Bosch LLC Automotive Electronics
+D0B523|Bestcare Cloucal Corp.
+D0B53D|SEPRO ROBOTIQUE
+D0B5C2|Texas Instruments
+D0BB80|SHL Telemedicine International Ltd.
+D0BD01|DS International
+D0BE2C|CNSLink Co., Ltd.
+D0BF9C|Hewlett Packard
+D0C0BF|Actions Microelectronics Co., Ltd
+D0C1B1|Samsung
+D0C282|Cisco
+D0C42F|Tamagawa Seiki Co.,Ltd.
+D0C789|Cisco
+D0C7C0|TP-LINK TECHNOLOGIES CO.,LTD.
+D0CDE1|Scientech Electronics
+D0CF5E|Energy Micro AS
+D0D0FD|Cisco
+D0D212|K2NET Co.,Ltd.
+D0D286|Beckman Coulter K.K.
+D0D3FC|Mios, Ltd.
+D0D412|ADB Broadband Italia
+D0D471|MVTECH co., Ltd
+D0D6CC|Wintop
+D0DB32|Nokia Corporation
+D0DF9A|Liteon Technology Corporation
+D0DFB2|Genie Networks Limited
+D0DFC7|Samsung
+D0E140|Apple
+D0E347|Yoga
+D0E40B|Wearable Inc.
+D0E54D|Pace plc
+D0E782|Azurewave Technologies, Inc.
+D0EB03|Zhehua technology limited
+D0EB9E|Seowoo Inc.
+D0F0DB|Ericsson
+D0F27F|SteadyServ Technoligies, LLC
+D0F73B|Helmut Mauell GmbH
+D0FA1D|Qihoo  360  Technology Co.,Ltd
+D0FF50|Texas Instruments, Inc
+D4000D|Phoenix Broadband Technologies, LLC.
+D40057|MC Technologies GmbH
+D40129|Broadcom Corporation
+D4016D|TP-LINK TECHNOLOGIES CO.,LTD.
+D4024A|Delphian Systems LLC
+D40598|ARRIS Group, Inc.
+D40B1A|HTC Corporation
+D40BB9|Solid Semecs bv.
+D40FB2|Applied Micro Electronics AME bv
+D41090|iNFORM Systems AG
+D410CF|Huanshun Network Science and Technology Co., Ltd.
+D411D6|ShotSpotter, Inc.
+D41296|Anobit Technologies Ltd.
+D412BB|Quadrant Components Inc. Ltd
+D4136F|Asia Pacific Brands
+D41C1C|RCF S.P.A.
+D41E35|TOHO Electronics INC.
+D41F0C|JAI Oy
+D4206D|HTC Corporation
+D42122|Sercomm Corporation
+D4223F|Lenovo Mobile Communication Technology Ltd.
+D4224E|Alcatel Lucent
+D42751|Infopia Co., Ltd
+D428B2|ioBridge, Inc.
+D429EA|Zimory GmbH
+D42C3D|Sky Light Digital Limited
+D42F23|Akenori PTE Ltd
+D4319D|Sinwatec
+D43266|Fike Corporation
+D437D7|zte corporation
+D43A65|IGRS Engineering Lab Ltd.
+D43AE9|DONGGUAN ipt INDUSTRIAL CO., LTD
+D43D67|Carma Industries Inc.
+D43D7E|Micro-Star Int'l Co, Ltd
+D443A8|Changzhou Haojie Electric Co., Ltd.
+D44B5E|TAIYO YUDEN CO., LTD.
+D44C24|Vuppalamritha Magnetic Components LTD
+D44C9C|Shenzhen YOOBAO Technology Co.Ltd
+D44CA7|Informtekhnika & Communication, LLC
+D44F80|Kemper Digital GmbH
+D4507A|CEIVA Logic, Inc
+D4522A|TangoWiFi.com
+D45251|IBT Ingenieurbureau Broennimann Thun
+D45297|nSTREAMS Technologies, Inc.
+D453AF|VIGO System S.A.
+D45556|Fiber Mountain Inc.
+D45AB2|Galleon Systems
+D45C70|Wi-Fi Alliance
+D45D42|Nokia Corporation
+D46132|Pro Concept Manufacturer Co.,Ltd.
+D464F7|CHENGDU USEE DIGITAL TECHNOLOGY CO., LTD
+D466A8|Riedo Networks GmbH
+D46761|SAHAB TECHNOLOGY
+D467E7|Fiberhome Telecommunication Tech.Co.,Ltd.
+D4684D|Ruckus Wireless
+D46867|Neoventus Design Group
+D468BA|Shenzhen Sundray Technologies Company Limited
+D46A91|Snap AV
+D46AA8|HUAWEI TECHNOLOGIES CO.,LTD
+D46CBF|Goodrich ISR
+D46CDA|CSM GmbH
+D46D50|Cisco
+D46E5C|Huawei Technologies Co., Ltd
+D46F42|WAXESS USA Inc
+D479C3|Cameronet GmbH & Co. KG
+D47B35|NEO Monitors AS
+D47B75|HARTING Electronics GmbH
+D481CA|iDevices, LLC
+D4823E|Argosy Technologies, Ltd.
+D48564|Hewlett-Packard Company
+D487D8|Samsung
+D48890|Samsung
+D48CB5|Cisco
+D48DD9|Meld Technology, Inc
+D48F33|Microsoft
+D48FAA|Sogecam Industrial, S.A.
+D491AF|Electroacustica General Iberica, S.A.
+D49398|Nokia Corporation
+D493A0|Fidelix Oy
+D4945A|COSMO CO., LTD
+D494A1|Texas Instruments
+D49524|Clover Network, Inc.
+D496DF|SUNGJIN C&T CO.,LTD
+D4970B|Xiaomi
+D49A20|Apple
+D49C28|JayBird Gear LLC
+D49C8E|University of FUKUI
+D49E6D|Wuhan Zhongyuan Huadian Science & Technology Co.,
+D4A02A|Cisco
+D4A425|SMAX Technology Co., Ltd.
+D4A499|InView Technology Corporation
+D4A928|GreenWave Reality Inc
+D4AAFF|MICRO WORLD
+D4AC4E|BODi rS, LLC
+D4AD2D|Fiberhome Telecommunication Tech.Co.,Ltd.
+D4AE52|Dell Inc
+D4B110|HUAWEI TECHNOLOGIES CO.,LTD
+D4B43E|Messcomp Datentechnik GmbH
+D4BED9|Dell Inc
+D4BF2D|SE Controls Asia Pacific Ltd
+D4BF7F|UPVEL
+D4C1FC|Nokia Corporation
+D4C766|Acentic GmbH
+D4C9EF|Hewlett Packard
+D4CA6D|Routerboard.com
+D4CA6E|u-blox AG
+D4CBAF|Nokia Corporation
+D4CEB8|Enatel LTD
+D4CFF9|Shenzhen Sen5 Technology Co., Ltd.
+D4D184|ADB Broadband Italia
+D4D249|Power Ethernet
+D4D50D|Southwest Microwave, Inc
+D4D748|Cisco
+D4D7A9|Shanghai Kaixiang Info Tech LTD
+D4D898|Korea CNO Tech Co., Ltd
+D4D919|GoPro
+D4DF57|Alpinion Medical Systems
+D4E08E|ValueHD Corporation
+D4E32C|S. Siedle & Sohne
+D4E33F|Alcatel-Lucent
+D4E8B2|Samsung
+D4EA0E|Avaya, Inc
+D4EC0C|Harley-Davidson Motor Company
+D4EC86|LinkedHope Intelligent Technologies Co., Ltd
+D4EE07|HIWIFI Co., Ltd.
+D4F027|Navetas Energy Management
+D4F0B4|Napco Security Technologies
+D4F143|IPROAD.,Inc
+D4F46F|Apple
+D4F513|Texas Instruments
+D4F63F|IEA S.R.L.
+D4F9A1|HUAWEI TECHNOLOGIES CO.,LTD
+D8004D|Apple
+D8052E|Skyviia Corporation
+D806D1|Honeywell Fire System (Shanghai) Co,. Ltd.
+D808F5|Arcadia Networks Co. Ltd.
+D809C3|Cercacor Labs
+D80CCF|C.G.V. S.A.S.
+D80DE3|FXI TECHNOLOGIES AS
+D8150D|TP-LINK TECHNOLOGIES CO.,LTD.
+D8160A|Nippon Electro-Sensory Devices
+D8182B|Conti Temic Microelectronic GmbH
+D819CE|Telesquare
+D81BFE|TWINLINX CORPORATION
+D81C14|Compacta International, Ltd.
+D81D72|Apple
+D81EDE|B&W Group Ltd
+D824BD|Cisco
+D82522|Pace plc
+D826B9|Guangdong Coagent Electronics S &T Co., Ltd.
+D8270C|MaxTronic International Co., Ltd.
+D828C9|General Electric Consumer and Industrial
+D82916|Ascent Communication Technology
+D82986|Best Wish Technology LTD
+D82A15|Leitner SpA
+D82A7E|Nokia Corporation
+D82D9B|Shenzhen G.Credit Communication Technology Co., Ltd
+D82DE1|Tricascade Inc.
+D83062|Apple
+D831CF|Samsung
+D8337F|Office FA.com Co.,Ltd.
+D83C69|Tinno Mobile Technology Corp
+D842AC|Shanghai Feixun Communication Co.,Ltd.
+D84606|Silicon Valley Global Marketing
+D8490B|HUAWEI TECHNOLOGIES CO.,LTD
+D8492F|CANON INC.
+D84A87|OI ELECTRIC CO.,LTD
+D84B2A|Cognitas Technologies, Inc.
+D850E6|ASUSTek COMPUTER INC.
+D8543A|Texas Instruments
+D854A2|Aerohive Networks Inc.
+D855A3|zte corporation
+D857EF|Samsung
+D858D7|CZ.NIC, z.s.p.o.
+D85D4C|TP-LINK Technologies Co.,Ltd.
+D85D84|CAx soft GmbH
+D85DE2|Hon Hai Precision Ind. Co.,Ltd.
+D85DEF|Busch-Jaeger Elektro GmbH
+D86194|Objetivos y Sevicios de Valor Anadido
+D862DB|Eno Inc.
+D86595|Toy's Myth Inc.
+D866C6|Shenzhen Daystar Technology Co.,ltd
+D866EE|BOXIN COMMUNICATION CO.,LTD.
+D867D9|Cisco
+D86960|Steinsvik
+D86BF7|Nintendo Co., Ltd.
+D86CE9|SAGEMCOM SAS
+D87157|Lenovo Mobile Communication Technology Ltd.
+D87495|zte corporation
+D87533|Nokia Corporation
+D8760A|Escort, Inc.
+D878E5|KUHN SA
+D87988|Hon Hai Precision Ind. Co., Ltd.
+D87CDD|SANIX INCORPORATED
+D87EB1|x.o.ware, inc.
+D88039|Microchip Technology Inc.
+D881CE|AHN INC.
+D88466|Extreme Networks
+D88A3B|UNIT-EM
+D88D5C|Elentec
+D890E8|Samsung
+D89341|General Electric Global Research
+D8952F|Texas Instruments
+D89685|GoPro
+D89695|Apple
+D896E0|Alibaba Cloud Computing Ltd.
+D8973B|Artesyn Embedded Technologies
+D89760|C2 Development, Inc.
+D8977C|Grey Innovation
+D897BA|PEGATRON CORPORATION
+D89A34|Beijing SHENQI Technology Co., Ltd.
+D89D67|Hewlett Packard
+D89DB9|eMegatech International Corp.
+D89E3F|Apple
+D8A25E|Apple
+D8ADDD|Sonavation, Inc.
+D8AE90|Itibia Technologies
+D8AF3B|Hangzhou Bigbright Integrated communications system Co.,Ltd
+D8AFF1|Panasonic Appliances Company
+D8B02E|Guangzhou Zonerich Business Machine Co., Ltd
+D8B04C|Jinan USR IOT Technology Co., Ltd.
+D8B12A|Panasonic Mobile Communications Co., Ltd.
+D8B377|HTC Corporation
+D8B6B7|Comtrend Corporation
+D8B6C1|NetworkAccountant, Inc.
+D8B6D6|Blu Tether Limited
+D8B8F6|Nantworks
+D8B90E|Triple Domain Vision Co.,Ltd.
+D8BB2C|Apple
+D8BF4C|Victory Concept Electronics Limited
+D8C068|Netgenetech.co.,ltd.
+D8C3FB|DETRACOM
+D8C691|Hichan Technology Corp.
+D8C7C8|Aruba Networks
+D8C99D|EA DISPLAY LIMITED
+D8CB8A|Micro-Star INTL CO., LTD.
+D8CF9C|Apple
+D8D1CB|Apple
+D8D27C|JEMA ENERGY, SA
+D8D385|Hewlett-Packard Company
+D8D43C|Sony Corporation
+D8D5B9|Rainforest Automation, Inc.
+D8D67E|GSK CNC EQUIPMENT CO.,LTD
+D8DA52|APATOR S.A.
+D8DCE9|Kunshan Erlab ductless filtration system Co.,Ltd
+D8DD5F|BALMUDA Inc.
+D8DDFD|Texas Instruments
+D8DECE|ISUNG CO.,LTD
+D8DF0D|beroNet GmbH
+D8E3AE|CIRTEC MEDICAL SYSTEMS
+D8E56D|TCT Mobile Limited
+D8E72B|NetScout Systems, Inc.
+D8E743|Wush, Inc
+D8E952|KEOPSYS
+D8EB97|TRENDnet, Inc.
+D8EE78|Moog Protokraft
+D8F0F2|Zeebo Inc
+D8F710|Libre Wireless Technologies Inc.
+D8FB11|AXACORE
+D8FC93|Intel Corporate
+D8FE8F|IDFone Co., Ltd.
+D8FEE3|D-Link International
+DC0265|Meditech Kft
+DC028E|zte corporation
+DC052F|National Products Inc.
+DC0575|SIEMENS ENERGY AUTOMATION
+DC05ED|Nabtesco  Corporation
+DC07C1|HangZhou QiYang Technology Co.,Ltd.
+DC0914|Talk-A-Phone Co.
+DC0B1A|ADB Broadband Italia
+DC0EA1|COMPAL INFORMATION (KUNSHAN) CO., LTD
+DC15DB|Ge Ruili Intelligent Technology ( Beijing ) Co., Ltd.
+DC16A2|Medtronic Diabetes
+DC175A|Hitachi High-Technologies Corporation
+DC1792|Captivate Network
+DC1D9F|U & B tech
+DC1DD4|Microstep-MIS spol. s r.o.
+DC1EA3|Accensus LLC
+DC2008|ASD Electronics Ltd
+DC2A14|Shanghai Longjing Technology Co.
+DC2B61|Apple
+DC2B66|InfoBLOCK S.A. de C.V.
+DC2BCA|Zera GmbH
+DC2C26|Iton Technology Limited
+DC2E6A|HCT. Co., Ltd.
+DC2F03|Step forward Group Co., Ltd.
+DC309C|Heyrex Limited
+DC3350|TechSAT GmbH
+DC3714|Apple
+DC37D2|Hunan HKT Electronic Technology Co., Ltd
+DC38E1|Juniper networks
+DC3979|Skyport Systems
+DC3A5E|Roku, Inc
+DC3C2E|Manufacturing System Insights, Inc.
+DC3C84|Ticom Geomatics, Inc.
+DC3E51|Solberg & Andersen AS
+DC3EF8|Nokia Corporation
+DC4517|ARRIS Group, Inc.
+DC49C9|CASCO SIGNAL LTD
+DC4EDE|SHINYEI TECHNOLOGY CO., LTD.
+DC537C|Compal Broadband Networks, Inc.
+DC56E6|Shenzhen Bococom Technology Co.,LTD
+DC5726|Power-One
+DC5E36|Paterson Technology
+DC60A1|Teledyne DALSA Professional Imaging
+DC647C|C.R.S. iiMotion GmbH
+DC663A|Apacer Technology Inc.
+DC6F00|Livescribe, Inc.
+DC6F08|Bay Storage Technology
+DC7014|ZZZZ 
+DC7144|Samsung
+DC7B94|Cisco
+DC825B|JANUS, spol. s r.o.
+DC85DE|Azurewave Technologies., inc.
+DC86D8|Apple
+DC9B1E|Intercom, Inc.
+DC9B9C|Apple
+DC9C52|Sapphire Technology Limited.
+DC9FA4|Nokia Corporation
+DC9FDB|Ubiquiti Networks
+DCA5F4|Cisco
+DCA6BD|Beijing Lanbo Technology Co., Ltd.
+DCA7D9|Compressor Controls Corp
+DCA8CF|New Spin Golf, LLC.
+DCA971|Intel Corporate
+DCA989|MACANDC
+DCAD9E|GreenPriz
+DCAE04|CELOXICA Ltd
+DCB058|Burkert Werke GmbH
+DCB4C4|Microsoft
+DCBF90|HUIZHOU QIAOXING TELECOMMUNICATION INDUSTRY CO.,LTD.
+DCC0DB|Shenzhen Kaiboer Technology Co., Ltd.
+DCC101|SOLiD Technologies, Inc.
+DCC422|Systembase Limited
+DCC622|BUHEUNG SYSTEM
+DCC793|Nokia Corporation
+DCCBA8|Explora Technologies Inc
+DCCE41|FE GLOBAL HONG KONG LIMITED
+DCCEBC|Shenzhen JSR Technology Co.,Ltd.
+DCCF94|Beijing Rongcheng Hutong Technology Co., Ltd.
+DCD0F7|Bentek Systems Ltd.
+DCD2FC|HUAWEI TECHNOLOGIES CO.,LTD
+DCD321|HUMAX co.,tld
+DCD52A|Sunny Heart Limited
+DCD87F|Shenzhen JoinCyber Telecom Equipment Ltd
+DCDA4F|GETCK TECHNOLOGY,  INC
+DCDB70|Tonfunk Systementwicklung und Service GmbH
+DCDECA|Akyllor
+DCE026|Patrol Tag, Inc
+DCE1AD|Shenzhen Wintop Photoelectric Technology Co., Ltd
+DCE2AC|Lumens Digital Optics Inc.
+DCE578|Experimental Factory of Scientific Engineering and Special Design Department
+DCE71C|AUG Elektronik GmbH
+DCEC06|Heimi Network Technology Co., Ltd.
+DCF05D|Letta Teknoloji
+DCF110|Nokia Corporation
+DCF755|SITRONIK
+DCF858|Lorent Networks, Inc.
+DCFAD5|STRONG Ges.m.b.H.
+DCFB02|Buffalo Inc.
+E00370|ShenZhen Continental Wireless Technology Co., Ltd.
+E005C5|TP-LINK Technologies Co.,Ltd.
+E006E6|Hon Hai Precision Ind. Co.,Ltd.
+E00B28|Inovonics
+E00C7F|Nintendo Co., Ltd.
+E0107F|Ruckus Wireless
+E0143E|Modoosis Inc.
+E01877|Fujitsu Limited
+E0191D|Huawei Technologies Co., Ltd
+E01C41|Aerohive Networks Inc.
+E01CEE|Bravo Tech, Inc.
+E01D38|Beijing HuaqinWorld Technology Co.,Ltd
+E01D3B|Cambridge Industries(Group) Co.,Ltd
+E01E07|Anite Telecoms  US. Inc
+E01F0A|Xslent Energy Technologies. LLC
+E0247F|HUAWEI TECHNOLOGIES CO.,LTD
+E02538|Titan Pet Products
+E02630|Intrigue Technologies, Inc.
+E02636|Nortel Networks
+E0271A|TTC Next-generation Home Network System WG
+E02A82|Universal Global Scientific Industrial Co., Ltd.
+E02F6D|Cisco
+E03005|Alcatel-Lucent Shanghai Bell Co., Ltd
+E031D0|SZ Telstar CO., LTD
+E03560|Challenger Supply Holdings, LLC
+E036E3|Stage One International Co., Ltd.
+E039D7|Plexxi, Inc.
+E03C5B|SHENZHEN JIAXINJIE ELECTRON CO.,LTD
+E03E44|Broadcom Corporation
+E03E4A|Cavanagh Group International
+E03E7D|data-complex GmbH
+E03F49|ASUSTek COMPUTER INC.
+E0469A|Netgear
+E04B45|Hi-P Electronics Pte Ltd
+E05597|Emergent Vision Technologies Inc.
+E056F4|AxesNetwork Solutions inc.
+E0589E|Laerdal Medical
+E05B70|Innovid, Co., Ltd.
+E05DA6|Detlef Fink Elektronik & Softwareentwicklung
+E05FB9|Cisco
+E061B2|HANGZHOU ZENOINTEL TECHNOLOGY CO., LTD
+E06290|Jinan Jovision Science & Technology Co., Ltd.
+E063E5|Sony Mobile Communications AB
+E064BB|DigiView S.r.l.
+E06678|Apple
+E067B3|C-Data Technology Co., Ltd
+E06995|PEGATRON CORPORATION
+E0750A|ALPS ERECTORIC CO.,LTD.
+E0757D|Motorola
+E076D0|AMPAK Technology, Inc.
+E07C62|Whistle Labs, Inc.
+E07F53|TECHBOARD SRL
+E07F88|EVIDENCE Network SIA
+E08177|GreenBytes, Inc.
+E087B1|Nata-Info Ltd.
+E0885D|Technicolor CH USA Inc
+E0899D|Cisco
+E08A7E|Exponent
+E08E3C|Aztech Electronics Pte Ltd
+E08FEC|REPOTEC CO., LTD.
+E09153|XAVi Technologies Corp.
+E091F5|Netgear
+E09467|Intel Corporate
+E09579|ORTHOsoft inc, d/b/a Zimmer CAS
+E09796|HUAWEI TECHNOLOGIES CO.,LTD
+E097F2|Atomax Inc.
+E09971|Samsung
+E09D31|Intel Corporate
+E09DB8|PLANEX COMMUNICATIONS INC.
+E0A198|NOJA Power Switchgear Pty Ltd
+E0A1D7|SFR
+E0A30F|Pevco
+E0A670|Nokia Corporation
+E0AAB0|GENERAL VISION ELECTRONICS CO. LTD.
+E0ABFE|Orb Networks, Inc.
+E0ACF1|Cisco
+E0AE5E|ALPS Co,. Ltd.
+E0AEB2|Bender GmbH &amp; Co.KG
+E0AEED|LOENK
+E0AF4B|Pluribus Networks, Inc.
+E0B2F1|FN-LINK TECHNOLOGY LIMITED
+E0B52D|Apple
+E0B70A|ARRIS Group, Inc.
+E0B7B1|Pace plc
+E0B9A5|Azurewave
+E0B9BA|Apple
+E0BC43|C2 Microsystems, Inc.
+E0C286|Aisai Communication Technology Co., Ltd.
+E0C2B7|Masimo Corporation
+E0C3F3|ZTE Corporation
+E0C6B3|MilDef AB
+E0C79D|Texas Instruments
+E0C86A|SHENZHEN TW-SCIE Co., Ltd
+E0C922|Jireh Energy Tech., Ltd.
+E0C97A|Apple
+E0CA4D|Shenzhen Unistar Communication Co.,LTD
+E0CA94|Askey Computer
+E0CB1D|ZZZZ 
+E0CB4E|ASUSTek COMPUTER INC.
+E0CBEE|Samsung
+E0CEC3|ASKEY COMPUTER CORP
+E0CF2D|Gemintek Corporation
+E0D10A|Katoudenkikougyousyo co ltd
+E0D173|Cisco
+E0D1E6|Aliph dba Jawbone
+E0D31A|EQUES Technology Co., Limited
+E0D7BA|Texas Instruments
+E0D9A2|Hippih aps
+E0DADC|JVC KENWOOD Corporation
+E0DB10|Samsung
+E0DB55|Dell Inc
+E0DB88|Open Standard Digital-IF Interface for SATCOM Systems
+E0DCA0|Siemens Electrical Apparatus Ltd., Suzhou Chengdu Branch
+E0E5CF|Texas Instruments
+E0E631|SNB TECHNOLOGIES LIMITED
+E0E751|Nintendo Co., Ltd.
+E0E8E8|Olive Telecommunication Pvt. Ltd
+E0ED1A|vastriver Technology Co., Ltd
+E0EDC7|Shenzhen Friendcom Technology Development Co., Ltd
+E0EE1B|Panasonic Automotive Systems Company of America
+E0EF25|Lintes Technology Co., Ltd.
+E0F211|Digitalwatt
+E0F379|Vaddio
+E0F5C6|Apple
+E0F5CA|CHENG UEI PRECISION INDUSTRY CO.,LTD.
+E0F847|Apple
+E0F9BE|Cloudena Corp.
+E0FAEC|Platan sp. z o.o. sp. k.
+E0FFF7|Softiron Inc.
+E40439|TomTom Software Ltd
+E4115B|Hewlett Packard
+E41218|ShenZhen Rapoo Technology Co., Ltd.
+E4121D|Samsung
+E41289|topsystem Systemhaus GmbH
+E41C4B|V2 TECHNOLOGY, INC.
+E41D2D|Mellanox Technologies, Inc.
+E41F13|IBM Corp
+E42354|SHENZHEN FUZHI SOFTWARE TECHNOLOGY CO.,LTD
+E425E7|Apple
+E425E9|Color-Chip
+E42771|Smartlabs
+E42AD3|Magneti Marelli S.p.A. Powertrain
+E42C56|Lilee Systems, Ltd.
+E42D02|TCT Mobile Limited
+E42F26|Fiberhome Telecommunication Tech.Co.,Ltd.
+E42FF6|Unicore communication Inc.
+E432CB|Samsung
+E43593|Hangzhou GoTo technology Co.Ltd
+E435FB|Sabre Technology (Hull) Ltd
+E437D7|HENRI DEPAEPE S.A.S.
+E438F2|Advantage Controls
+E43FA2|Wuxi DSP Technologies Inc.
+E440E2|Samsung
+E441E6|Ottec Technology GmbH
+E446BD|C&C TECHNIC TAIWAN CO., LTD.
+E448C7|Cisco
+E44C6C|Shenzhen Guo Wei Electronic Co,. Ltd.
+E44E18|Gardasoft VisionLimited
+E44F29|MA Lighting Technology GmbH
+E44F5F|EDS Elektronik Destek San.Tic.Ltd.Sti
+E455EA|Dedicated Computing
+E45614|Suttle Apparatus
+E457A8|Stuart Manufacturing, Inc.
+E458E7|Samsung
+E45AA2|vivo Mobile Communication Co., Ltd.
+E45D52|Avaya, Inc
+E46449|ARRIS Group, Inc.
+E467BA|Danish Interpretation Systems A/S
+E468A3|HUAWEI TECHNOLOGIES CO.,LTD
+E4695A|Dictum Health, Inc.
+E46C21|messMa GmbH
+E47185|Securifi Ltd
+E4751E|Getinge Sterilization AB
+E47723|zte corporation
+E4776B|AARTESYS AG
+E477D4|Minrray Industry Co.,Ltd
+E47CF9|Samsung
+E47D5A|Beijing Hanbang Technology Corp.
+E47FB2|Fujitsu Limited
+E48184|Alcatel-Lucent
+E481B3|Shenzhen ACT Industrial Co.,Ltd.
+E48399|ARRIS Group, Inc.
+E48501|Geberit International AG
+E48AD5|RF WINDOW CO., LTD.
+E48B7F|Apple
+E48C0F|Discovery Insure
+E48D8C|Routerboard.com
+E49069|Rockwell Automation
+E4907E|Motorola
+E492E7|Gridlink Tech. Co.,Ltd.
+E492FB|Samsung
+E4956E|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+E496AE|ALTOGRAPHICS Inc.
+E497F0|Shanghai VLC Technologies Ltd. Co.
+E498D6|Apple
+E4A5EF|TRON LINK ELECTRONICS CO., LTD.
+E4A7FD|Cellco Partnership
+E4AB46|UAB Selteka
+E4AD7D|SCL Elements
+E4AFA1|HES-SO
+E4B021|Samsung
+E4BAD9|360 Fly Inc.
+E4C146|Objetivos y Servicios de Valor A
+E4C62B|Airware
+E4C63D|Apple
+E4C6E6|Mophie, LLC
+E4C722|Cisco
+E4C806|Ceiec Electric Technology Inc.
+E4CE70|Health & Life co., Ltd.
+E4CE8F|Apple
+E4D332|TP-LINK TECHNOLOGIES CO.,LTD.
+E4D3F1|Cisco
+E4D53D|Hon Hai Precision Ind. Co.,Ltd.
+E4D71D|Oraya Therapeutics
+E4DD79|En-Vision America, Inc.
+E4E0C5|Samsung
+E4E409|LEIFHEIT AG
+E4EC10|Nokia Corporation
+E4EEFD|MR&D Manufacturing
+E4F365|Time-O-Matic, Inc.
+E4F3E3|Shanghai iComhome Co.,Ltd.
+E4F4C6|Netgear
+E4F7A1|Datafox GmbH
+E4F89C|Intel Corporate
+E4F8EF|Samsung
+E4F939|Minxon Hotel Technology INC.
+E4FA1D|PAD Peripheral Advanced Design Inc.
+E4FAFD|Intel Corporate
+E4FED9|EDMI Europe Ltd
+E4FFDD|ELECTRON INDIA
+E8039A|Samsung
+E8040B|Apple
+E80462|Cisco
+E804F3|Throughtek Co., Ltd.
+E8056D|Nortel Networks
+E80688|Apple
+E807BF|SHENZHEN BOOMTECH INDUSTRY CO.,LTD
+E8088B|Huawei Technologies Co., Ltd
+E80B13|Akib Systems Taiwan, INC
+E80C38|DAEYOUNG INFORMATION SYSTEM CO., LTD
+E80C75|Syncbak, Inc.
+E8102E|Really Simple Software, Inc
+E81132|Samsung
+E81324|GuangZhou Bonsoninfo System CO.,LTD
+E8150E|Nokia Corporation
+E8162B|IDEO Security Co., Ltd.
+E817FC|NIFTY Corporation
+E81863|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+E82877|TMY Co., Ltd.
+E828D5|Cots Technology
+E82AEA|Intel Corporate
+E82E24|Out of the Fog Research LLC
+E83381|ARRIS Group, Inc.
+E8377A|ZyXEL Communications Corporation
+E83935|Hewlett Packard
+E839DF|Askey Computer
+E83A97|OCZ Technology Group
+E83EB6|RIM
+E83EFB|GEODESIC LTD.
+E83EFC|ARRIS Group, Inc.
+E84040|Cisco
+E840F2|PEGATRON CORPORATION
+E843B6|QNAP Systems, Inc.
+E8447E|Bitdefender SRL
+E8481F|Advanced Automotive Antennas
+E84E06|EDUP INTERNATIONAL (HK) CO., LTD
+E84E84|Samsung
+E84ECE|Nintendo Co., Ltd.
+E8508B|Samsung
+E8516E|TSMART Inc.
+E8519D|Yeonhab Precision Co.,LTD
+E85484|NEO INFORMATION SYSTEMS CO., LTD.
+E856D6|NCTech Ltd
+E85AA7|LLC Emzior
+E85B5B|LG Electronics
+E85BF0|Imaging Diagnostics
+E85D6B|Luminate Wireless
+E85E53|Infratec Datentechnik GmbH
+E8611F|Dawning Information Industry Co.,Ltd
+E8617E|Liteon Technology Corporation
+E86183|Black Diamond Advanced Technology, LLC
+E861BE|Melec Inc.
+E86549|Cisco
+E866C4|Datawise Systems
+E86CDA|Supercomputers and Neurocomputers Research Center
+E86D52|ARRIS Group, Inc.
+E86D54|Digit Mobile Inc
+E86D6E|Control & Display Systems Ltd t/a CDSRail
+E8718D|Elsys Equipamentos Eletronicos Ltda
+E874E6|ADB BROADBAND ITALIA
+E8757F|FIRS Technologies(Shenzhen) Co., Ltd
+E878A1|BEOVIEW INTERCOM DOO
+E87AF3|S5 Tech S.r.l.
+E8802E|Apple
+E880D8|GNTEK Electronics Co.,Ltd.
+E887A3|Loxley Public Company Limited
+E8892C|ARRIS Group, Inc.
+E88D28|Apple
+E88DF5|ZNYX Networks, Inc.
+E88E60|NSD Corporation
+E89120|Motorola
+E89218|Arcontia International AB
+E892A4|LG Electronics
+E8944C|Cogent Healthcare Systems Ltd
+E894F6|TP-LINK TECHNOLOGIES CO.,LTD.
+E89606|testo Instruments (Shenzhen) Co., Ltd.
+E8995A|PiiGAB, Processinformation i Goteborg AB
+E899C4|HTC Corporation
+E89A8F|Quanta Computer Inc.
+E89AFF|Fujian Landi Commercial Equipment Co.,Ltd
+E89D87|Toshiba
+E8A364|Signal Path International / Peachtree Audio
+E8A4C1|Deep Sea Electronics PLC
+E8ABFA|Shenzhen Reecam Tech.Ltd.
+E8B1FC|Intel Corporate
+E8B4AE|Shenzhen C&D Electronics Co.,Ltd
+E8B748|Cisco
+E8BA70|Cisco
+E8BB3D|Sino Prime-Tech Limited
+E8BBA8|GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD.
+E8BE81|SAGEMCOM
+E8C229|H-Displays (MSC) Bhd
+E8C320|Austco Communication Systems Pty Ltd
+E8C74F|Liteon Technology Corporation
+E8CBA1|Nokia Corporation
+E8CC18|D-Link International
+E8CC32|Micronet  LTD
+E8CD2D|Huawei Technologies Co., Ltd
+E8CE06|SkyHawke Technologies, LLC.
+E8D0FA|MKS Instruments Deutschland GmbH
+E8D483|ULTIMATE Europe Transportation Equipment GmbH
+E8D4E0|Beijing BenyWave Technology Co., Ltd.
+E8DA96|Zhuhai Tianrui Electrical Power Tech. Co., Ltd.
+E8DAAA|VideoHome Technology Corp.
+E8DE27|TP-LINK TECHNOLOGIES CO.,LTD.
+E8DFF2|PRF Co., Ltd.
+E8E08F|GRAVOTECH MARKING SAS
+E8E0B7|Toshiba
+E8E1E2|Energotest
+E8E5D6|Samsung
+E8E732|Alcatel-Lucent
+E8E770|Warp9 Tech Design, Inc.
+E8E776|Shenzhen Kootion Technology Co., Ltd
+E8E875|iS5 Communications Inc.
+E8EA6A|StarTech.com
+E8EADA|Denkovi Assembly Electroncs LTD
+E8ED05|ARRIS Group, Inc.
+E8EDF3|Cisco
+E8EF89|OPMEX Tech.
+E8F1B0|SAGEMCOM SAS
+E8F226|MILLSON CUSTOM SOLUTIONS INC.
+E8F2E3|Starcor Beijing Co.,Limited
+E8F928|RFTECH SRL
+E8FC60|ELCOM Innovations Private Limited
+E8FCAF|Netgear
+EC0EC4|Hon Hai Precision Ind. Co.,Ltd.
+EC0ED6|ITECH INSTRUMENTS SAS
+EC1120|FloDesign Wind Turbine Corporation
+EC1127|Texas Instruments
+EC13B2|Netonix
+EC14F6|BioControl AS
+EC172F|TP-LINK TECHNOLOGIES CO., LTD.
+EC1766|Research Centre Module
+EC1A59|Belkin International Inc.
+EC1D7F|zte corporation
+EC219F|VidaBox LLC
+EC2257|JiangSu NanJing University Electronic Information Technology Co.,Ltd
+EC2280| D-Link International
+EC233D|Huawei Technologies Co., Ltd
+EC2368|IntelliVoice Co.,Ltd.
+EC24B8|Texas Instruments
+EC26CA|TP-LINK TECHNOLOGIES CO.,LTD
+EC2AF0|Ypsomed AG
+EC2C49|University of Tokyo
+EC2E4E|HITACHI-LG DATA STORAGE INC
+EC3091|Cisco
+EC3586|Apple
+EC3BF0|NovelSat
+EC3C5A|SHEN ZHEN HENG SHENG HUI DIGITAL TECHNOLOGY CO.,LTD
+EC3C88|MCNEX Co.,Ltd.
+EC3E09|PERFORMANCE DESIGNED PRODUCTS, LLC
+EC3F05|Institute 706, The Second Academy China Aerospace Science & Industry Corp
+EC42F0|ADL Embedded Solutions, Inc.
+EC43E6|AWCER Ltd.
+EC43F6|ZyXEL Communications Corporation
+EC4476|Cisco
+EC4644|TTK SAS
+EC4670|Meinberg Funkuhren GmbH & Co. KG
+EC473C|Redwire, LLC
+EC4993|Qihan Technology Co., Ltd
+EC4C4D|ZAO NPK RoTeK
+EC4F82|Calix Inc.
+EC542E|Shanghai XiMei Electronic Technology Co. Ltd
+EC55F9|Hon Hai Precision Ind. Co.,Ltd.
+EC59E7|Microsoft
+EC5A86|Yulong Computer Telecommunication Scientific (Shenzhen) Co.,Ltd
+EC5C69|MITSUBISHI HEAVY INDUSTRIES MECHATRONICS SYSTEMS,LTD.
+EC60E0|AVI-ON LABS
+EC6264|Global411 Internet Services, LLC
+EC63E5|ePBoard Design LLC
+EC66D1|B&W Group LTD
+EC6C9F|Chengdu Volans Technology CO.,LTD
+EC71DB|Shenzhen Baichuan Digital Technology Co., Ltd.
+EC74BA|Hirschmann Automation and Control GmbH
+EC7C74|Justone Technologies Co., Ltd.
+EC7D9D|MEI
+EC8009|NovaSparks
+EC836C|RM Tech Co., Ltd.
+EC852F|Apple
+EC888F|TP-LINK TECHNOLOGIES CO., LTD.
+EC8892|Motorola
+EC89F5|Lenovo Mobile Communication Technology Ltd.
+EC8A4C|zte corporation
+EC8EAD|DLX
+EC9233|Eddyfi NDT Inc
+EC9327|MEMMERT GmbH + Co. KG
+EC9681|2276427 Ontario Inc
+EC986C|Lufft Mess- und Regeltechnik GmbH
+EC98C1|Beijing Risbo Network Technology Co.,Ltd
+EC9A74|Hewlett Packard
+EC9B5B|Nokia Corporation
+EC9ECD|Artesyn Embedded Technologies
+ECA29B|Kemppi Oy
+ECA86B|ELITEGROUP COMPUTER SYSTEMS CO., LTD.
+ECB106|Acuro Networks, Inc
+ECB1D7|Hewlett Packard
+ECB541|SHINANO E and E Co.Ltd.
+ECB907|CloudGenix Inc
+ECBAFE|GIROPTIC
+ECBBAE|Digivoice Tecnologia em Eletronica Ltda
+ECBD09|FUSION Electronics Ltd
+ECC38A|Accuenergy (CANADA) Inc
+ECC882|Cisco
+ECCB30|Huawei Technologies Co., Ltd
+ECCD6D|Allied Telesis, Inc.
+ECD00E|MiraeRecognition Co., Ltd.
+ECD040|GEA Farm Technologies GmbH
+ECD19A|Zhuhai Liming Industries Co., Ltd
+ECD925|RAMI
+ECD950|IRT SA
+ECD9D1|Shenzhen TG-NET Botone Technology Co.,Ltd.
+ECDE3D|Lamprey Networks, Inc.
+ECE09B|Samsung
+ECE1A9|Cisco
+ECE2FD|SKG Electric Group(Thailand) Co., Ltd.
+ECE512|tado GmbH
+ECE555|Hirschmann Automation
+ECE744|Omntec mfg. inc
+ECE90B|SISTEMA SOLUCOES ELETRONICAS LTDA - EASYTECH
+ECE915|STI Ltd
+ECE9F8|Guang Zhou TRI-SUN Electronics Technology  Co., Ltd
+ECEA03|DARFON LIGHTING CORP
+ECF00E|Abocom
+ECF236|NEOMONTANA ELECTRONICS
+ECF35B|Nokia Corporation
+ECF4BB|Dell Inc
+ECF72B|HD DIGITAL TECH CO., LTD.
+ECFAAA|The IMS Company
+ECFC55|A. Eberle GmbH & Co. KG
+ECFE7E|BlueRadios, Inc.
+F0007F|Janz - Contadores de Energia, SA
+F0022B|Chrontel
+F00248|SmarteBuilding
+F00786|Shandong Bittel Electronics Co., Ltd
+F008F1|Samsung
+F013C3|SHENZHEN FENDA TECHNOLOGY CO., LTD
+F015A0|KyungDong One Co., Ltd.
+F01C13|LG Electronics
+F01C2D|Juniper Networks
+F01E34|ORICO Technologies Co., Ltd
+F01FAF|Dell Inc
+F0219D|Cal-Comp Electronics & Communications Company Ltd.
+F02329|SHOWA DENKI CO.,LTD.
+F02405|OPUS High Technology Corporation
+F02408|Talaris (Sweden) AB
+F02475|Apple
+F02572|Cisco
+F025B7|Samsung
+F0264C|Dr. Sigrist AG
+F02765|Murata Manufactuaring Co.,Ltd.
+F02929|Cisco
+F02A23|Creative Next Design
+F02A61|Waldo Networks, Inc.
+F02FD8|Bi2-Vision
+F0321A|Mita-Teknik A/S
+F037A1|Huike Electronics (SHENZHEN) CO., LTD.
+F03A4B|Bloombase, Inc.
+F03A55|Omega Elektronik AS
+F03D29|Actility
+F03FF8|R L Drake
+F04335|DVN(Shanghai)Ltd.
+F04A2B|PYRAMID Computer GmbH
+F04B6A|Scientific Production Association Siberian Arsenal, Ltd.
+F04BF2|JTECH Communications, Inc.
+F04DA2|Dell Inc.
+F04F7C|ZZZZ 
+F05849|CareView Communications
+F05A09|Samsung
+F05D89|Dycon Limited
+F05DC8|Duracell Powermat
+F05F5A|Getriebebau NORD GmbH and Co. KG
+F06130|Advantage Pharmacy Services, LLC
+F0620D|Shenzhen Egreat Tech Corp.,Ltd
+F06281|ProCurve Networking by HP
+F065DD|Primax Electronics Ltd.
+F06853|Integrated Corporation
+F06BCA|Samsung
+F0728C|Samsung
+F073AE|PEAK-System Technik
+F0761C|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+F07765|Sourcefire, Inc
+F077D0|Xcellen
+F07816|Cisco
+F07959|ASUSTek COMPUTER INC.
+F07BCB|Hon Hai Precision Ind. Co.,Ltd.
+F07D68|D-Link Corporation
+F07F06|Cisco
+F07F0C|Leopold Kostal GmbH &Co. KG
+F081AF|IRZ AUTOMATION TECHNOLOGIES LTD
+F08261|SAGEMCOM
+F0842F|ADB Broadband Italia
+F084C9|zte corporation
+F08A28|JIANGSU HENGSION ELECTRONIC S and T CO.,LTD
+F08BFE|COSTEL.,CO.LTD
+F08CFB|Fiberhome Telecommunication Tech.Co.,Ltd.
+F08EDB|VeloCloud Networks
+F0921C|Hewlett Packard
+F0933A|NxtConect
+F093C5|Garland Technology
+F099BF|Apple
+F09CBB|RaonThink Inc.
+F09CE9|Aerohive Networks Inc
+F09E63|Cisco
+F09FC2|Ubiquiti Networks
+F0A225|ZZZZ 
+F0A764|GST Co., Ltd.
+F0AB54|MITSUMI ELECTRIC CO.,LTD.
+F0ACA4|HBC-radiomatic
+F0AD4E|Globalscale Technologies, Inc.
+F0AE51|Xi3 Corp
+F0B052|Ruckus Wireless
+F0B479|Apple
+F0B6EB|Poslab Technology Co., Ltd.
+F0BCC8|MaxID (Pty) Ltd
+F0BDF1|Sipod Inc.
+F0BF97|Sony Corporation
+F0C1F1|Apple
+F0C24C|Zhejiang FeiYue Digital Technology Co., Ltd
+F0C27C|Mianyang Netop Telecom Equipment Co.,Ltd.
+F0C88C|LeddarTech Inc.
+F0CBA1|Apple
+F0D14F|LINEAR LLC
+F0D1A9|Apple
+F0D3A7|CobaltRay Co., Ltd
+F0D3E7|Sensometrix SA
+F0D657|ECHOSENS
+F0D767|Axema Passagekontroll AB
+F0DA7C|RLH INDUSTRIES,INC.
+F0DB30|Yottabyte
+F0DBE2|Apple
+F0DBF8|Apple
+F0DCE2|Apple
+F0DE71|Shanghai EDO Technologies Co.,Ltd.
+F0DEB9|ShangHai Y&Y Electronics Co., Ltd
+F0DEF1|Wistron InfoComm (Kunshan)Co
+F0E5C3|Dragerwerk AG & Co. KG aA
+F0E77E|Samsung
+F0EBD0|Shanghai Feixun Communication Co.,Ltd.
+F0EC39|Essec
+F0ED1E|Bilkon Bilgisayar Kontrollu Cih. Im.Ltd.
+F0EEBB|VIPAR GmbH
+F0F002|Hon Hai Precision Ind. Co.,Ltd.
+F0F260|Mobitec AB
+F0F336|TP-LINK TECHNOLOGIES CO.,LTD
+F0F5AE|Adaptrum Inc.
+F0F61C|Apple
+F0F644|Whitesky Science & Technology Co.,Ltd.
+F0F669|Motion Analysis Corporation
+F0F755|Cisco
+F0F7B3|Phorm
+F0F842|KEEBOX, Inc.
+F0F9F7|IES GmbH & Co. KG
+F0FDA0|Acurix Networks LP
+F0FE6B|Shanghai High-Flying Electronics Technology Co., Ltd
+F40321|BeNeXt B.V.
+F4032F|Reduxio Systems
+F4044C|ValenceTech Limited
+F40669|Intel Corporate
+F4068D|devolo AG
+F406A5|Hangzhou Bianfeng Networking Technology Co., Ltd.
+F409D8|Samsung
+F40B93|Research In Motion
+F40E11|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+F40F1B|Cisco
+F40F9B|WAVELINK
+F41563|F5 Networks, Inc.
+F415FD|Shanghai Pateo Electronic Equipment Manufacturing Co., Ltd.
+F41BA1|Apple
+F41E26|Simon-Kaloi Engineering
+F41F0B|YAMABISHI Corporation
+F41FC2|Cisco
+F42012|Cuciniale GmbH
+F42833|MMPC Inc.
+F42853|Zioncom Electronics (Shenzhen) Ltd.
+F42896|SPECTO PAINEIS ELETRONICOS LTDA
+F42981|vivo Mobile Communication Co., Ltd.
+F42C56|SENOR TECH CO LTD
+F436E1|Abilis Systems SARL
+F437B7|Apple
+F43814|Shanghai Howell Electronic Co.,Ltd
+F43D80|FAG Industrial Services GmbH
+F43E61|Shenzhen Gongjin Electronics Co., Ltd
+F43E9D|Benu Networks, Inc.
+F44227|S & S Research Inc.
+F44450|BND Co., Ltd.
+F445ED|Portable Innovation Technology Ltd.
+F44713|Leading Public Performance Co., Ltd.
+F4472A|Nanjing Rousing Sci. and Tech. Industrial Co., Ltd
+F44848|Amscreen Group Ltd
+F44E05|Cisco
+F44EFD|Actions Semiconductor Co.,Ltd.(Cayman Islands)
+F450EB|Telechips Inc
+F45214|Mellanox Technologies, Inc.
+F45433|Rockwell Automation
+F45595|HENGBAO Corporation LTD.
+F4559C|Huawei Technologies Co., Ltd
+F455E0|Niceway CNC Technology Co.,Ltd.Hunan Province
+F4573E|Fiberhome Telecommunication Technologies Co.,LTD
+F45842|Boxx TV Ltd
+F45F69|Matsufu Electronics distribution Company
+F45FD4|Cisco
+F45FF7|DQ Technology Inc.
+F4600D|Panoptic Technology, Inc
+F46349|Diffon Corporation
+F4645D|Toshiba
+F46A92|SHENZHEN FAST TECHNOLOGIES CO.,LTD
+F46ABC|Adonit Corp. Ltd.
+F46D04|ASUSTek COMPUTER INC.
+F46DE2|zte corporation
+F473CA|Conversion Sound Inc.
+F47626|Viltechmeda UAB
+F47A4E|Woojeon&Handan
+F47ACC|SolidFire, Inc.
+F47B5E|Samsung
+F47F35|Cisco
+F48139|CANON INC.
+F48771|Infoblox
+F48E09|Nokia Corporation
+F490CA|Tensorcom
+F490EA|Deciso B.V.
+F49461|NexGen Storage
+F49466|CountMax,  ltd
+F499AC|WEBER Schraubautomaten GmbH
+F49F54|Samsung
+F49FF3|Huawei Technologies Co., Ltd
+F4A294|EAGLE WORLD DEVELOPMENT CO., LIMITED
+F4A52A|Hawa Technologies Inc
+F4ACC1|Cisco
+F4B164|Lightning Telecommunications Technology Co. Ltd
+F4B381|WindowMaster A/S
+F4B52F|Juniper networks
+F4B549|Yeastar Technology Co., Ltd.
+F4B6E5|TerraSem Co.,Ltd
+F4B72A|TIME INTERCONNECT LTD
+F4B7E2|Hon Hai Precision Ind. Co.,Ltd.
+F4B85E|Texas INstruments
+F4BD7C|Chengdu jinshi communication Co., LTD
+F4C447|Coagent International Enterprise Limited
+F4C6D7|blackned GmbH
+F4C714|Shenzhen Huawei Communication Technologies Co., Ltd
+F4C795|WEY Elektronik AG
+F4CAE5|FREEBOX SA
+F4CD90|Vispiron Rotec GmbH
+F4CE46|Hewlett-Packard Company
+F4CFE2|Cisco
+F4D032|Yunnan Ideal Information&Technology.,Ltd
+F4D261|SEMOCON Co., Ltd
+F4D9FB|Samsung
+F4DC4D|Beijing CCD Digital Technology Co., Ltd
+F4DCDA|Zhuhai Jiahe Communication Technology Co., limited
+F4DCF9|Huawei Technologies Co., Ltd
+F4DD9E|GoPro
+F4E142|Delta Elektronika BV
+F4E3FB|Huawei Technologies Co., Ltd
+F4E6D7|Solar Power Technologies, Inc.
+F4E9D4|QLogic Corporation
+F4EA67|Cisco
+F4EC38|TP-LINK TECHNOLOGIES CO., LTD.
+F4EE14|SHENZHEN MERCURY COMMUNICATION TECHNOLOGIES CO.,LTD.
+F4F15A|Apple
+F4F1E1|Motorola
+F4F26D|TP-LINK TECHNOLOGIES CO.,LTD.
+F4F5A5|Nokia corporation
+F4F5E8|Google
+F4F646|Dediprog Technology Co. Ltd.
+F4F951|Apple
+F4FC32|Texas Instruments
+F4FD2B|ZOYI Company
+F80113|Huawei Technologies Co., Ltd
+F80278|IEEE REGISTRATION AUTHORITY  - Please see MAM public listing for more information.
+F80332|Khomp
+F8042E|Samsung
+F8051C|DRS Imaging and Targeting Solutions
+F80BBE|ARRIS Group, Inc.
+F80BD0|Datang Telecom communication terminal (Tianjin) Co., Ltd.
+F80CF3|LG Electronics
+F80D43|Hon Hai Precision Ind. Co., Ltd.
+F80DEA|ZyCast Technology Inc.
+F80F41|Wistron InfoComm(ZhongShan) Corporation
+F80F84|Natural Security SAS
+F81037|Atopia Systems, LP
+F81547|Avaya, Inc
+F81654|Intel Corporate
+F81897|2Wire
+F81A67|TP-LINK TECHNOLOGIES CO., LTD.
+F81CE5|Telefonbau Behnke GmbH
+F81D93|Longdhua(Beijing) Controls Technology Co.,Ltd
+F81EDF|Apple
+F82285|Cypress Technology CO., LTD.
+F82441|Yeelink
+F82793|Apple
+F82BC8|Jiangsu Switter Co., Ltd
+F82EDB|RTW GmbH & Co. KG
+F82F5B|eGauge Systems LLC
+F82FA8|Hon Hai Precision Ind. Co.,Ltd.
+F83094|Alcatel-Lucent Telecom Limited
+F8313E|endeavour GmbH
+F83376|Good Mind Innovation Co., Ltd.
+F83553|Magenta Research Ltd.
+F835DD|Gemtek Technology Co., Ltd.
+F83D4E|Softlink Automation System Co., Ltd
+F83DFF|Huawei Technologies Co., Ltd
+F842FB|Yasuda Joho Co.,ltd.
+F845AD|Konka Group Co., Ltd.
+F8462D|SYNTEC Incorporation
+F8472D|X2gen Digital Corp. Ltd
+F84897|Hitachi, Ltd.
+F84A73|EUMTECH CO., LTD
+F84A7F|Innometriks Inc
+F84ABF|HUAWEI TECHNOLOGIES CO.,LTD
+F84F57|Cisco
+F85063|Verathon
+F8516D|Denwa Technology Corp.
+F852DF|VNL Europe AB
+F854AF|ECI Telecom Ltd.
+F8572E|Core Brands, LLC
+F85BC9|M-Cube Spa
+F85C45|IC Nexus Co. Ltd.
+F85F2A|Nokia Corporation
+F862AA|xn systems
+F86601|Suzhou Chi-tek information technology Co., Ltd
+F866D1|Hon Hai Precision Ind. Co., Ltd.
+F866F2|Cisco
+F86971|Seibu Electric Co.,
+F86ECF|Arcx Inc
+F871FE|The Goldman Sachs Group, Inc.
+F872EA|Cisco
+F87394|Netgear
+F8769B|Neopis Co., Ltd.
+F87AEF|Rosonix Technology, Inc.
+F87B62|FASTWEL INTERNATIONAL CO., LTD. Taiwan Branch
+F87B7A|ARRIS Group, Inc.
+F87B8C|Amped Wireless
+F8811A|OVERKIZ
+F88479|Yaojin Technology(Shenzhen)Co.,Ltd
+F884F2|Samsung
+F88C1C|KAISHUN ELECTRONIC TECHNOLOGY CO., LTD. BEIJING
+F88DEF|Tenebraex
+F88E85|COMTREND CORPORATION
+F88FCA|Google
+F8912A|GLP German Light Products GmbH
+F893F3|VOLANS
+F89550|Proton Products Chengdu Ltd
+F895C7|LG Electronics
+F897CF|DAESHIN-INFORMATION TECHNOLOGY CO., LTD.
+F89955|Fortress Technology Inc
+F89D0D|Control Technology Inc.
+F89FB8|YAZAKI Energy System Corporation
+F8A03D|Dinstar Technologies Co., Ltd.
+F8A2B4|RHEWA-WAAGENFABRIK August Freudewald GmbH &amp;Co. KG
+F8A45F|Beijing Xiaomi communications co.,ltd
+F8A963|COMPAL INFORMATION (KUNSHAN) CO., LTD.
+F8A9D0|LG Electronics
+F8A9DE|PUISSANCE PLUS
+F8AA8A|Axview Technology (Shenzhen) Co.,Ltd
+F8AC6D|Deltenna Ltd
+F8B156|Dell Inc
+F8B2F3|GUANGZHOU BOSMA TECHNOLOGY CO.,LTD
+F8B599|Guangzhou CHNAVS Digital Technology Co.,Ltd
+F8BC12|Dell Inc
+F8BC41|Rosslare Enterprises Limited
+F8C001|Juniper Networks
+F8C091|Highgates Technology
+F8C288|Cisco
+F8C397|NZXT Corp. Ltd.
+F8C678|Carefusion
+F8C96C|Fiberhome Telecommunication Tech.Co.,Ltd.
+F8CFC5|Motorola
+F8D0AC|Sony Computer Entertainment Inc.
+F8D0BD|Samsung
+F8D111|TP-LINK TECHNOLOGIES CO., LTD.
+F8D3A9|AXAN Networks
+F8D462|Pumatronix Equipamentos Eletronicos Ltda.
+F8D756|Simm Tronic Limited
+F8D7BF|REV Ritter GmbH
+F8DADF|EcoTech, Inc.
+F8DAE2|Beta LaserMike
+F8DAF4|Taishan Online Technology Co., Ltd.
+F8DB4C|PNY Technologies, INC.
+F8DB7F|HTC Corporation
+F8DB88|Dell Inc
+F8DC7A|Variscite LTD
+F8DFA8|ZTE Corporation
+F8E079|Motorola
+F8E4FB|Actiontec Electronics, Inc
+F8E7B5|uTech Tecnologia LTDA
+F8E811|HUAWEI TECHNOLOGIES CO.,LTD
+F8E903|D-Link International
+F8E968|Egker Kft.
+F8EA0A|Dipl.-Math. Michael Rauch
+F8EDA5|ARRIS Group, Inc.
+F8F005|Newport Media Inc.
+F8F014|RackWare Inc.
+F8F082|Orion Networks International, Inc
+F8F1B6|Motorola
+F8F25A|G-Lab GmbH
+F8F7D3|International Communications Corporation
+F8F7FF|SYN-TECH SYSTEMS INC
+F8FB2F|Santur Corporation
+F8FE5C|Reciprocal Labs Corp
+F8FEA8|Technico Japan Corporation
+F8FF5F|Shenzhen Communication Technology Co.,Ltd
+FC0012|Toshiba Samsung Storage Technolgoy Korea Corporation
+FC019E|VIEVU
+FC01CD|FUNDACION TEKNIKER
+FC0647|Cortland Research, LLC
+FC07A0|LRE Medical GmbH
+FC0877|Prentke Romich Company
+FC09D8|ACTEON Group
+FC09F6|GUANGDONG TONZE ELECTRIC CO.,LTD
+FC0A81|Zebra Technologies Inc
+FC0FE6|Sony Computer Entertainment Inc.
+FC10BD|Control Sistematizado S.A.
+FC1186|Logic3 plc
+FC1349|Global Apps Corp.
+FC15B4|Hewlett Packard
+FC1607|Taian Technology(Wuxi) Co.,Ltd.
+FC1794|InterCreative Co., Ltd
+FC1910|Samsung
+FC19D0|Cloud Vision Networks Technology Co.,Ltd.
+FC1BFF|V-ZUG AG
+FC1D59|I Smart Cities HK Ltd
+FC1D84|Autobase
+FC1E16|IPEVO corp
+FC1F19|Samsung
+FC1FC0|EURECAM
+FC229C|Han Kyung I Net Co.,Ltd.
+FC2325|EosTek (Shenzhen) Co., Ltd.
+FC253F|Apple
+FC27A2|TRANS ELECTRIC CO., LTD.
+FC2A54|Connected Data, Inc.
+FC2E2D|Lorom Industrial Co.LTD.
+FC2F40|Calxeda, Inc.
+FC3288|CELOT Wireless Co., Ltd
+FC3598|Favite Inc.
+FC35E6|Visteon corp
+FC3D93|LONGCHEER TELECOMMUNICATION LIMITED
+FC3FAB|Henan Lanxin Technology Co., Ltd
+FC4463|Universal Audio, Inc
+FC4499|Swarco LEA d.o.o.
+FC455F|JIANGXI SHANSHUI OPTOELECTRONIC TECHNOLOGY CO.,LTD
+FC48EF|HUAWEI TECHNOLOGIES CO.,LTD
+FC4AE9|Castlenet Technology Inc.
+FC4B1C|INTERSENSOR S.R.L.
+FC4BBC|Sunplus Technology Co., Ltd.
+FC4DD4|Universal Global Scientific Industrial Co., Ltd.
+FC5090|SIMEX Sp. z o.o.
+FC52CE|Control iD
+FC58FA|Shen Zhen Shi Xin Zhong Xin Technology Co.,Ltd.
+FC5B24|Weibel Scientific A/S
+FC5B26|MikroBits
+FC5B39|Cisco
+FC6018|Zhejiang Kangtai Electric Co., Ltd.
+FC6198|NEC Personal Products, Ltd
+FC626E|Beijing MDC Telecom
+FC62B9|ALPS ERECTRIC CO.,LTD
+FC683E|Directed Perception, Inc
+FC6C31|LXinstruments GmbH
+FC6DC0|BME CORPORATION
+FC6FB7|Pace plc
+FC7516|D-Link International
+FC75E6|Handreamnet
+FC790B|Hitachi High Technologies America, Inc.
+FC7CE7|FCI USA LLC
+FC8329|Trei technics
+FC8399|Avaya, Inc
+FC8B97|Shenzhen Gongjin Electronics Co.,Ltd
+FC8E7E|Pace plc
+FC8F90|Samsung
+FC8FC4|Intelligent Technology Inc.
+FC923B|Nokia Corporation
+FC946C|UBIVELOX
+FC94E3|Technicolor USA Inc.
+FC9947|Cisco
+FC9AFA|Motus Global Inc.
+FC9FAE|Fidus Systems Inc
+FC9FE1|CONWIN.Tech. Ltd
+FCA13E|Samsung
+FCA22A|PT. Callysta Multi Engineering
+FCA841|Avaya, Inc
+FCA9B0|MIARTECH (SHANGHAI),INC.
+FCAA14|GIGA-BYTE TECHNOLOGY CO.,LTD.
+FCAD0F|QTS NETWORKS
+FCAF6A|Qulsar Inc
+FCAFAC|Panasonic System LSI
+FCB0C4|Shanghai DareGlobal Technologies Co., Ltd
+FCB4E6|ASKEY COMPUTER CORP.
+FCB698|Cambridge Industries(Group) Co.,Ltd.
+FCBBA1|Shenzhen Minicreate Technology Co.,Ltd
+FCC23D|Atmel Corporation
+FCC2DE|Murata Manufacturing Co., Ltd.
+FCC734|Samsung
+FCC897|ZTE Corporation
+FCCCE4|Ascon Ltd.
+FCCF62|IBM Corp
+FCD4F2|The Coca Cola Company
+FCD4F6|Messana Air.Ray Conditioning s.r.l.
+FCD5D9|Shenzhen SDMC Technology Co., Ltd.
+FCD6BD|Robert Bosch GmbH
+FCD817|Beijing Hesun Technologies Co.Ltd.
+FCDB96|ENERVALLEY CO., LTD
+FCDBB3|Murata Manufacturing Co., Ltd.
+FCDC4A|G-Wearables Corp.
+FCDD55|Shenzhen WeWins wireless Co.,Ltd
+FCE186|A3M Co., LTD
+FCE192|Sichuan Jinwangtong Electronic Science&Technology Co,.Ltd
+FCE1D9|Stable Imaging Solutions LLC
+FCE1FB|Array Networks
+FCE23F|CLAY PAKY SPA
+FCE33C|HUAWEI TECHNOLOGIES CO.,LTD
+FCE557|Nokia Corporation
+FCE892|Hangzhou Lancable Technology Co.,Ltd
+FCE998|Apple
+FCEDB9|Arrayent
+FCF152|Sony Corporation
+FCF1CD|OPTEX-FA CO.,LTD.
+FCF528|ZyXEL Communications Corporation
+FCF647|Fiberhome Telecommunication Tech.Co.,Ltd.
+FCF8AE|Intel Corporate
+FCF8B7|TRONTEQ Electronic
+FCFAF7|Shanghai Baud Data Communication Co.,Ltd.
+FCFBFB|Cisco
+FCFE77|Hitachi Reftechno, Inc.
+FCFFAA|IEEE REGISTRATION AUTHORITY  - Please see MAL public listing for more information.


### PR DESCRIPTION
* Due to a missing `/etc/objects/mac_vendors` file, Logstash was crashing on the location filter plugin on `register` because it was trying to read the file. I fixed the issue by including the file in resources/etc, as the old CentOS 6 version does.

